### PR TITLE
Upstreaming - Separating out TrailblazeAgent and MaestroTrailblazeAgent, Custom Trailblaze Tool Support in Yaml

### DIFF
--- a/trailblaze-agent/src/main/java/xyz/block/trailblaze/openai/MixedModeExecutor.kt
+++ b/trailblaze-agent/src/main/java/xyz/block/trailblaze/openai/MixedModeExecutor.kt
@@ -20,8 +20,10 @@ import xyz.block.trailblaze.exception.TrailblazeToolExecutionException
 import xyz.block.trailblaze.llm.LlmModel
 import xyz.block.trailblaze.logs.client.TrailblazeLog
 import xyz.block.trailblaze.logs.client.TrailblazeLogger
+import xyz.block.trailblaze.toolcalls.TrailblazeTool
 import xyz.block.trailblaze.toolcalls.TrailblazeToolResult
 import kotlin.math.abs
+import kotlin.reflect.KClass
 
 /**
  * MixedModeExecutor provides functionality to execute YAML flows that contain
@@ -33,6 +35,7 @@ class MixedModeExecutor(
   private val screenStateProvider: () -> ScreenState,
   private val runYamlFlowFunction: (String) -> TrailblazeToolResult,
   private val runner: TrailblazeOpenAiRunner,
+  private val additionalTrailblazeTools: List<KClass<out TrailblazeTool>> = emptyList(),
 ) {
   // Variable store for remember commands
   private val variables = mutableMapOf<String, String>()
@@ -57,7 +60,7 @@ class MixedModeExecutor(
     yamlContent: String,
     executeSteps: Boolean = true,
   ) {
-    val testCase = MixedModeTestCase(yamlContent, executeSteps)
+    val testCase = MixedModeTestCase(yamlContent, executeSteps, additionalTrailblazeTools)
     testCase.objectives.forEach { objective ->
       when (objective) {
         is AssertEqualsCommand -> handleAssertEqualsCommand(objective)

--- a/trailblaze-android/src/main/java/xyz/block/trailblaze/AndroidMaestroTrailblazeAgent.kt
+++ b/trailblaze-android/src/main/java/xyz/block/trailblaze/AndroidMaestroTrailblazeAgent.kt
@@ -1,6 +1,7 @@
 package xyz.block.trailblaze
 
 import maestro.orchestra.Command
+import xyz.block.trailblaze.android.AndroidMaestroYaml
 import xyz.block.trailblaze.toolcalls.TrailblazeToolExecutionContext
 import xyz.block.trailblaze.toolcalls.TrailblazeToolResult
 
@@ -12,4 +13,15 @@ class AndroidMaestroTrailblazeAgent(
     commands = commands,
     llmResponseId = llmResponseId,
   )
+
+  override fun runMaestroYaml(
+    yaml: String,
+    llmResponseId: String?,
+  ): TrailblazeToolResult {
+    val commands = AndroidMaestroYaml.parseYaml(yaml)
+    return executeMaestroCommands(
+      commands = commands,
+      llmResponseId = llmResponseId,
+    )
+  }
 }

--- a/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidTrailblazeRule.kt
+++ b/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidTrailblazeRule.kt
@@ -86,7 +86,10 @@ class AndroidTrailblazeRule(
    * Run a Trailblaze tool with the agent.
    */
   override fun maestroCommands(vararg maestroCommand: Command): TrailblazeToolResult {
-    val runCommandsResult = trailblazeAgent.runMaestroCommands(maestroCommand.toList())
+    val runCommandsResult = trailblazeAgent.runMaestroCommands(
+      maestroCommand.toList(),
+      null,
+    )
     return if (runCommandsResult is TrailblazeToolResult.Success) {
       runCommandsResult
     } else {

--- a/trailblaze-common/src/main/java/xyz/block/trailblaze/api/TrailblazeAgent.kt
+++ b/trailblaze-common/src/main/java/xyz/block/trailblaze/api/TrailblazeAgent.kt
@@ -1,6 +1,5 @@
 package xyz.block.trailblaze.api
 
-import maestro.orchestra.Command
 import xyz.block.trailblaze.toolcalls.TrailblazeTool
 import xyz.block.trailblaze.toolcalls.TrailblazeToolResult
 
@@ -11,9 +10,4 @@ interface TrailblazeAgent {
     llmResponseId: String? = null,
     screenState: ScreenState? = null,
   ): Pair<List<TrailblazeTool>, TrailblazeToolResult>
-
-  fun runMaestroCommands(
-    maestroCommands: List<Command>,
-    llmResponseId: String? = null,
-  ): TrailblazeToolResult
 }

--- a/trailblaze-common/src/main/java/xyz/block/trailblaze/toolcalls/TrailblazeToolExecutionContext.kt
+++ b/trailblaze-common/src/main/java/xyz/block/trailblaze/toolcalls/TrailblazeToolExecutionContext.kt
@@ -1,12 +1,14 @@
 package xyz.block.trailblaze.toolcalls
 
 import xyz.block.trailblaze.api.ScreenState
+import xyz.block.trailblaze.api.TrailblazeAgent
 
 /**
  * Context for handling Trailblaze tools.
  */
-data class TrailblazeToolExecutionContext(
+class TrailblazeToolExecutionContext(
   val trailblazeTool: TrailblazeTool,
   val screenState: ScreenState?,
   val llmResponseId: String?,
+  val trailblazeAgentProvider: () -> TrailblazeAgent,
 )

--- a/trailblaze-common/src/main/java/xyz/block/trailblaze/toolcalls/TrailblazeToolRepo.kt
+++ b/trailblaze-common/src/main/java/xyz/block/trailblaze/toolcalls/TrailblazeToolRepo.kt
@@ -53,7 +53,7 @@ class TrailblazeToolRepo(
       TapOnPointTrailblazeTool::class,
     )
 
-    val ALL = DEFAULT_COMMON_COMMAND_CLASSES + RECORDING_ENABLED_COMMAND_CLASSES + RECORDING_DISABLED_COMMAND_CLASSES + OTHER_COMMAND_CLASSES
+    val ALL: Set<KClass<out TrailblazeTool>> = DEFAULT_COMMON_COMMAND_CLASSES + RECORDING_ENABLED_COMMAND_CLASSES + RECORDING_DISABLED_COMMAND_CLASSES + OTHER_COMMAND_CLASSES
   }
 
   private val registeredTrailblazeToolClasses = mutableSetOf<KClass<out TrailblazeTool>>().apply {

--- a/trailblaze-common/src/main/java/xyz/block/trailblaze/toolcalls/commands/LaunchAppTrailblazeTool.kt
+++ b/trailblaze-common/src/main/java/xyz/block/trailblaze/toolcalls/commands/LaunchAppTrailblazeTool.kt
@@ -11,9 +11,7 @@ import xyz.block.trailblaze.toolcalls.TrailblazeToolClass
 @Serializable
 @TrailblazeToolClass("launchApp")
 @LLMDescription(
-  """
-Use this to open an app on the device as if a user tapped on the app icon in the launcher.
-    """,
+  "Use this to open an app on the device as if a user tapped on the app icon in the launcher.",
 )
 data class LaunchAppTrailblazeTool(
   @LLMDescription("The package name of the app to launch. Example: 'com.example.app'")

--- a/trailblaze-common/src/test/java/xyz/block/trailblaze/agent/model/MixedModeTestCaseTest.kt
+++ b/trailblaze-common/src/test/java/xyz/block/trailblaze/agent/model/MixedModeTestCaseTest.kt
@@ -335,7 +335,7 @@ class MixedModeTestCaseTest {
     val yaml = """
 - assertEquals:
     actual: "{{chargeText}}"
-    expected: "Charge ${'$'}5.00"
+    expected: "Charge $5.00"
     """.trimIndent()
     val testCase = MixedModeTestCase(yaml)
     assertThat(testCase.objectives)
@@ -367,7 +367,7 @@ class MixedModeTestCaseTest {
   fun assertEqualsCommandNoActual() {
     val yaml = """
 - assertEquals:
-    expected: "Charge ${'$'}5.00"
+    expected: "Charge $5.00"
     """.trimIndent()
     assertThat(
       runCatching {
@@ -428,7 +428,7 @@ class MixedModeTestCaseTest {
   fun assertWithAiCommand() {
     val yaml = """
 - assertWithAI:
-    prompt: "Is there a Charge button showing ${'$'}0.00 at the bottom of the screen?"
+    prompt: "Is there a Charge button showing $0.00 at the bottom of the screen?"
     """.trimIndent()
     val testCase = MixedModeTestCase(yaml)
     assertThat(testCase.objectives)


### PR DESCRIPTION
- Stronger separation between `TrailblazeAgent` (Only works with `TrailblazeTool`) and `MaestroTrailblazeAgent` (`TrailblazeTool` + Maestro stuff)
- In the `MixedModeTestCase` runner, we can now pass in custom tools so that they can be used from `yaml`.
- Added `trailblazeAgent` provider to the `TrailblazeToolExecutionContext`.  This gives tools the context to interact with the agent to perform commands, etc.