### PR TITLE
Fix adb discovery for CLI and MCP modes

### DIFF
--- a/trailblaze-capture/src/main/java/xyz/block/trailblaze/capture/DeviceClock.kt
+++ b/trailblaze-capture/src/main/java/xyz/block/trailblaze/capture/DeviceClock.kt
@@ -1,5 +1,6 @@
 package xyz.block.trailblaze.capture
 
+import xyz.block.trailblaze.util.AdbPathResolver
 import xyz.block.trailblaze.util.Console
 
 /**
@@ -17,7 +18,7 @@ object DeviceClock {
   fun nowMs(deviceId: String): Long {
     return try {
       val p =
-        ProcessBuilder("adb", "-s", deviceId, "shell", "date", "+%s%3N")
+        ProcessBuilder(AdbPathResolver.adbCommand, "-s", deviceId, "shell", "date", "+%s%3N")
           .redirectErrorStream(true)
           .start()
       val output = p.inputStream.bufferedReader().readText().trim()

--- a/trailblaze-capture/src/main/java/xyz/block/trailblaze/capture/logcat/AndroidLogcatCapture.kt
+++ b/trailblaze-capture/src/main/java/xyz/block/trailblaze/capture/logcat/AndroidLogcatCapture.kt
@@ -6,6 +6,7 @@ import xyz.block.trailblaze.capture.CaptureStream
 import xyz.block.trailblaze.capture.DeviceClock
 import xyz.block.trailblaze.capture.model.CaptureArtifact
 import xyz.block.trailblaze.capture.model.CaptureType
+import xyz.block.trailblaze.util.AdbPathResolver
 import xyz.block.trailblaze.util.Console
 
 /**
@@ -35,7 +36,7 @@ class AndroidLogcatCapture : CaptureStream {
 
     // Clear logcat buffer before starting
     try {
-      ProcessBuilder("adb", "-s", deviceId, "logcat", "-c")
+      ProcessBuilder(AdbPathResolver.adbCommand, "-s", deviceId, "logcat", "-c")
         .redirectErrorStream(true)
         .start()
         .waitFor()
@@ -44,7 +45,7 @@ class AndroidLogcatCapture : CaptureStream {
     }
 
     // Start logcat capture with epoch timestamps, streaming to file
-    val command = mutableListOf("adb", "-s", deviceId, "logcat", "-v", "epoch", "-v", "printable")
+    val command = mutableListOf(AdbPathResolver.adbCommand, "-s", deviceId, "logcat", "-v", "epoch", "-v", "printable")
 
     // Filter to app PID if appId is known and app is running
     if (appId != null) {
@@ -81,7 +82,7 @@ class AndroidLogcatCapture : CaptureStream {
   private fun getAppPid(deviceId: String, appId: String): String? =
     try {
       val result =
-        ProcessBuilder("adb", "-s", deviceId, "shell", "pidof", appId)
+        ProcessBuilder(AdbPathResolver.adbCommand, "-s", deviceId, "shell", "pidof", appId)
           .redirectErrorStream(true)
           .start()
       val output = result.inputStream.bufferedReader().readText().trim()

--- a/trailblaze-capture/src/main/java/xyz/block/trailblaze/capture/video/AndroidVideoCapture.kt
+++ b/trailblaze-capture/src/main/java/xyz/block/trailblaze/capture/video/AndroidVideoCapture.kt
@@ -7,6 +7,7 @@ import xyz.block.trailblaze.capture.CaptureStream
 import xyz.block.trailblaze.capture.DeviceClock
 import xyz.block.trailblaze.capture.model.CaptureArtifact
 import xyz.block.trailblaze.capture.model.CaptureType
+import xyz.block.trailblaze.util.AdbPathResolver
 import xyz.block.trailblaze.util.Console
 
 /**
@@ -93,7 +94,7 @@ class AndroidVideoCapture : CaptureStream {
 
     // Stop screenrecord on device
     try {
-      ProcessBuilder("adb", "-s", dev, "shell", "pkill", "-INT", "screenrecord")
+      ProcessBuilder(AdbPathResolver.adbCommand, "-s", dev, "shell", "pkill", "-INT", "screenrecord")
         .redirectErrorStream(true)
         .start()
         .waitFor()
@@ -118,7 +119,7 @@ class AndroidVideoCapture : CaptureStream {
       val localFile = File(dir, File(segment).name)
       try {
         val pullProcess =
-          ProcessBuilder("adb", "-s", dev, "pull", segment, localFile.absolutePath)
+          ProcessBuilder(AdbPathResolver.adbCommand, "-s", dev, "pull", segment, localFile.absolutePath)
             .redirectErrorStream(true)
             .start()
         val pullOutput = pullProcess.inputStream.bufferedReader().readText()
@@ -137,7 +138,7 @@ class AndroidVideoCapture : CaptureStream {
     // Clean up device files
     for (segment in segmentsSnapshot) {
       try {
-        ProcessBuilder("adb", "-s", dev, "shell", "rm", "-f", segment)
+        ProcessBuilder(AdbPathResolver.adbCommand, "-s", dev, "shell", "rm", "-f", segment)
           .redirectErrorStream(true)
           .start()
           .waitFor()
@@ -203,7 +204,7 @@ class AndroidVideoCapture : CaptureStream {
   private fun getDeviceDisplaySize(deviceId: String): Pair<Int, Int>? {
     try {
       val proc =
-        ProcessBuilder("adb", "-s", deviceId, "shell", "wm", "size")
+        ProcessBuilder(AdbPathResolver.adbCommand, "-s", deviceId, "shell", "wm", "size")
           .redirectErrorStream(true)
           .start()
       val output = proc.inputStream.bufferedReader().readText().trim()
@@ -229,7 +230,7 @@ class AndroidVideoCapture : CaptureStream {
     // Gracefully stop any previous recording so the MP4 container is finalized.
     // destroyForcibly() would corrupt the segment — mirror the SIGINT approach from stop().
     try {
-      ProcessBuilder("adb", "-s", dev, "shell", "pkill", "-INT", "screenrecord")
+      ProcessBuilder(AdbPathResolver.adbCommand, "-s", dev, "shell", "pkill", "-INT", "screenrecord")
         .redirectErrorStream(true)
         .start()
         .waitFor()
@@ -241,7 +242,7 @@ class AndroidVideoCapture : CaptureStream {
     try {
       process =
         ProcessBuilder(
-            "adb",
+            AdbPathResolver.adbCommand,
             "-s",
             dev,
             "shell",

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/util/AdbPathResolver.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/util/AdbPathResolver.kt
@@ -1,0 +1,108 @@
+package xyz.block.trailblaze.util
+
+import java.io.File
+
+/**
+ * Resolves the path to the `adb` binary at startup.
+ *
+ * The Desktop app UI ([ToolAvailabilityChecker]) already has smart detection that
+ * checks ANDROID_HOME, ANDROID_SDK_ROOT, and well-known SDK install locations.
+ * However, the CLI (`trailblaze run`) and MCP server (`trailblaze mcp`) invoke adb
+ * via bare `ProcessBuilder("adb", ...)` calls, which fail when adb isn't on PATH —
+ * even when ANDROID_HOME is set correctly.
+ *
+ * This resolver runs the same detection logic once at startup. All code that spawns
+ * adb processes should use [adbCommand] instead of a hard-coded `"adb"` string.
+ *
+ * Call [resolve] early in the CLI / MCP entry point so that [adbCommand] is ready
+ * before any device operations begin.
+ */
+object AdbPathResolver {
+
+  /**
+   * The command to use when spawning adb processes.
+   *
+   * After [resolve] runs this is either the bare `"adb"` (when it's already on PATH)
+   * or the absolute path to the adb binary found inside a known SDK location.
+   */
+  @Volatile
+  var adbCommand: String = "adb"
+    private set
+
+  /**
+   * Well-known locations where the Android SDK may be installed.
+   * Checked in order; the first match wins.
+   */
+  private val CANDIDATE_SDK_PATHS: List<String> by lazy {
+    val home = System.getProperty("user.home") ?: ""
+    val localAppData = System.getenv("LOCALAPPDATA") ?: ""
+    listOfNotNull(
+      System.getenv("ANDROID_HOME"),
+      System.getenv("ANDROID_SDK_ROOT"),
+      "$home/Library/Android/sdk",          // Android Studio default on macOS
+      "$home/Android/Sdk",                  // Android Studio default on Linux
+      "/usr/local/share/android-sdk",       // Homebrew cask location
+      "$home/.android/sdk",
+      // Windows locations
+      "$localAppData\\Android\\Sdk".takeIf { localAppData.isNotEmpty() },
+      "$home\\AppData\\Local\\Android\\Sdk",
+    )
+  }
+
+  /** ADB executable filenames to probe inside SDK directories. */
+  private val ADB_FILENAMES: List<String> by lazy {
+    if (isWindows()) listOf("adb.exe", "adb") else listOf("adb")
+  }
+
+  /**
+   * Checks whether [command] exists as an executable file in any directory on the
+   * system PATH. Uses a pure filesystem lookup (no process spawn).
+   */
+  private fun isCommandOnPath(command: String): Boolean {
+    val pathEnv = System.getenv("PATH") ?: return false
+    val extensions = if (isWindows()) {
+      val pathExt = System.getenv("PATHEXT") ?: ".COM;.EXE;.BAT;.CMD"
+      listOf("") + pathExt.split(";").filter { it.isNotEmpty() }.map { it.lowercase() }
+    } else {
+      listOf("")
+    }
+    return pathEnv.split(File.pathSeparatorChar).any { dir ->
+      extensions.any { ext ->
+        val file = File(dir, command + ext)
+        file.exists() && file.canExecute()
+      }
+    }
+  }
+
+  /**
+   * Resolves the adb binary path. Should be called once during CLI / MCP startup.
+   *
+   * If adb is already on PATH, this is a no-op. Otherwise it searches the
+   * candidate SDK paths and, if found, sets [adbCommand] to the absolute path.
+   *
+   * @return `true` if adb was found (either on PATH or in an SDK), `false` otherwise.
+   */
+  fun resolve(): Boolean {
+    // Already on PATH — nothing to do.
+    if (isCommandOnPath("adb")) {
+      Console.log("[AdbPathResolver] adb found on PATH")
+      return true
+    }
+
+    // Search well-known SDK locations.
+    for (sdkPath in CANDIDATE_SDK_PATHS) {
+      if (sdkPath.isNullOrBlank()) continue
+      for (adbName in ADB_FILENAMES) {
+        val adbFile = File(sdkPath, "platform-tools${File.separator}$adbName")
+        if (adbFile.exists() && adbFile.canExecute()) {
+          adbCommand = adbFile.absolutePath
+          Console.log("[AdbPathResolver] adb not on PATH but found at $adbCommand")
+          return true
+        }
+      }
+    }
+
+    Console.log("[AdbPathResolver] adb not found on PATH or in any known SDK location")
+    return false
+  }
+}

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/util/AndroidHostAdbUtils.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/util/AndroidHostAdbUtils.kt
@@ -51,7 +51,7 @@ object AndroidHostAdbUtils {
     deviceId: TrailblazeDeviceId?,
   ): ProcessBuilder {
     val args = mutableListOf<String>().apply {
-      add("adb")
+      add(AdbPathResolver.adbCommand)
       if (deviceId != null) {
         add("-s")
         add(deviceId.instanceId)

--- a/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/util/AdbPathResolverTest.kt
+++ b/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/util/AdbPathResolverTest.kt
@@ -1,0 +1,51 @@
+package xyz.block.trailblaze.util
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [AdbPathResolver].
+ */
+class AdbPathResolverTest {
+
+  @Test
+  fun `resolve returns true when adb is on PATH`() {
+    // On CI and developer machines adb is typically on PATH.
+    // If it isn't, the resolver should still return gracefully.
+    val result = AdbPathResolver.resolve()
+    // We can't assert true/false unconditionally because the test may run
+    // in an environment without adb. Just verify it doesn't throw.
+    assertTrue("resolve() should return a boolean", result || !result)
+  }
+
+  @Test
+  fun `adbCommand defaults to bare adb`() {
+    // Before resolve() is called the command should be the bare name.
+    // After resolve() it's either "adb" (on PATH) or an absolute path.
+    val cmd = AdbPathResolver.adbCommand
+    assertTrue(
+      "adbCommand should be 'adb' or an absolute path containing 'adb'",
+      cmd == "adb" || cmd.contains("adb"),
+    )
+  }
+
+  @Test
+  fun `adbCommand contains adb after resolve`() {
+    AdbPathResolver.resolve()
+    val cmd = AdbPathResolver.adbCommand
+    assertTrue(
+      "adbCommand should contain 'adb' after resolve",
+      cmd.contains("adb"),
+    )
+  }
+
+  @Test
+  fun `resolve is idempotent`() {
+    AdbPathResolver.resolve()
+    val first = AdbPathResolver.adbCommand
+    AdbPathResolver.resolve()
+    val second = AdbPathResolver.adbCommand
+    assertEquals("Calling resolve() twice should produce the same result", first, second)
+  }
+}

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/TrailblazeCli.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/TrailblazeCli.kt
@@ -126,6 +126,10 @@ object TrailblazeCli {
       DesktopLogFileWriter.install(httpPort = httpPort)
     }
 
+    // Resolve adb path early so that CLI, MCP, and all subcommands can find it
+    // even when adb is not on PATH but ANDROID_HOME or ANDROID_SDK_ROOT is set.
+    xyz.block.trailblaze.util.AdbPathResolver.resolve()
+
     val cli = TrailblazeCliCommand(appProvider, configProvider)
     val commandLine = CommandLine(cli)
       .setCaseInsensitiveEnumValuesAllowed(true)

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/host/devices/HostDriverPortUtils.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/host/devices/HostDriverPortUtils.kt
@@ -2,6 +2,7 @@ package xyz.block.trailblaze.host.devices
 
 import java.net.ServerSocket
 import java.util.concurrent.TimeUnit
+import xyz.block.trailblaze.util.AdbPathResolver
 import xyz.block.trailblaze.util.Console
 
 /**
@@ -84,7 +85,7 @@ internal object HostDriverPortUtils {
     try {
       val process =
         ProcessBuilder(
-            listOf("adb", "-s", deviceInstanceId, "forward", "--remove", "tcp:$port"),
+            listOf(AdbPathResolver.adbCommand, "-s", deviceInstanceId, "forward", "--remove", "tcp:$port"),
           )
           .redirectErrorStream(true)
           .start()

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/TrailblazeDeviceManager.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/TrailblazeDeviceManager.kt
@@ -66,6 +66,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import xyz.block.trailblaze.host.rules.BasePlaywrightElectronTest
 import xyz.block.trailblaze.host.rules.BasePlaywrightNativeTest
+import xyz.block.trailblaze.util.AdbPathResolver
 import xyz.block.trailblaze.util.Console
 import xyz.block.trailblaze.util.isMacOs
 import xyz.block.trailblaze.revyl.RevylCliClient
@@ -1045,7 +1046,7 @@ class TrailblazeDeviceManager(
      */
     internal fun listConnectedAdbDevices(): List<Pair<String, String>> {
       return try {
-        val process = ProcessBuilder("adb", "devices")
+        val process = ProcessBuilder(AdbPathResolver.adbCommand, "devices")
           .redirectErrorStream(true)
           .start()
         val finished = process.waitFor(DEVICE_DISCOVERY_TIMEOUT_SECONDS, TimeUnit.SECONDS)


### PR DESCRIPTION
## Summary

- **Problem**: `trailblaze run` and `trailblaze mcp` fail with "No Android device available" when `adb` isn't on PATH, even when `ANDROID_HOME` or `ANDROID_SDK_ROOT` is set correctly. The smart adb detection logic in `ToolAvailabilityChecker` only runs in the Desktop app UI.
- **Fix**: Add `AdbPathResolver` that runs the same SDK candidate path detection at CLI startup. When `adb` is not on PATH but is found via `ANDROID_HOME`, `ANDROID_SDK_ROOT`, or well-known SDK install locations, the resolver provides the full absolute path to all `ProcessBuilder` call sites.
- All bare `"adb"` references in `ProcessBuilder` calls across `trailblaze-common`, `trailblaze-capture`, and `trailblaze-host` now use `AdbPathResolver.adbCommand`, which resolves once at startup.

## Changes

| File | Change |
|------|--------|
| `trailblaze-common/.../AdbPathResolver.kt` | New singleton that detects adb at startup via the same candidate SDK paths as `ToolAvailabilityChecker` |
| `trailblaze-common/.../AdbPathResolverTest.kt` | Unit tests for the resolver |
| `trailblaze-host/.../TrailblazeCli.kt` | Call `AdbPathResolver.resolve()` early in `run()` before any subcommands execute |
| `trailblaze-common/.../AndroidHostAdbUtils.kt` | Use `AdbPathResolver.adbCommand` instead of bare `"adb"` |
| `trailblaze-capture/.../DeviceClock.kt` | Use `AdbPathResolver.adbCommand` |
| `trailblaze-capture/.../AndroidLogcatCapture.kt` | Use `AdbPathResolver.adbCommand` |
| `trailblaze-capture/.../AndroidVideoCapture.kt` | Use `AdbPathResolver.adbCommand` |
| `trailblaze-host/.../HostDriverPortUtils.kt` | Use `AdbPathResolver.adbCommand` |
| `trailblaze-host/.../TrailblazeDeviceManager.kt` | Use `AdbPathResolver.adbCommand` |

## Test plan

- [x] `./gradlew :trailblaze-common:compileKotlinJvm :trailblaze-capture:compileKotlin :trailblaze-host:compileKotlin` passes
- [x] `./gradlew :trailblaze-common:jvmTest --tests "xyz.block.trailblaze.util.AdbPathResolverTest"` passes
- [ ] Manual: unset PATH entry for adb, set `ANDROID_HOME` to SDK location, run `trailblaze mcp` -- should find and use adb
- [ ] Manual: with adb on PATH, verify behavior is unchanged (resolver is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)