### PR TITLE
Upstream 2026.05.05

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -579,7 +579,9 @@ trailblaze waypoint list
 trailblaze waypoint locate
 trailblaze waypoint validate
 trailblaze waypoint capture-example
+trailblaze waypoint suggest-selector
 trailblaze waypoint segment
+trailblaze waypoint graph
 ```
 
 **Options:**
@@ -694,6 +696,36 @@ trailblaze waypoint capture-example [OPTIONS] [<<positionalLogFile>>]
 
 ---
 
+### `trailblaze waypoint suggest-selector`
+
+Suggest waypoint-ready selector YAML for a specific element ref in a captured screen. Pair with `./trailblaze snapshot --all` to see refs, then run this on the matching session log to translate ref → selector. Returns up to --max named candidates (the TrailblazeNodeSelectorGenerator strategies that uniquely resolve to the target), plus one structural-only candidate at the bottom for forbidden-clause use.
+
+**Synopsis:**
+
+```
+trailblaze waypoint suggest-selector [OPTIONS] [<<positionalLogFile>>]
+```
+
+**Arguments:**
+
+| Argument | Description | Required |
+|----------|-------------|----------|
+| `<<positionalLogFile>>` | Path to a *_TrailblazeLlmRequestLog.json (required unless --session/--step given). Same shape as the input to `waypoint validate`. | No |
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--ref` | Element ref from the captured tree (e.g. 'a812'). Required. | - |
+| `--session` | Session log directory (containing *_TrailblazeLlmRequestLog.json files) | - |
+| `--step` | 1-based step within --session (default: last step) | - |
+| `--max` | Maximum candidate selectors to return (default: 5) | - |
+| `--anchor` | Compose the leaf selector with an ancestor predicate. Currently supported:   parent-selected — find the nearest ancestor with isSelected=true and emit a     selector that matches that ancestor as a `View` with `isSelected: true`,     using the leaf as `containsChild`. This is the canonical bottom-nav-tab     waypoint pattern: any app with selectable bottom-nav tabs uses this to     pin identity to the *currently active* tab rather than to any tab with the     given label. Without the anchor, the leaf selector matches a tab regardless     of selection state — fine for tap targets, wrong for waypoint identity,     because we want to know WHICH tab is currently active. | - |
+| `-h`, `--help` | Show this help message and exit. | - |
+| `-V`, `--version` | Print version information and exit. | - |
+
+---
+
 ### `trailblaze waypoint segment`
 
 Inspect transitions between waypoints observed in a session log.
@@ -730,6 +762,27 @@ trailblaze waypoint segment list [OPTIONS]
 |--------|-------------|---------|
 | `--session` | Session log directory (containing *.json log files) | - |
 | `--root` | Additional directory to scan for *.waypoint.yaml files (default: ./trails, resolved against the current working directory). Pack waypoints are always included regardless of --root. | - |
+| `-h`, `--help` | Show this help message and exit. | - |
+| `-V`, `--version` | Print version information and exit. | - |
+
+---
+
+### `trailblaze waypoint graph`
+
+Render the waypoint navigation graph (waypoints, authored shortcuts, authored trailheads) as a single self-contained HTML file. The output bakes in screenshots as data URIs and loads React Flow + dagre at runtime via esm.sh CDN — open it in any browser, share it via email/Slack/zip, no Trailblaze install required on the viewer's side.  For a live, refresh-on-edit view from the running daemon, point your browser at http://localhost:<daemon-port>/waypoints/graph instead.
+
+**Synopsis:**
+
+```
+trailblaze waypoint graph [OPTIONS]
+```
+
+**Options:**
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--root` | Filesystem directory to scan for *.waypoint.yaml files (default: ./trails, resolved against the current working directory). Pack-bundled waypoints from the classpath are always included regardless of this flag. | - |
+| `--out`, `-o` | Output HTML file path (default: ./waypoint-graph.html in the current directory). Parent directories are created if missing. The file is overwritten if present. | - |
 | `-h`, `--help` | Show this help message and exit. | - |
 | `-V`, `--version` | Print version information and exit. | - |
 

--- a/trailblaze-agent/src/main/java/xyz/block/trailblaze/agent/TrailblazeRunner.kt
+++ b/trailblaze-agent/src/main/java/xyz/block/trailblaze/agent/TrailblazeRunner.kt
@@ -242,11 +242,15 @@ class TrailblazeRunner(
 
       val cycleHint = detectActionCycleHint(recentToolFingerprints.toList())
       if (cycleHint != null && cycleHint.startsWith("CRITICAL:")) {
-        val toolName = toolCalls.lastOrNull()?.tool ?: "unknown"
         Console.info("  Agent stuck: $cycleHint")
+        // Surface the full pattern (tool + args + repeat count) in the exception so
+        // post-mortem readers see *what* was looping, not just that something was. The
+        // previous form collapsed to "[stuck: <toolname> in repeating cycle]" which
+        // dropped the cycle pattern and left no breadcrumb for triaging.
+        val cycleSummary = cycleHint.removePrefix("CRITICAL: ").trim()
         throw MaxCallsLimitReachedException(
           maxCalls = stepStatus.currentStep,
-          objectivePrompt = "${stepStatus.promptStep.prompt} [stuck: $toolName in repeating cycle]",
+          objectivePrompt = "${stepStatus.promptStep.prompt} [stuck: $cycleSummary]",
         )
       }
 
@@ -346,11 +350,18 @@ class TrailblazeRunner(
   companion object {
     /**
      * Sliding window over the last N tool fingerprints, used by `detectActionCycleHint`
-     * to spot repeating cycles (length 1, 2, or 3) in the suffix. Sized to comfortably
-     * cover a length-3 cycle repeated 3 times (9 entries) with headroom; also covers a
-     * length-2 cycle repeated 5 times (10 entries) and length-1 repeated 12 times.
+     * to spot repeating cycles (length 1, 2, or 3) in the suffix.
+     *
+     * Sized to fit any of the per-cycle-length CRITICAL thresholds in `ProgressTracking.kt`:
+     * length-1 needs `LENGTH_1_CRITICAL_REPEATS = 30` entries to fire, length-2 needs
+     * `LENGTH_2_CRITICAL_REPEATS = 15` × 2 = 30 entries, length-3 needs
+     * `LENGTH_3_CRITICAL_REPEATS = 10` × 3 = 30 entries. So 30 is the smallest window
+     * that lets every length reach its CRITICAL threshold without falling off the front.
+     *
+     * Memory cost is small: ~200 bytes per fingerprint × 30 = ~6 KB held during a
+     * running step.
      */
-    private const val STUCK_FINGERPRINT_WINDOW = 12
+    private const val STUCK_FINGERPRINT_WINDOW = 30
 
     val baseSystemPrompt = TemplatingUtil.getResourceAsText(
       "trailblaze_base_system_prompt.md",

--- a/trailblaze-agent/src/main/java/xyz/block/trailblaze/agent/blaze/ProgressTracking.kt
+++ b/trailblaze-agent/src/main/java/xyz/block/trailblaze/agent/blaze/ProgressTracking.kt
@@ -123,6 +123,25 @@ internal fun detectRepetitiveActionHint(state: BlazeState): String? {
 }
 
 /**
+ * Per-cycle-length thresholds for escalating a detected loop from `WARNING` (gentle hint
+ * to the LLM) to `CRITICAL` (consumed by [TrailblazeRunner] to terminate the step).
+ *
+ * Length-1 (consecutive identical actions) tolerates the most repetition because legitimate
+ * cases are common: counter-driven flows ("add the same item three times"), sequential PIN
+ * digit entry that happens to use the same tool with the same args, scrolling a long list
+ * in a fixed direction, etc. Length-2/3 cycles (alternating, three-step) are far less
+ * likely to be intentional, so the threshold drops, but still leaves a buffer so the LLM
+ * can recover after the WARNING hint without us hard-killing the run.
+ *
+ * Numbers chosen to hit roughly the same total entry count (≈ 30) across all three lengths
+ * — that's what determines the sliding window's required size in [TrailblazeRunner]'s
+ * `STUCK_FINGERPRINT_WINDOW`.
+ */
+internal const val LENGTH_1_CRITICAL_REPEATS: Int = 30
+internal const val LENGTH_2_CRITICAL_REPEATS: Int = 15
+internal const val LENGTH_3_CRITICAL_REPEATS: Int = 10
+
+/**
  * Generic cycle detector over a list of action signatures.
  *
  * Each entry in [signatures] should be a stable string representation of one action
@@ -163,9 +182,25 @@ internal fun detectActionCycleHint(signatures: List<String>): String? {
  * Formats a corrective hint for a detected loop. Length-1 phrasing is preserved from
  * the prior single-action detector to avoid regressing prompt quality on the most
  * common case; length-2/3 phrasing surfaces the cycle explicitly.
+ *
+ * The CRITICAL threshold is per cycle length so the bar for hard-failing the run scales
+ * with the loop's "obviousness." Tight single-action repetition can be legitimate (entering
+ * a PIN sequentially, "add the same item N times" instructions, scrolling a long list with
+ * a fixed direction) so we tolerate a much longer streak before declaring stuck. Multi-step
+ * loops (length 2 / 3) are easier to mistake for genuine progress, so they need fewer full
+ * repetitions before we flip to CRITICAL — but still a healthy buffer beyond the previous
+ * 3-cycle bar to give the LLM room to back out on its own after seeing the WARNING-level
+ * hint. All three thresholds intentionally land near 30 raw entries so a single sliding
+ * window (see [STUCK_FINGERPRINT_WINDOW_SIZE] in TrailblazeRunner) sizes to fit any of them.
  */
 private fun formatCycleHint(cycle: List<String>, cycleLen: Int, fullRepeats: Int): String {
-  val isCritical = fullRepeats >= 3
+  val criticalThreshold = when (cycleLen) {
+    1 -> LENGTH_1_CRITICAL_REPEATS
+    2 -> LENGTH_2_CRITICAL_REPEATS
+    3 -> LENGTH_3_CRITICAL_REPEATS
+    else -> LENGTH_1_CRITICAL_REPEATS
+  }
+  val isCritical = fullRepeats >= criticalThreshold
   return when (cycleLen) {
     1 -> {
       val signature = cycle.first()

--- a/trailblaze-agent/src/test/kotlin/xyz/block/trailblaze/agent/blaze/ProgressTrackingTest.kt
+++ b/trailblaze-agent/src/test/kotlin/xyz/block/trailblaze/agent/blaze/ProgressTrackingTest.kt
@@ -37,19 +37,33 @@ class ProgressTrackingTest {
   }
 
   @Test
-  fun `length-1 critical at three repeats`() {
+  fun `length-1 stays WARNING below the critical threshold`() {
+    // Three identical actions is *frequently* legitimate — the trail step might
+    // literally say "add the same item three times" or "tap N to enter PIN digit by
+    // digit." The detector should hint to the LLM but not hard-fail the run yet.
     val hint = detectActionCycleHint(listOf("tap(a)", "tap(a)", "tap(a)"))
     assertNotNull(hint)
-    assertTrue(hint.startsWith("CRITICAL:"))
+    assertTrue(hint.startsWith("WARNING:"))
     assertTrue(hint.contains("3 times"))
   }
 
   @Test
-  fun `length-1 escalates with more repeats`() {
+  fun `length-1 still WARNING at five repeats`() {
+    // Pre-2026-05 this was CRITICAL; the bar is intentionally higher now so legitimate
+    // multi-step repetition (PIN entry, "add the same item N times" prompts, scrolling
+    // a long list with a fixed direction) doesn't trip stuck-detection.
     val hint = detectActionCycleHint(List(5) { "tap(a)" })
     assertNotNull(hint)
-    assertTrue(hint.startsWith("CRITICAL:"))
+    assertTrue(hint.startsWith("WARNING:"))
     assertTrue(hint.contains("5 times"))
+  }
+
+  @Test
+  fun `length-1 escalates to CRITICAL at the configured threshold`() {
+    val hint = detectActionCycleHint(List(LENGTH_1_CRITICAL_REPEATS) { "tap(a)" })
+    assertNotNull(hint)
+    assertTrue(hint.startsWith("CRITICAL:"))
+    assertTrue(hint.contains("$LENGTH_1_CRITICAL_REPEATS times"))
   }
 
   @Test
@@ -71,7 +85,7 @@ class ProgressTrackingTest {
   }
 
   @Test
-  fun `length-2 critical at three full cycles`() {
+  fun `length-2 stays WARNING below the critical threshold`() {
     val hint = detectActionCycleHint(
       listOf(
         "tap(items)", "tap(back)",
@@ -80,9 +94,18 @@ class ProgressTrackingTest {
       ),
     )
     assertNotNull(hint)
-    assertTrue(hint.startsWith("CRITICAL:"))
+    assertTrue(hint.startsWith("WARNING:"))
     assertTrue(hint.contains("cycle of 2 actions"))
     assertTrue(hint.contains("3 times"))
+  }
+
+  @Test
+  fun `length-2 escalates to CRITICAL at the configured threshold`() {
+    val pingPong = List(LENGTH_2_CRITICAL_REPEATS) { listOf("tap(items)", "tap(back)") }.flatten()
+    val hint = detectActionCycleHint(pingPong)
+    assertNotNull(hint)
+    assertTrue(hint.startsWith("CRITICAL:"))
+    assertTrue(hint.contains("$LENGTH_2_CRITICAL_REPEATS times"))
   }
 
   @Test
@@ -131,7 +154,7 @@ class ProgressTrackingTest {
   }
 
   @Test
-  fun `length-3 critical at three full cycles`() {
+  fun `length-3 stays WARNING below the critical threshold`() {
     val hint = detectActionCycleHint(
       listOf(
         "tap(a)", "tap(b)", "tap(c)",
@@ -140,7 +163,16 @@ class ProgressTrackingTest {
       ),
     )
     assertNotNull(hint)
+    assertTrue(hint.startsWith("WARNING:"))
+  }
+
+  @Test
+  fun `length-3 escalates to CRITICAL at the configured threshold`() {
+    val triple = List(LENGTH_3_CRITICAL_REPEATS) { listOf("tap(a)", "tap(b)", "tap(c)") }.flatten()
+    val hint = detectActionCycleHint(triple)
+    assertNotNull(hint)
     assertTrue(hint.startsWith("CRITICAL:"))
+    assertTrue(hint.contains("$LENGTH_3_CRITICAL_REPEATS times"))
   }
 
   // --- Negative cases ---

--- a/trailblaze-agent/src/test/kotlin/xyz/block/trailblaze/agent/trail/TrailGoalPlannerSignatureTest.kt
+++ b/trailblaze-agent/src/test/kotlin/xyz/block/trailblaze/agent/trail/TrailGoalPlannerSignatureTest.kt
@@ -95,7 +95,10 @@ class TrailGoalPlannerSignatureTest {
     val signatures = rawHistory.map(::stripActionOutcomeSuffix)
     val hint = detectActionCycleHint(signatures)
     assertNotNull(hint, "alternating tap-pair across mixed outcomes should trigger a hint")
-    assertEquals(true, hint.startsWith("CRITICAL"))
+    // 3 full cycles is below the length-2 CRITICAL threshold (now 15) but above WARNING
+    // (≥ 2). The point of this test is that the SUCCESS/FAILED suffix stripping lets the
+    // detector see the alternation through the variant outcomes — not the specific
+    // severity. Asserting hint+pattern shape is sufficient for that contract.
     assertEquals(true, hint.contains("cycle of 2 actions"))
   }
 

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/config/YamlBackedHostAppTarget.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/config/YamlBackedHostAppTarget.kt
@@ -159,6 +159,16 @@ class YamlBackedHostAppTarget(
   ): Set<ToolName> =
     resolvedExcludedToolsByDriver.yamlNames[driverType] ?: emptySet()
 
+  override fun getDeclaredToolSetIdsForDriver(driverType: TrailblazeDriverType): List<String> {
+    val ids = mutableListOf<String>()
+    config.platforms?.forEach { (platformKey, platformConfig) ->
+      if (driverType in platformConfig.resolveDriverTypes(platformKey)) {
+        platformConfig.toolSets?.let { ids.addAll(it) }
+      }
+    }
+    return ids.distinct()
+  }
+
   // --- MCP server declarations (Decision 038) ---
 
   override fun getMcpServers(): List<McpServerConfig> = config.mcpServers ?: emptyList()

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/TapOnByElementSelector.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/TapOnByElementSelector.kt
@@ -28,23 +28,46 @@ import xyz.block.trailblaze.util.Console
  */
 data class TapOnByElementSelector(
   val reason: String? = null,
-  val selector: TrailblazeElementSelector,
+  /**
+   * Legacy Maestro-shaped flat selector. Optional as of the Android 100% accessibility
+   * cutover — accessibility-only recordings (`nodeSelector.androidAccessibility != null`)
+   * skip the Maestro path entirely, so authoring those without a [selector] is the
+   * correct shape going forward. Existing trail recordings that carry both still load
+   * unchanged; the dispatch logic in [execute] picks the right path per recording.
+   *
+   * For the legacy Maestro-driver runtime path (no longer exercised on Android post-
+   * cutover but still used elsewhere), [selector] remains the source of truth. If both
+   * [selector] and [nodeSelector] are null the tool refuses to run with a clear error
+   * rather than silently no-op.
+   */
+  val selector: TrailblazeElementSelector? = null,
   val longPress: Boolean = false,
   /**
    * Rich driver-native selector generated from [TrailblazeNode] trees.
-   * When present, the agent will attempt to use this for richer element matching
-   * before falling back to the legacy Maestro command path via [selector].
+   *
+   * Set this for accessibility-driver recordings. When [selector] is also set, it acts as
+   * the legacy Maestro fallback for non-accessibility runtimes. When [selector] is null,
+   * this is the only way to identify the target — appropriate for Android post-cutover
+   * since Maestro/UiAutomator routing isn't used anymore.
    *
    * Serialized in trail YAML files so recordings preserve the rich selector for playback.
    */
   val nodeSelector: TrailblazeNodeSelector? = null,
 ) : MapsToMaestroCommands() {
-  override fun toMaestroCommands(memory: AgentMemory): List<Command> = listOf(
-    TapOnElementCommand(
-      selector = selector.toMaestroElementSelector(),
-      longPress = longPress,
-    ),
-  )
+  override fun toMaestroCommands(memory: AgentMemory): List<Command> {
+    // Maestro command projection is only meaningful when the legacy flat [selector] is
+    // populated — that's the field whose shape Maestro's Orchestra knows how to consume.
+    // Accessibility-only recordings (selector=null, nodeSelector!=null) can't be lowered
+    // into a Maestro command at all; emit an empty command list and rely on the
+    // accessibility dispatch path in [execute] to handle them.
+    val maestroSelector = selector ?: return emptyList()
+    return listOf(
+      TapOnElementCommand(
+        selector = maestroSelector.toMaestroElementSelector(),
+        longPress = longPress,
+      ),
+    )
+  }
 
   override suspend fun execute(
     toolExecutionContext: TrailblazeToolExecutionContext,
@@ -100,20 +123,22 @@ data class TapOnByElementSelector(
 
     when (mode) {
       NodeSelectorMode.FORCE_LEGACY -> {
-        return super.execute(toolExecutionContext)
+        return runMaestroFallbackOrFail(toolExecutionContext)
       }
       NodeSelectorMode.FORCE_NODE_SELECTOR -> {
         if (agent != null) {
           val effectiveNodeSelector = nodeSelector
-            ?: selector.toTrailblazeNodeSelector(toolExecutionContext.trailblazeDeviceInfo.platform)
-          val result = agent.executeNodeSelectorTap(
-            nodeSelector = effectiveNodeSelector,
-            longPress = longPress,
-            traceId = toolExecutionContext.traceId,
-          )
-          if (result != null) return result
+            ?: selector?.toTrailblazeNodeSelector(toolExecutionContext.trailblazeDeviceInfo.platform)
+          if (effectiveNodeSelector != null) {
+            val result = agent.executeNodeSelectorTap(
+              nodeSelector = effectiveNodeSelector,
+              longPress = longPress,
+              traceId = toolExecutionContext.traceId,
+            )
+            if (result != null) return result
+          }
         }
-        return super.execute(toolExecutionContext)
+        return runMaestroFallbackOrFail(toolExecutionContext)
       }
       NodeSelectorMode.PREFER_NODE_SELECTOR -> {
         if (nodeSelector != null && agent != null) {
@@ -124,8 +149,28 @@ data class TapOnByElementSelector(
           )
           if (result != null) return result
         }
-        return super.execute(toolExecutionContext)
+        return runMaestroFallbackOrFail(toolExecutionContext)
       }
     }
+  }
+
+  /**
+   * Runs the legacy Maestro command path via [super.execute] only when [selector] is set —
+   * the parent class' [toMaestroCommands] would otherwise produce an empty command list and
+   * Maestro would silently no-op. Accessibility-only recordings (selector=null) reach this
+   * point only when nodeSelector dispatch failed, so failing loud is the right behavior.
+   */
+  private suspend fun runMaestroFallbackOrFail(
+    toolExecutionContext: TrailblazeToolExecutionContext,
+  ): TrailblazeToolResult {
+    if (selector == null) {
+      val message = "tapOnElementBySelector: nodeSelector dispatch failed and no Maestro " +
+        "fallback selector is set on this recording. Accessibility-only recordings must " +
+        "resolve via the on-device agent. Check that the device is running with the " +
+        "accessibility driver and the target node is present in the live tree."
+      Console.log("### tap (no fallback): $message — nodeSelector=${nodeSelector?.driverMatch?.description() ?: "?"}")
+      return TrailblazeToolResult.Error.ExceptionThrown(errorMessage = message)
+    }
+    return super.execute(toolExecutionContext)
   }
 }

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointCaptureExampleCommand.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointCaptureExampleCommand.kt
@@ -14,6 +14,7 @@ import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import picocli.CommandLine.Parameters
+import xyz.block.trailblaze.api.ImageFormatDetector
 import xyz.block.trailblaze.api.waypoint.WaypointDefinition
 import xyz.block.trailblaze.logs.client.TrailblazeJson
 import xyz.block.trailblaze.util.Console
@@ -100,10 +101,18 @@ class WaypointCaptureExampleCommand : Callable<Int> {
       return 1
     }
 
-    // Compute output paths next to the waypoint YAML — keep the source file extension
-    // so .png stays .png, .webp stays .webp.
+    // Compute output paths next to the waypoint YAML.
+    //
+    // Pick the extension by **sniffing the source bytes**, NOT by trusting the source
+    // file's extension. The session log directory has historically contained `.png`-named
+    // files whose bytes were actually WebP (caused by `LogsRepo.saveScreenshotBytes`
+    // defaulting the extension and the on-device screencap pipeline returning WebP for
+    // wire-size). Trusting `rawScreenshot.extension` would propagate that lie into the
+    // committed example pair. Sniffing makes the output extension always match the bytes.
     val baseName = defFile.name.removeSuffix(WAYPOINT_SUFFIX)
-    val screenshotExt = rawScreenshot.extension.ifEmpty { "webp" }
+    val sourceBytes = rawScreenshot.readBytes()
+    val screenshotExt = ImageFormatDetector.detectFormat(sourceBytes).fileExtension
+      .ifEmpty { rawScreenshot.extension.ifEmpty { "webp" } }
     val exampleJsonFile = File(defFile.parentFile, "$baseName$EXAMPLE_JSON_SUFFIX")
     val screenshotFile = File(defFile.parentFile, "$baseName.example.$screenshotExt")
 

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointCommand.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointCommand.kt
@@ -15,12 +15,21 @@ import java.util.concurrent.Callable
     WaypointLocateCommand::class,
     WaypointValidateCommand::class,
     WaypointCaptureExampleCommand::class,
+    // Translate one element ref (as shown in `trailblaze snapshot`) into a list of
+    // selector candidates the author can paste into a *.waypoint.yaml. Wraps the
+    // existing TrailblazeNodeSelectorGenerator strategies — same logic the runtime
+    // uses for tap recordings, repurposed for waypoint authoring.
+    WaypointSuggestSelectorCommand::class,
     // Segments are derived from waypoints — running the matcher against a session log
     // and emitting the observed transitions between matched waypoints. Lives under
     // `waypoint` rather than as a top-level peer because its inputs (waypoints) and
     // its outputs (transitions between waypoints) are both inside the waypoint world.
     // Future shortcut/route commands per the 2026-04-28 devlog will sit alongside.
     SegmentCommand::class,
+    // Renders the navigation graph (waypoints + authored shortcuts + trailheads) as a
+    // standalone HTML page suitable for emailing/Slacking. Same data that backs the
+    // daemon's live `/waypoints/graph` browser view.
+    WaypointGraphCommand::class,
   ],
 )
 class WaypointCommand : Callable<Int> {

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointGraphCommand.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointGraphCommand.kt
@@ -1,0 +1,100 @@
+package xyz.block.trailblaze.cli
+
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import xyz.block.trailblaze.graph.WaypointGraphBuilder
+import xyz.block.trailblaze.graph.WaypointGraphHtmlRenderer
+import xyz.block.trailblaze.util.Console
+import java.io.File
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.util.concurrent.Callable
+
+@Command(
+  name = "graph",
+  mixinStandardHelpOptions = true,
+  description = [
+    "Render the waypoint navigation graph (waypoints, authored shortcuts, authored",
+    "trailheads) as a single self-contained HTML file. The output bakes in screenshots",
+    "as data URIs and loads React Flow + dagre at runtime via esm.sh CDN — open it in any",
+    "browser, share it via email/Slack/zip, no Trailblaze install required on the viewer's",
+    "side.",
+    "",
+    "For a live, refresh-on-edit view from the running daemon, point your browser at",
+    "http://localhost:<daemon-port>/waypoints/graph instead.",
+  ],
+)
+class WaypointGraphCommand : Callable<Int> {
+
+  @Option(
+    names = ["--root"],
+    description = [
+      "Filesystem directory to scan for *.waypoint.yaml files (default: " +
+        "$DEFAULT_WAYPOINT_ROOT, resolved against the current working directory). " +
+        "Pack-bundled waypoints from the classpath are always included regardless of this flag.",
+    ],
+  )
+  var root: File = File(DEFAULT_WAYPOINT_ROOT)
+
+  @Option(
+    names = ["--out", "-o"],
+    description = [
+      "Output HTML file path (default: $DEFAULT_OUT_PATH in the current directory). " +
+        "Parent directories are created if missing. The file is overwritten if present.",
+    ],
+  )
+  var out: File = File(DEFAULT_OUT_PATH)
+
+  override fun call(): Int {
+    if (root.exists() && !root.isDirectory) {
+      Console.error(
+        "Warning: --root is not a directory: ${root.absolutePath} " +
+          "(filesystem-walk waypoints will be empty; classpath-bundled packs still load)",
+      )
+    }
+
+    val timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+    val data = WaypointGraphBuilder.build(
+      root = root,
+      // The CLI emits a frozen snapshot — embed the timestamp + "snapshot" tag in the
+      // generated note so a viewer of the saved file knows it isn't live. The daemon
+      // endpoint uses "live" for the same field.
+      liveSourceLabel = "snapshot · $timestamp",
+    )
+
+    if (data.waypoints.isEmpty()) {
+      // Don't fail with non-zero — emitting a valid HTML "empty state" is the right
+      // contract for a tool that's also called from automation. The CLI is loud
+      // enough on stderr that interactive users still notice.
+      Console.error(
+        "Warning: no waypoints discovered. Output will render an empty-state page. " +
+          "Check that --root points at a directory containing *.waypoint.yaml files, " +
+          "or that the trailblaze-config classpath packs are on the runtime classpath.",
+      )
+    }
+
+    val html = WaypointGraphHtmlRenderer.render(data)
+
+    out.parentFile?.takeIf { !it.exists() }?.mkdirs()
+    out.writeText(html)
+
+    Console.log("Wrote waypoint graph to ${out.absolutePath}")
+    Console.log(
+      "  ${data.waypoints.size} waypoint(s), " +
+        "${data.shortcuts.size} shortcut(s), " +
+        "${data.trailheads.size} trailhead(s)",
+    )
+    Console.log("Open in a browser: file://${out.absolutePath}")
+    return CommandLine.ExitCode.OK
+  }
+
+  companion object {
+    /**
+     * Default output filename — colocated with the user's `cwd`. Picked over
+     * `~/Downloads/...` so the file is easy to find right after running and easy to
+     * `.gitignore` if a workspace wants to drop the artifact next to its `trails/`.
+     */
+    private const val DEFAULT_OUT_PATH = "./waypoint-graph.html"
+  }
+}

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointSuggestSelectorCommand.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointSuggestSelectorCommand.kt
@@ -1,0 +1,416 @@
+package xyz.block.trailblaze.cli
+
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import picocli.CommandLine.Option
+import picocli.CommandLine.Parameters
+import xyz.block.trailblaze.api.DriverNodeDetail
+import xyz.block.trailblaze.api.TrailblazeNode
+import xyz.block.trailblaze.api.TrailblazeNodeSelector
+import xyz.block.trailblaze.api.TrailblazeNodeSelectorGenerator
+import xyz.block.trailblaze.util.Console
+import xyz.block.trailblaze.waypoint.SessionLogScreenState
+import xyz.block.trailblaze.yaml.TrailblazeYaml
+import java.io.File
+import java.util.concurrent.Callable
+
+/**
+ * Suggest waypoint-ready selectors for a specific element ref captured in a session log.
+ *
+ * The hard part of authoring a `*.waypoint.yaml` is translating "this thing on the screen"
+ * into "the right selector YAML." `./trailblaze snapshot --all` shows every element with a
+ * short ref like `[a812]` next to its label, but the ref-to-selector translation has historically
+ * been done by hand, with two failure modes that have actually shipped:
+ *
+ *  1. Picking a selector that uniquely resolves on the recorded screen but is fragile across
+ *     runs — e.g. matching by `text=` when the field that's actually populated for the node
+ *     is `contentDescription=`, or missing the parent `isSelected: true` anchor that makes
+ *     bottom-nav waypoints stable.
+ *  2. Reaching for non-Trailblaze tools (raw `adb shell uiautomator dump`) for "speed" and
+ *     ending up with a Maestro-shaped tree whose attributes are subtly different from the
+ *     accessibility-driver tree the matcher actually reads (Pitfall 5 in the waypoints skill).
+ *
+ * This command short-circuits both. It loads the captured `trailblazeNodeTree` from a session
+ * log, finds the node by ref, and runs the same `TrailblazeNodeSelectorGenerator` cascade the
+ * runtime uses to pick a selector for a tap. The generator returns up to N **named** candidates
+ * (text, content-description, resource id, hierarchy-anchored, etc.) — each verified against
+ * the resolver to produce exactly one match. The author picks the candidate that best
+ * communicates *why* this signal identifies the screen, then pastes its YAML into a
+ * `required:` / `forbidden:` entry.
+ *
+ * ## Why a list, not just "the best"
+ *
+ * `findBestSelector` returns whichever simplest strategy uniquely resolves — usually the
+ * resource id when one exists. That's the right call for tap recordings (machine consumes
+ * it, stability matters) but the wrong call for waypoint authoring, where the human consumer
+ * cares about semantic meaning. A bottom-nav tab might have an opaque resource id like
+ * `com.squareup.development:id/nav_tab_0` and a content description like "Banking" — both
+ * resolve uniquely, but only the latter carries meaning when a future agent reads the YAML.
+ * The author should see both options and choose. (Per the same logic, the structural-only
+ * candidate at the bottom of the output is the right pick for `forbidden:` clauses on sibling
+ * waypoints — it doesn't depend on locale-bound text.)
+ *
+ * ## Inputs
+ *
+ *  - `--ref <X>` — the short ref shown by `snapshot` / the LLM context (`a812`, `n220b`, …).
+ *    Required.
+ *  - Either a positional log file argument or `--session DIR --step N`, mirroring the input
+ *    surface of `waypoint validate`. Same loader — `SessionLogScreenState.loadStep` — so any
+ *    file that command accepts works here too. The default `--step` is "last step in the
+ *    session," matching `waypoint validate`.
+ *  - `--max <N>` — cap the candidate count (default 5). Useful when the generator finds
+ *    many valid candidates and the author only wants the top few.
+ *
+ * ## Output
+ *
+ * One pasteable `required:` block per candidate, with a comment line explaining the strategy
+ * the generator used to produce it. The author trims to the entries they want and edits the
+ * surrounding context (description, minCount). The structural-only candidate prints last so
+ * authors who skim the bottom land on it for forbidden-clause use.
+ */
+@Command(
+  name = "suggest-selector",
+  mixinStandardHelpOptions = true,
+  description = [
+    "Suggest waypoint-ready selector YAML for a specific element ref in a captured screen.",
+    "Pair with `./trailblaze snapshot --all` to see refs, then run this on the matching",
+    "session log to translate ref → selector. Returns up to --max named candidates (the",
+    "TrailblazeNodeSelectorGenerator strategies that uniquely resolve to the target),",
+    "plus one structural-only candidate at the bottom for forbidden-clause use.",
+  ],
+)
+class WaypointSuggestSelectorCommand : Callable<Int> {
+
+  @Parameters(
+    arity = "0..1",
+    description = [
+      "Path to a *_TrailblazeLlmRequestLog.json (required unless --session/--step given).",
+      "Same shape as the input to `waypoint validate`.",
+    ],
+  )
+  var positionalLogFile: File? = null
+
+  @Option(
+    names = ["--ref"],
+    description = ["Element ref from the captured tree (e.g. 'a812'). Required."],
+    required = true,
+  )
+  lateinit var ref: String
+
+  @Option(
+    names = ["--session"],
+    description = ["Session log directory (containing *_TrailblazeLlmRequestLog.json files)"],
+  )
+  var session: File? = null
+
+  @Option(
+    names = ["--step"],
+    description = ["1-based step within --session (default: last step)"],
+  )
+  var step: Int? = null
+
+  @Option(
+    names = ["--max"],
+    description = ["Maximum candidate selectors to return (default: 5)"],
+  )
+  var max: Int = 5
+
+  @Option(
+    names = ["--anchor"],
+    description = [
+      "Compose the leaf selector with an ancestor predicate. Currently supported:",
+      "  parent-selected — find the nearest ancestor with isSelected=true and emit a",
+      "    selector that matches that ancestor as a `View` with `isSelected: true`,",
+      "    using the leaf as `containsChild`. This is the canonical bottom-nav-tab",
+      "    waypoint pattern: any app with selectable bottom-nav tabs uses this to",
+      "    pin identity to the *currently active* tab rather than to any tab with the",
+      "    given label. Without the anchor, the leaf selector matches a tab regardless",
+      "    of selection state — fine for tap targets, wrong for waypoint identity,",
+      "    because we want to know WHICH tab is currently active.",
+    ],
+  )
+  var anchor: String? = null
+
+  override fun call(): Int {
+    val logFile = resolveLogFile() ?: return CommandLine.ExitCode.USAGE
+    val screen = SessionLogScreenState.loadStep(logFile)
+    val tree = screen.trailblazeNodeTree ?: run {
+      Console.error("Log has no trailblazeNodeTree: ${logFile.name}")
+      Console.error("Pick a log file from a step that captured an accessibility tree.")
+      return 1
+    }
+
+    val target = tree.findFirstByRef(ref) ?: run {
+      Console.error("Ref not found in tree: '$ref' (log: ${logFile.name})")
+      Console.error(
+        "Hint: cross-check with `./trailblaze snapshot --all` — refs are " +
+          "tree-capture-local and don't survive across captures.",
+      )
+      return 1
+    }
+
+    Console.log("# Element ref: $ref")
+    Console.log("# Source: ${logFile.name}")
+    Console.log("# ${describeNode(target)}")
+    Console.log("")
+
+    val candidates = TrailblazeNodeSelectorGenerator.findAllValidSelectors(
+      root = tree,
+      target = target,
+      maxResults = max,
+    )
+
+    if (candidates.isEmpty()) {
+      // findAllValidSelectors guarantees at least the index fallback, so this
+      // path is mostly defensive — but we want the failure mode to be loud rather
+      // than emitting silently-empty output.
+      Console.error("No selectors generated for ref '$ref'. This shouldn't happen.")
+      return 1
+    }
+
+    Console.log("# ${candidates.size} candidate selector(s), best-first.")
+    Console.log("# Pick the one that best expresses *why* this signal identifies the screen.")
+    Console.log("# Resource ids are most stable; text / contentDescription are most readable.")
+    Console.log("")
+
+    candidates.forEachIndexed { idx, named ->
+      val marker = if (named.isBest) " (best)" else ""
+      Console.log("# [${idx + 1}] Strategy: ${named.strategy}$marker")
+      printSelectorYaml(named.selector)
+      Console.log("")
+    }
+
+    // Structural-only candidate as a separate section. It's not in `candidates` because
+    // findAllValidSelectors uses the full strategy cascade (which prefers text), while
+    // findBestStructuralSelector deliberately excludes text/content. Different question,
+    // different answer; both worth showing.
+    val structural = TrailblazeNodeSelectorGenerator.findBestStructuralSelector(tree, target)
+    Console.log("# Structural-only (text-independent — useful for `forbidden:` clauses on sibling")
+    Console.log("# waypoints, or when locale changes the visible text):")
+    Console.log("# Strategy: ${structural.strategy}")
+    printSelectorYaml(structural.selector)
+
+    // Anchor composition. The default cascade returns selectors that uniquely identify
+    // the *leaf* (e.g. the View with `contentDescription="Money"`). For bottom-nav tab
+    // waypoints we want a stronger predicate: "the bottom-nav Money tab is currently
+    // selected." That requires composing the leaf with an ancestor's `isSelected: true`
+    // — `findAllValidSelectors` won't emit it because the leaf is already unique without
+    // it (and isSelected is deliberately excluded from the structural generator on the
+    // grounds that selection is transient — true for tap-recording, but exactly the
+    // signal we want for a waypoint that should ONLY match when the user is on this
+    // tab).
+    if (anchor != null) {
+      Console.log("")
+      emitAnchorSelector(tree, target)
+    }
+
+    return CommandLine.ExitCode.OK
+  }
+
+  private fun emitAnchorSelector(tree: TrailblazeNode, target: TrailblazeNode) {
+    when (anchor) {
+      "parent-selected" -> {
+        val parentMap = buildParentMap(tree)
+        val ancestor = walkUp(target, parentMap).firstOrNull { node ->
+          (node.driverDetail as? DriverNodeDetail.AndroidAccessibility)?.isSelected == true
+        }
+        if (ancestor == null) {
+          Console.log("# --anchor=parent-selected: no ancestor with isSelected=true above ref '$ref'.")
+          Console.log("# Drop the flag, or pick a ref whose tab is currently active.")
+          return
+        }
+        val ancestorDetail = ancestor.driverDetail as DriverNodeDetail.AndroidAccessibility
+        val leafDetail = target.driverDetail as? DriverNodeDetail.AndroidAccessibility ?: return
+        Console.log("# Anchored: parent isSelected + this as containsChild")
+        Console.log("# This is the canonical bottom-nav-tab pattern — only matches when this tab is the active one.")
+        Console.log("- description: \"\"")
+        Console.log("  selector:")
+        Console.log("    androidAccessibility:")
+        ancestorDetail.className?.let {
+          Console.log("      classNameRegex: \"${escapeYamlString(escapeForYamlRegex(it))}\"")
+        }
+        Console.log("      isSelected: true")
+        Console.log("    containsChild:")
+        Console.log("      androidAccessibility:")
+        leafDetail.className?.let {
+          Console.log("        classNameRegex: \"${escapeYamlString(escapeForYamlRegex(it))}\"")
+        }
+        when {
+          leafDetail.text != null -> Console.log(
+            "        textRegex: \"${escapeYamlString("^" + Regex.escape(leafDetail.text!!) + "$")}\"",
+          )
+          leafDetail.contentDescription != null -> Console.log(
+            "        contentDescriptionRegex: \"${escapeYamlString("^" + Regex.escape(leafDetail.contentDescription!!) + "$")}\"",
+          )
+        }
+      }
+      else -> Console.log("# Unknown --anchor mode: '$anchor'. Supported: parent-selected.")
+    }
+  }
+
+  private fun buildParentMap(root: TrailblazeNode): Map<Long, TrailblazeNode> {
+    val map = mutableMapOf<Long, TrailblazeNode>()
+    fun rec(parent: TrailblazeNode) {
+      for (c in parent.children) {
+        map[c.nodeId] = parent
+        rec(c)
+      }
+    }
+    rec(root)
+    return map
+  }
+
+  private fun walkUp(node: TrailblazeNode, parentMap: Map<Long, TrailblazeNode>): Sequence<TrailblazeNode> =
+    generateSequence(parentMap[node.nodeId]) { parentMap[it.nodeId] }
+
+  /**
+   * Escape a literal string for inclusion in a regex pattern (Java regex `\Q...\E`
+   * equivalent of [Regex.escape] — kept identical to what
+   * `TrailblazeNodeSelectorGeneratorAndroidAccessibility.escapeForSelector` produces so
+   * anchored selectors round-trip through the same matcher.
+   */
+  private fun escapeForYamlRegex(s: String): String = "\\Q$s\\E"
+
+  private fun resolveLogFile(): File? {
+    positionalLogFile?.let { return validateLogFile(it, label = "Log file") }
+    session?.let { return resolveFromSession(it) }
+    Console.error("Provide either a positional log file argument or --session [--step].")
+    return null
+  }
+
+  private fun resolveFromSession(sessionDir: File): File? {
+    val validated = validateSessionDir(sessionDir) ?: return null
+    val logs = SessionLogScreenState.listLlmRequestLogs(validated)
+    if (logs.isEmpty()) {
+      Console.error("No *_TrailblazeLlmRequestLog.json files found in: ${validated.absolutePath}")
+      return null
+    }
+    val idx = step?.let { it - 1 } ?: (logs.size - 1)
+    if (idx !in logs.indices) {
+      Console.error("--step out of range: 1..${logs.size}")
+      return null
+    }
+    return logs[idx]
+  }
+
+  private fun describeNode(target: TrailblazeNode): String {
+    val parts = mutableListOf<String>()
+    when (val d = target.driverDetail) {
+      is DriverNodeDetail.AndroidAccessibility -> {
+        d.className?.substringAfterLast('.')?.let { parts += it }
+        d.text?.takeIf { it.isNotBlank() }?.let { parts += "text=\"$it\"" }
+        d.contentDescription?.takeIf { it.isNotBlank() }?.let { parts += "desc=\"$it\"" }
+        d.resourceId?.let { parts += "id=\"$it\"" }
+        if (d.isSelected) parts += "isSelected"
+        if (d.isHeading) parts += "isHeading"
+        if (d.isClickable) parts += "isClickable"
+      }
+      else -> parts += d::class.simpleName.orEmpty()
+    }
+    return if (parts.isEmpty()) "(no identifying properties)" else parts.joinToString(" ")
+  }
+
+  private fun printSelectorYaml(selector: TrailblazeNodeSelector) {
+    // Emit a pasteable WaypointSelectorEntry — `- description: ""\n  selector:\n    ...`.
+    //
+    // Hand-format rather than using the kaml `TrailblazeYaml` instance because:
+    //  1. We want to control indent precisely (4-space child indent, matching the existing
+    //     hand-authored waypoint files in the repo).
+    //  2. We want `\Qfoo\E` literal blocks emitted verbatim (`\Q` / `\E` escape chars
+    //     are valid YAML scalars but kaml's default scalar style escapes them in a way
+    //     that makes the regex hard to read).
+    //  3. The selector shape is shallow — driver match + optional spatial / hierarchy
+    //     children — so the formatting recursion stays tiny and reads cleanly.
+    Console.log("- description: \"\"")
+    Console.log("  selector:")
+    emitSelectorBody(selector, indent = 4)
+  }
+
+  private fun emitSelectorBody(selector: TrailblazeNodeSelector, indent: Int) {
+    val pad = " ".repeat(indent)
+    val childPad = " ".repeat(indent + 2)
+    selector.androidAccessibility?.let { match ->
+      Console.log("${pad}androidAccessibility:")
+      match.classNameRegex?.let { Console.log("$childPad" + "classNameRegex: \"${escapeYamlString(it)}\"") }
+      match.resourceIdRegex?.let { Console.log("$childPad" + "resourceIdRegex: \"${escapeYamlString(it)}\"") }
+      match.textRegex?.let { Console.log("$childPad" + "textRegex: \"${escapeYamlString(it)}\"") }
+      match.contentDescriptionRegex?.let { Console.log("$childPad" + "contentDescriptionRegex: \"${escapeYamlString(it)}\"") }
+      match.hintTextRegex?.let { Console.log("$childPad" + "hintTextRegex: \"${escapeYamlString(it)}\"") }
+      match.labeledByTextRegex?.let { Console.log("$childPad" + "labeledByTextRegex: \"${escapeYamlString(it)}\"") }
+      match.stateDescriptionRegex?.let { Console.log("$childPad" + "stateDescriptionRegex: \"${escapeYamlString(it)}\"") }
+      match.paneTitleRegex?.let { Console.log("$childPad" + "paneTitleRegex: \"${escapeYamlString(it)}\"") }
+      match.roleDescriptionRegex?.let { Console.log("$childPad" + "roleDescriptionRegex: \"${escapeYamlString(it)}\"") }
+      match.composeTestTagRegex?.let { Console.log("$childPad" + "composeTestTagRegex: \"${escapeYamlString(it)}\"") }
+      match.uniqueId?.let { Console.log("$childPad" + "uniqueId: \"${escapeYamlString(it)}\"") }
+      match.isSelected?.takeIf { it }?.let { Console.log("$childPad" + "isSelected: true") }
+      match.isHeading?.takeIf { it }?.let { Console.log("$childPad" + "isHeading: true") }
+      match.isClickable?.takeIf { it }?.let { Console.log("$childPad" + "isClickable: true") }
+      match.isCheckable?.takeIf { it }?.let { Console.log("$childPad" + "isCheckable: true") }
+      match.isChecked?.takeIf { it }?.let { Console.log("$childPad" + "isChecked: true") }
+      match.isEditable?.takeIf { it }?.let { Console.log("$childPad" + "isEditable: true") }
+      match.isPassword?.takeIf { it }?.let { Console.log("$childPad" + "isPassword: true") }
+      match.isScrollable?.takeIf { it }?.let { Console.log("$childPad" + "isScrollable: true") }
+      match.isEnabled?.takeIf { it }?.let { Console.log("$childPad" + "isEnabled: true") }
+      match.isFocused?.takeIf { it }?.let { Console.log("$childPad" + "isFocused: true") }
+      match.inputType?.takeIf { it != 0 }?.let { Console.log("$childPad" + "inputType: $it") }
+      match.collectionItemRowIndex?.let { Console.log("$childPad" + "collectionItemRowIndex: $it") }
+      match.collectionItemColumnIndex?.let { Console.log("$childPad" + "collectionItemColumnIndex: $it") }
+    }
+    selector.containsChild?.let {
+      Console.log("${pad}containsChild:")
+      emitSelectorBody(it, indent + 2)
+    }
+    selector.childOf?.let {
+      Console.log("${pad}childOf:")
+      emitSelectorBody(it, indent + 2)
+    }
+    selector.containsDescendants?.takeIf { it.isNotEmpty() }?.let { list ->
+      Console.log("${pad}containsDescendants:")
+      list.forEach { d ->
+        Console.log("$pad  -")
+        emitSelectorBody(d, indent + 4)
+      }
+    }
+    selector.above?.let {
+      Console.log("${pad}above:")
+      emitSelectorBody(it, indent + 2)
+    }
+    selector.below?.let {
+      Console.log("${pad}below:")
+      emitSelectorBody(it, indent + 2)
+    }
+    selector.leftOf?.let {
+      Console.log("${pad}leftOf:")
+      emitSelectorBody(it, indent + 2)
+    }
+    selector.rightOf?.let {
+      Console.log("${pad}rightOf:")
+      emitSelectorBody(it, indent + 2)
+    }
+    selector.index?.let { Console.log("${pad}index: $it") }
+  }
+
+  /**
+   * Minimal YAML string escape: backslashes and double-quotes only, since these are the
+   * two characters that break a `"..."`-quoted scalar. Regex literals like `\Qfoo\E` need
+   * the backslash doubled so YAML parses them back as the literal `\Q...\E` for the regex
+   * engine. Newlines and control characters don't appear in selector regex strings (the
+   * generator escapes input via `escapeForSelector`), so this stays simple.
+   */
+  private fun escapeYamlString(s: String): String =
+    s.replace("\\", "\\\\").replace("\"", "\\\"")
+}
+
+/**
+ * Walks the tree depth-first and returns the first node whose [TrailblazeNode.ref] equals
+ * [ref]. Refs are unique within a single capture (by construction in
+ * `CompactElementListUtils`), so first-hit is exact-hit; the function name documents the
+ * search style for callers who'd otherwise wonder if they should iterate.
+ */
+private fun TrailblazeNode.findFirstByRef(ref: String): TrailblazeNode? {
+  if (this.ref == ref) return this
+  for (child in children) {
+    child.findFirstByRef(ref)?.let { return it }
+  }
+  return null
+}

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/graph/WaypointGraphBuilder.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/graph/WaypointGraphBuilder.kt
@@ -1,0 +1,132 @@
+package xyz.block.trailblaze.graph
+
+import xyz.block.trailblaze.api.ImageFormatDetector
+import xyz.block.trailblaze.config.ToolYamlLoader
+import xyz.block.trailblaze.ui.tabs.waypoints.loadWaypoints
+import java.io.File
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+/**
+ * Assembles a [WaypointGraphData] snapshot from a workspace root path, suitable for
+ * either the in-app browser endpoint or the standalone CLI export. Pure function that
+ * takes (root path, optional source label) and returns a fully-loaded graph — no
+ * network, no UI dependencies.
+ *
+ * ## Why this lives in trailblaze-host (not trailblaze-server)
+ *
+ * Waypoint discovery (`WaypointDiscovery.discover`) and the existing example-loader
+ * pipeline (`loadWaypoints`) live in trailblaze-host. The server module depends on
+ * trailblaze-host (not the other way around — the server is a substrate, the host is
+ * the surface), so co-locating the graph builder with discovery avoids the inversion of
+ * pulling host-only types into the server module just for one endpoint.
+ *
+ * The Ktor endpoint that serves graph JSON ([WaypointGraphEndpoint]) registers as a
+ * route on the server's routing block via a callback the desktop app passes when it
+ * starts the daemon — that's how host-side data reaches a server-side request without
+ * the dep direction flipping.
+ */
+object WaypointGraphBuilder {
+
+  /**
+   * Builds a snapshot. The expensive bits (filesystem walk, classpath pack scan,
+   * example decoding) all happen here synchronously — callers are responsible for
+   * pushing the call onto an IO dispatcher when invoking from a UI/RPC thread.
+   *
+   * @param root filesystem root to scan for `*.waypoint.yaml` files. Pack-bundled
+   *             waypoints from the classpath are always included regardless.
+   * @param liveSourceLabel populates the trailing `(live)` / `(snapshot)` suffix in the
+   *             generated note. The desktop endpoint passes "live"; the CLI passes a
+   *             timestamp-based label so users opening a saved file know it's frozen.
+   */
+  @OptIn(ExperimentalEncodingApi::class)
+  fun build(
+    root: File,
+    liveSourceLabel: String = "live",
+  ): WaypointGraphData {
+    val output = loadWaypoints(root)
+
+    val nodes = output.items.map { item ->
+      val def = item.definition
+      val screenshotBytes = item.example?.screenshotBytes?.takeIf { it.isNotEmpty() }
+      // Inline screenshot as a data URI. Format-sniffing here keeps the generated HTML
+      // self-contained (no separate `?id=...&type=...` content-type negotiation needed).
+      // Sniffing via the canonical [ImageFormatDetector] — same util the screenshotSaver
+      // and capture-example call sites use, so the whole pipeline picks the same answer
+      // for the same bytes.
+      val dataUri = screenshotBytes?.let { bytes ->
+        val mime = ImageFormatDetector.detectFormat(bytes).mimeType
+        "data:$mime;base64,${Base64.encode(bytes)}"
+      }
+      // Derive platform from the source-label path (`packs/<pack>/waypoints/<platform>/...`).
+      // The id no longer carries it post-URL-rename — the platform lives on disk now and
+      // gets surfaced here so the front-end filter pills don't have to parse it themselves.
+      val platform = item.sourceLabel?.let { label ->
+        when {
+          "/android/" in label -> "android"
+          "/ios/" in label -> "ios"
+          "/web/" in label -> "web"
+          else -> null
+        }
+      }
+      WaypointGraphNode(
+        id = def.id,
+        description = def.description,
+        screenshotDataUri = dataUri,
+        sourceLabel = item.sourceLabel,
+        platform = platform,
+        // Selector entries surface in the detail panel — they answer "how
+        // does the matcher know this screen is <id>?". Pulled straight from
+        // the WaypointDefinition so what the panel shows is exactly what the
+        // matcher checks.
+        required = def.required,
+        forbidden = def.forbidden,
+      )
+    }
+
+    val toolConfigs = try {
+      ToolYamlLoader.discoverShortcutsAndTrailheads()
+    } catch (e: Exception) {
+      // Loader failures are non-fatal for the graph view — we'd rather render the
+      // node grid with no edges than fail the whole page on a single bad YAML.
+      // Server-side: the load already logs its own warning via the lenient-load
+      // path, so we don't double-log here.
+      emptyMap()
+    }
+
+    val shortcuts = toolConfigs.mapNotNull { (toolName, config) ->
+      config.shortcut?.let { meta ->
+        WaypointGraphShortcut(
+          id = toolName.toolName,
+          description = config.description,
+          from = meta.from,
+          to = meta.to,
+          variant = meta.variant,
+        )
+      }
+    }
+
+    val trailheads = toolConfigs.mapNotNull { (toolName, config) ->
+      config.trailhead?.let { meta ->
+        WaypointGraphTrailhead(
+          id = toolName.toolName,
+          description = config.description,
+          to = meta.to,
+        )
+      }
+    }
+
+    val timestamp = DateTimeFormatter.ISO_INSTANT.format(Instant.now())
+    val generatedNote = "Generated $timestamp from ${root.absolutePath} ($liveSourceLabel)"
+
+    return WaypointGraphData(
+      waypoints = nodes,
+      shortcuts = shortcuts,
+      trailheads = trailheads,
+      generatedNote = generatedNote,
+    )
+  }
+
+}

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/graph/WaypointGraphData.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/graph/WaypointGraphData.kt
@@ -1,0 +1,97 @@
+package xyz.block.trailblaze.graph
+
+import kotlinx.serialization.Serializable
+import xyz.block.trailblaze.api.waypoint.WaypointSelectorEntry
+
+/**
+ * Pure data shape of the waypoint navigation graph — the JSON contract between Kotlin
+ * (which builds it) and the React Flow front-end (which renders it).
+ *
+ * This intentionally lives outside the existing `xyz.block.trailblaze.ui.*` packages so
+ * the renderer (HTML) and the builder (Kotlin) share a single source of truth that has
+ * nothing to do with Compose. Both the in-app browser button and the standalone
+ * `./trailblaze waypoint graph` CLI emit the same structure; the front-end is unaware of
+ * which surface produced it.
+ *
+ * Shape choices:
+ *  - **Screenshots inlined as data URIs.** The whole point of "save the page and share
+ *    it" is single-file portability. Externalizing screenshots (as `/screenshot/<id>`
+ *    URLs served by the daemon) is a future optimization for the live in-desktop view
+ *    but would break the standalone-file workflow. Inline by default; revisit if file
+ *    sizes get unreasonable for huge waypoint sets.
+ *  - **Pack ids parsed lazily on the front-end.** We don't pre-compute pack/platform
+ *    grouping here because React Flow's filter UI is cheap and doing it in JS keeps the
+ *    JSON payload smaller and lets the front-end iterate without re-emitting the file.
+ */
+@Serializable
+data class WaypointGraphData(
+  /** Every waypoint that should appear as a node, regardless of edge connectivity. */
+  val waypoints: List<WaypointGraphNode>,
+  /** Authored shortcut edges (`*.shortcut.yaml`) — render as solid arrows. */
+  val shortcuts: List<WaypointGraphShortcut>,
+  /** Authored trailhead edges (`*.trailhead.yaml`) — render as dashed arrows from a virtual origin. */
+  val trailheads: List<WaypointGraphTrailhead>,
+  /**
+   * One-line generation provenance shown in the page footer, e.g.
+   * `"generated 2026-04-29T13:45:00Z from /Users/sam/.../trails (live)"`. Shown to the
+   * viewer so they know this is a snapshot, not a live view (especially important when
+   * the file has been emailed/Slacked around).
+   */
+  val generatedNote: String,
+)
+
+@Serializable
+data class WaypointGraphNode(
+  /** Slash-separated waypoint id (e.g. `square/banking`). */
+  val id: String,
+  /** Optional human-readable description from the waypoint YAML's `description:` field. */
+  val description: String?,
+  /**
+   * Raw screenshot bytes encoded as a data URI (`data:image/<format>;base64,...`), or
+   * null when no example pair was found. The front-end falls back to a placeholder card
+   * for nulls so the layout still renders.
+   */
+  val screenshotDataUri: String?,
+  /**
+   * Provenance label for hover tooltip — e.g. `pack:myapp — waypoints/banking.waypoint.yaml`
+   * or a relative filesystem path. Helps the viewer debug "which file did this come from?"
+   * without leaving the page.
+   */
+  val sourceLabel: String?,
+  /**
+   * Platform for this waypoint variant — `"android"`, `"ios"`, `"web"`, or `null` when not
+   * platform-specific. Derived from the waypoint file's location on disk
+   * (`packs/<pack>/waypoints/<platform>/...`); the id itself no longer carries the
+   * platform segment. Drives the platform filter pills in the graph viewer.
+   */
+  val platform: String?,
+  /**
+   * Selector entries that must ALL match in the captured tree for the waypoint matcher to
+   * accept this screen. The detail panel renders these as the "how does the matcher know
+   * this is `<id>`?" answer — the selectors *are* the waypoint's identity.
+   */
+  val required: List<WaypointSelectorEntry> = emptyList(),
+  /**
+   * Selector entries that must NOT match. Even one match here disqualifies the waypoint —
+   * useful for distinguishing siblings that share most identity signals (e.g. "this is
+   * the Money tab specifically — the Withdraw button must NOT be present, otherwise we'd
+   * be on the Withdraw composer").
+   */
+  val forbidden: List<WaypointSelectorEntry> = emptyList(),
+)
+
+@Serializable
+data class WaypointGraphShortcut(
+  val id: String,
+  val description: String?,
+  val from: String,
+  val to: String,
+  val variant: String?,
+)
+
+@Serializable
+data class WaypointGraphTrailhead(
+  val id: String,
+  val description: String?,
+  val to: String,
+)

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/graph/WaypointGraphEndpoint.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/graph/WaypointGraphEndpoint.kt
@@ -1,0 +1,111 @@
+package xyz.block.trailblaze.graph
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import xyz.block.trailblaze.util.Console
+import java.io.File
+
+/**
+ * Ktor route registration for the live waypoint graph view served by the daemon.
+ *
+ * Two endpoints:
+ *  - `GET /waypoints/graph` → the React Flow HTML page with graph data inlined.
+ *  - `GET /waypoints/graph.json` → the same data as JSON for tooling that wants the
+ *    raw shape (e.g. piping into another visualizer, or scripting around it).
+ *
+ * Both endpoints accept `?root=<path>` to override the workspace root; if absent, they
+ * fall back to the [defaultRootProvider] (which the desktop wires to its current
+ * "trails directory" setting). The override exists so an operator can poke a different
+ * waypoint root without restarting the daemon — useful for comparing branches.
+ *
+ * ## Why register from trailblaze-host instead of trailblaze-server
+ *
+ * The graph data builder ([WaypointGraphBuilder]) needs `WaypointDiscovery` and
+ * `loadWaypoints` from trailblaze-host. Server depends on host *not* the other way, so
+ * the endpoint cannot live in trailblaze-server's routing block directly — it would
+ * pull host-only types into the lower layer. Instead this object exposes a `register`
+ * extension that the server's start-up code invokes via a callback param.
+ */
+object WaypointGraphEndpoint {
+
+  private const val PATH_HTML = "/waypoints/graph"
+  private const val PATH_JSON = "/waypoints/graph.json"
+
+  /**
+   * Registers both routes against [routing]. Call from inside a Ktor `routing { }` or
+   * directly from the server's `additionalRouteRegistration` callback.
+   *
+   * @param routing the Ktor routing block.
+   * @param defaultRootProvider returns the fallback `--root` filesystem path when the
+   *        request omits `?root=`. Typically `() -> File(savedSettingsRepo.trailsDir)`.
+   *        Called per-request so a settings change reflects without re-registering.
+   */
+  fun register(
+    routing: Routing,
+    defaultRootProvider: () -> File,
+  ) {
+    routing.apply {
+      get(PATH_HTML) {
+        val root = resolveRoot(call.parameters["root"], defaultRootProvider)
+        val html = withContext(Dispatchers.IO) {
+          val data = WaypointGraphBuilder.build(root, liveSourceLabel = "live · daemon")
+          WaypointGraphHtmlRenderer.render(data)
+        }
+        // text/html — Ktor's respondText writes UTF-8 by default, which round-trips
+        // non-ASCII waypoint descriptions cleanly without browser charset-guess
+        // heuristics tripping on em-dashes / smart-quotes.
+        call.respondText(text = html, contentType = ContentType.Text.Html)
+      }
+
+      get(PATH_JSON) {
+        val root = resolveRoot(call.parameters["root"], defaultRootProvider)
+        val data = withContext(Dispatchers.IO) {
+          WaypointGraphBuilder.build(root, liveSourceLabel = "live · daemon")
+        }
+        // Reuse the renderer's JSON encoder configuration so HTML and JSON stay in
+        // sync — if a future field is added, both surfaces emit it without separate
+        // serializer plumbing.
+        val json = kotlinx.serialization.json.Json { encodeDefaults = true }
+        call.respondText(
+          text = json.encodeToString(WaypointGraphData.serializer(), data),
+          contentType = ContentType.Application.Json,
+        )
+      }
+    }
+  }
+
+  /**
+   * Resolves the request-scoped `?root=` query param, falling back to the default
+   * provider when absent or blank. Empty strings are treated as absent — a query
+   * param like `?root=` (which can happen when a UI clears its input) shouldn't
+   * silently route to a non-existent file path; using the default is friendlier.
+   *
+   * Failure to resolve a `File` (provider throws) propagates upward as a 500, which
+   * is correct: the desktop misconfigured something and we'd rather see the stack
+   * trace in logs than render an empty graph and look fine.
+   */
+  private fun resolveRoot(rawParam: String?, defaultProvider: () -> File): File {
+    val trimmed = rawParam?.trim().orEmpty()
+    return if (trimmed.isEmpty()) {
+      defaultProvider()
+    } else {
+      File(trimmed).also {
+        if (!it.exists() || !it.isDirectory) {
+          // Don't fail the request — the discovery layer is robust to bad roots and
+          // will emit an empty filesystem-walk while still loading classpath packs.
+          // Surface it to the operator's log so a typo isn't invisible.
+          Console.error(
+            "[WaypointGraphEndpoint] ?root=$trimmed is not a directory. " +
+              "Filesystem-walk waypoints will be empty; classpath-bundled packs still load.",
+          )
+        }
+      }
+    }
+  }
+}

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/graph/WaypointGraphHtmlRenderer.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/graph/WaypointGraphHtmlRenderer.kt
@@ -1,0 +1,100 @@
+package xyz.block.trailblaze.graph
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Turns a [WaypointGraphData] into a complete, self-contained HTML page that renders
+ * the navigation graph via React Flow.
+ *
+ * ## How the page is assembled
+ *
+ * The template at `resources/xyz/block/trailblaze/graph/waypoint-graph-template.html`
+ * is a static HTML file with one substitution point: a marked-up `null` literal that
+ * sits between `JSON_DATA_PLACEHOLDER_BEGIN` and `JSON_DATA_PLACEHOLDER_END` markers.
+ * We swap that `null` for the JSON-encoded graph data and ship the result as-is.
+ *
+ * No string interpolation in the template means:
+ *  - The template can be edited and previewed in any browser (the `null` graph
+ *    triggers an "empty" branch that renders gracefully) without first running through
+ *    a build step.
+ *  - There's no risk of accidental escaping mistakes inside Kotlin string literals —
+ *    the template is plain text; only one well-defined region is replaced.
+ *  - The marker pair is a pure JS comment, so even if the substitution somehow fails
+ *    the page still loads (the empty-state shows up instead of a syntax error).
+ *
+ * ## Output is a single self-contained file
+ *
+ * The CLI's `--out` flag and the daemon endpoint both produce identical output —
+ * usable by anyone who has the file, regardless of whether they have the daemon
+ * running or even the trailblaze repo cloned. Screenshots are inlined as data URIs
+ * (see [WaypointGraphBuilder]), and the React Flow / dagre dependencies load from
+ * esm.sh on first view (cached after that). No build pipeline, no companion files.
+ */
+object WaypointGraphHtmlRenderer {
+
+  /**
+   * `kotlinx.serialization` instance configured for embedding in HTML. We don't pretty-
+   * print to keep the page small (dropping ~20% of bytes for typical graphs) and
+   * `ignoreUnknownKeys` doesn't apply on the encode path. `prettyPrint = false` is the
+   * default; making it explicit so a future "give me a debug-friendly version" override
+   * is one flag away.
+   */
+  private val json = Json {
+    prettyPrint = false
+    encodeDefaults = true
+  }
+
+  private val template: String by lazy { loadTemplate() }
+
+  /**
+   * Renders the page. Returns the full HTML as a string — caller decides whether to
+   * write it to a file (CLI) or stream it as a Ktor response (endpoint).
+   */
+  fun render(data: WaypointGraphData): String {
+    val payload = json.encodeToString(data)
+    return template.replace(
+      PLACEHOLDER_REGEX,
+      // String.replace(Regex, String) treats `$` as a back-reference. Use the lambda
+      // form so the JSON payload is inserted verbatim, with no group expansion drama.
+      transform = { _ -> payload },
+    )
+  }
+
+  /**
+   * Loaded once per JVM. The template is a small static file (~14 KB), but caching
+   * keeps the per-render cost bounded by JSON encoding alone — a hot path if the
+   * desktop server endpoint sees rapid refreshes.
+   *
+   * `getResourceAsStream` uses the class's classloader, which is the same loader that
+   * sees the resource directory we control — so this works regardless of how the JAR
+   * is packaged downstream.
+   */
+  private fun loadTemplate(): String {
+    val resource = WaypointGraphHtmlRenderer::class.java
+      .getResourceAsStream(TEMPLATE_RESOURCE_PATH)
+      ?: error(
+        "Waypoint graph template not found at classpath:$TEMPLATE_RESOURCE_PATH. " +
+          "This is a packaging bug — the template should ship alongside the renderer.",
+      )
+    return resource.bufferedReader(Charsets.UTF_8).use { it.readText() }
+  }
+
+  /**
+   * Placeholder region inside the template, written as a JS comment so the unsubstit-
+   * uted template still parses and renders the empty state. The `(?s)` flag is for
+   * dotall — the body might span lines after a future template edit, but defensively
+   * we don't depend on that today.
+   */
+  private val PLACEHOLDER_REGEX = Regex(
+    "/\\*JSON_DATA_PLACEHOLDER_BEGIN\\*/.*?/\\*JSON_DATA_PLACEHOLDER_END\\*/",
+    RegexOption.DOT_MATCHES_ALL,
+  )
+
+  /**
+   * Resource path is relative to the renderer's class — the leading `/` makes it
+   * absolute under the classloader root. Keeping the template colocated with this
+   * file's package means moving either one moves the other together.
+   */
+  private const val TEMPLATE_RESOURCE_PATH = "/xyz/block/trailblaze/graph/waypoint-graph-template.html"
+}

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/host/TrailblazeHostYamlRunner.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/host/TrailblazeHostYamlRunner.kt
@@ -1299,11 +1299,12 @@ object TrailblazeHostYamlRunner {
      */
     onSessionStarted: (SessionId) -> Unit = {},
   ): SessionId? {
+    val driverType = TrailblazeDriverType.ANDROID_ONDEVICE_ACCESSIBILITY
     val customToolClasses = targetTestApp
-      ?.getCustomToolsForDriver(TrailblazeDriverType.ANDROID_ONDEVICE_ACCESSIBILITY)
+      ?.getCustomToolsForDriver(driverType)
       ?: emptySet()
     val excludedToolClasses = targetTestApp
-      ?.getExcludedToolsForDriver(TrailblazeDriverType.ANDROID_ONDEVICE_ACCESSIBILITY)
+      ?.getExcludedToolsForDriver(driverType)
       ?: emptySet()
 
     val trailblazeYaml = createTrailblazeYaml(
@@ -1369,6 +1370,7 @@ object TrailblazeHostYamlRunner {
     val toolRepo = TrailblazeToolRepo.withDynamicToolSets(
       customToolClasses = customToolClasses,
       excludedToolClasses = excludedToolClasses,
+      driverType = driverType,
     )
 
     // Single AgentMemory shared between host-local tool execution contexts and the RPC
@@ -1665,6 +1667,7 @@ object TrailblazeHostYamlRunner {
     val toolRepo = TrailblazeToolRepo.withDynamicToolSets(
       customToolClasses = customToolClasses,
       excludedToolClasses = excludedToolClasses,
+      driverType = driverType,
     )
 
     val agent = HostOnDeviceRpcTrailblazeAgent(

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/MainTrailblazeApp.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/MainTrailblazeApp.kt
@@ -128,6 +128,7 @@ class MainTrailblazeApp(
         port = portManager.httpPort,
         httpsPort = portManager.httpsPort,
         wait = true,
+        additionalRouteRegistration = waypointGraphRouteRegistration(trailblazeSavedSettingsRepo),
       )
       return
     }
@@ -142,6 +143,7 @@ class MainTrailblazeApp(
           port = portManager.httpPort,
           httpsPort = portManager.httpsPort,
           wait = false,
+          additionalRouteRegistration = waypointGraphRouteRegistration(trailblazeSavedSettingsRepo),
         )
       }
 
@@ -543,4 +545,25 @@ private fun rememberTrayIcon(): Painter {
   ) { _, _ ->
     RenderVectorGroup(group = icon.root)
   }
+}
+
+/**
+ * Builds the Ktor route-registration callback that wires the waypoint graph endpoints
+ * (`/waypoints/graph` and `/waypoints/graph.json`) onto the daemon's HTTP server.
+ *
+ * The callback is fired once per server start, but the lambda it installs reads the
+ * trails directory **per request** so a settings change reflects without a restart.
+ * `getEffectiveTrailsDirectory` honors any in-app override of the default `./trails`
+ * path, so the browser view shows the same waypoints the desktop tab does.
+ */
+private fun waypointGraphRouteRegistration(
+  settingsRepo: TrailblazeSettingsRepo,
+): (io.ktor.server.routing.Routing.() -> Unit) = {
+  xyz.block.trailblaze.graph.WaypointGraphEndpoint.register(
+    routing = this,
+    defaultRootProvider = {
+      val appConfig = settingsRepo.serverStateFlow.value.appConfig
+      java.io.File(TrailblazeDesktopUtil.getEffectiveTrailsDirectory(appConfig))
+    },
+  )
 }

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/TrailblazeBuiltInTabs.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/TrailblazeBuiltInTabs.kt
@@ -137,6 +137,11 @@ object TrailblazeBuiltInTabs {
         logsRepo = logsRepo,
         availableTargets = deviceManager.availableAppTargets,
         appIconProvider = deviceManager.appIconProvider,
+        // The Map view lives in the browser (rendered by React Flow against the
+        // daemon's `/waypoints/graph` endpoint). The tab's "Open Map view →"
+        // button uses this URL to launch the page; rebuilt per recomposition so a
+        // mid-session port-manager change is reflected without a tab remount.
+        graphViewUrl = "http://localhost:${trailblazeSettingsRepo.portManager.httpPort}/waypoints/graph",
         onChangeDirectory = { newPath ->
           trailblazeSettingsRepo.updateAppConfig { it.copy(trailsDirectory = newPath) }
         },

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/tabs/waypoints/WaypointsTabComposable.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/tabs/waypoints/WaypointsTabComposable.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Map
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
@@ -37,6 +38,7 @@ import kotlinx.serialization.Serializable
 import xyz.block.trailblaze.api.TrailblazeNode
 import xyz.block.trailblaze.api.waypoint.WaypointDefinition
 import xyz.block.trailblaze.cli.WaypointDiscovery
+import xyz.block.trailblaze.config.ToolYamlLoader
 import xyz.block.trailblaze.config.project.LoadedTrailblazePackManifest
 import xyz.block.trailblaze.config.project.PackSource
 import xyz.block.trailblaze.config.project.TrailblazePackManifestLoader
@@ -51,6 +53,8 @@ import xyz.block.trailblaze.ui.waypoints.SegmentDisplayItem
 import xyz.block.trailblaze.ui.waypoints.SessionLensPanel
 import xyz.block.trailblaze.ui.waypoints.SessionLensResult
 import xyz.block.trailblaze.ui.waypoints.SessionLensState
+import xyz.block.trailblaze.ui.waypoints.ShortcutDisplayItem
+import xyz.block.trailblaze.ui.waypoints.TrailheadDisplayItem
 import xyz.block.trailblaze.ui.waypoints.WaypointDisplayItem
 import xyz.block.trailblaze.ui.waypoints.WaypointExample
 import xyz.block.trailblaze.ui.waypoints.WaypointVisualizer
@@ -76,6 +80,12 @@ fun WaypointsTabComposable(
   logsRepo: LogsRepo,
   availableTargets: Set<TrailblazeHostAppTarget> = emptySet(),
   appIconProvider: AppIconProvider = AppIconProvider.DefaultAppIconProvider,
+  /**
+   * URL of the daemon's `/waypoints/graph` endpoint, used by the toolbar's
+   * "Open Map view →" button. Optional so unit tests / future non-Block hosts can
+   * skip the map view entirely; null hides the button.
+   */
+  graphViewUrl: String? = null,
   onChangeDirectory: ((String) -> Unit)? = null,
 ) {
   var rootPath by remember(initialRootPath) { mutableStateOf(initialRootPath) }
@@ -101,6 +111,23 @@ fun WaypointsTabComposable(
       loadWaypoints(File(rootPath))
     }
     isLoading = false
+  }
+
+  // Authored shortcuts and trailheads — sourced from `*.shortcut.yaml` and
+  // `*.trailhead.yaml` files that `ToolYamlLoader.discoverShortcutsAndTrailheads()`
+  // returns (the loader returns configs whose parsed content carries a `shortcut:` or
+  // `trailhead:` metadata block, regardless of class- vs tools-mode body — both are
+  // valid edge metadata as far as the graph is concerned). Today's repo carries zero
+  // of these so the result is normally empty, but the wiring is here so the moment any
+  // author commits one it shows up on the Map view automatically.
+  var shortcuts by remember { mutableStateOf<List<ShortcutDisplayItem>>(emptyList()) }
+  var trailheads by remember { mutableStateOf<List<TrailheadDisplayItem>>(emptyList()) }
+  LaunchedEffect(refreshKey) {
+    val (loadedShortcuts, loadedTrailheads) = withContext(Dispatchers.IO) {
+      loadShortcutsAndTrailheads()
+    }
+    shortcuts = loadedShortcuts
+    trailheads = loadedTrailheads
   }
 
   // Re-extract on any change to (selectedSessionId, waypoint definitions) so a refresh
@@ -138,6 +165,15 @@ fun WaypointsTabComposable(
         }
       } else null,
       onRefresh = { refreshKey += 1 },
+      onOpenMapView = graphViewUrl?.let { url ->
+        {
+          // Pass the current root path so the browser view scopes to whatever
+          // directory the user has currently picked, not the daemon's startup
+          // default. URL-encoded so spaces / special chars survive.
+          val encodedRoot = java.net.URLEncoder.encode(rootPath, Charsets.UTF_8)
+          xyz.block.trailblaze.ui.TrailblazeDesktopUtil.openInDefaultBrowser("$url?root=$encodedRoot")
+        }
+      },
     )
 
     val result = loadResult
@@ -189,6 +225,8 @@ fun WaypointsTabComposable(
           availableTargets = availableTargets,
           appIconProvider = appIconProvider,
           matchedStepsByWaypoint = matchedStepsByWaypoint,
+          shortcuts = shortcuts,
+          trailheads = trailheads,
         )
       }
     }
@@ -200,6 +238,13 @@ private fun WaypointsToolbar(
   rootPath: String,
   onChangeDirectory: (() -> Unit)?,
   onRefresh: () -> Unit,
+  /**
+   * Optional callback to open the navigation graph view in the user's default browser.
+   * Null hides the chip — typically because the host didn't supply a graph URL (e.g.
+   * unit tests or non-Block embeddings). The button label intentionally trails an
+   * arrow ("Open Map view →") so users know it leaves the desktop app.
+   */
+  onOpenMapView: (() -> Unit)?,
 ) {
   Row(
     modifier = Modifier
@@ -239,6 +284,15 @@ private fun WaypointsToolbar(
         Icon(Icons.Filled.Refresh, contentDescription = null)
       },
     )
+    if (onOpenMapView != null) {
+      AssistChip(
+        onClick = onOpenMapView,
+        label = { Text("Open Map view →") },
+        leadingIcon = {
+          Icon(Icons.Filled.Map, contentDescription = null)
+        },
+      )
+    }
   }
 }
 
@@ -288,7 +342,7 @@ internal data class WaypointLoadOutput(
  */
 private const val MAX_FAILURE_MESSAGES_PER_SOURCE = 25
 
-private fun loadWaypoints(root: File): WaypointLoadOutput {
+internal fun loadWaypoints(root: File): WaypointLoadOutput {
   val discovery = WaypointDiscovery.discover(root)
   val idToFile = if (root.isDirectory) buildIdToFileMap(root) else emptyMap()
   val exampleFailures = mutableListOf<String>()
@@ -588,6 +642,52 @@ private fun pickDirectory(start: File): File? {
     JFileChooser.APPROVE_OPTION -> chooser.selectedFile
     else -> null
   }
+}
+
+/**
+ * Discovers authored shortcut and trailhead tools via
+ * [ToolYamlLoader.discoverShortcutsAndTrailheads] and converts each into the commonMain
+ * DTO the Map view renders. The loader returns configs whose parsed content carries a
+ * [xyz.block.trailblaze.config.ShortcutMetadata] or
+ * [xyz.block.trailblaze.config.TrailheadMetadata] block, regardless of whether the body
+ * is class-backed (`class:`) or YAML-bodied (`tools:`) — both shapes are valid edge
+ * metadata as far as the graph is concerned.
+ *
+ * Returns `(shortcuts, trailheads)`. Failures inside the loader (parse errors,
+ * suffix-mismatch) are already logged by the loader's own lenient-load path and surface
+ * as missing entries rather than thrown exceptions — we'd rather render N-1 edges than
+ * fail the whole tab on a single bad YAML. If the loader itself throws, we catch and
+ * return empty lists so the Definitions view continues to function while only the Map
+ * view's edge layer is impacted.
+ */
+private fun loadShortcutsAndTrailheads(): Pair<List<ShortcutDisplayItem>, List<TrailheadDisplayItem>> {
+  val configs = try {
+    ToolYamlLoader.discoverShortcutsAndTrailheads()
+  } catch (e: Exception) {
+    Console.error("[Waypoints Map] failed to discover shortcuts/trailheads: ${e.message}")
+    return emptyList<ShortcutDisplayItem>() to emptyList<TrailheadDisplayItem>()
+  }
+  val shortcuts = mutableListOf<ShortcutDisplayItem>()
+  val trailheads = mutableListOf<TrailheadDisplayItem>()
+  for ((toolName, config) in configs) {
+    config.shortcut?.let { meta ->
+      shortcuts += ShortcutDisplayItem(
+        id = toolName.toolName,
+        description = config.description,
+        from = meta.from,
+        to = meta.to,
+        variant = meta.variant,
+      )
+    }
+    config.trailhead?.let { meta ->
+      trailheads += TrailheadDisplayItem(
+        id = toolName.toolName,
+        description = config.description,
+        to = meta.to,
+      )
+    }
+  }
+  return shortcuts to trailheads
 }
 
 /**

--- a/trailblaze-host/src/main/resources/xyz/block/trailblaze/graph/waypoint-graph-template.html
+++ b/trailblaze-host/src/main/resources/xyz/block/trailblaze/graph/waypoint-graph-template.html
@@ -1,0 +1,1917 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trailblaze · Waypoint navigation graph</title>
+
+  <!-- React Flow's stylesheet. Loaded from esm.sh CDN — internal devtool, browser
+       will fetch on first load and cache thereafter. For air-gap support a future
+       version vendors these assets, but for now we choose the simpler path. -->
+  <link rel="stylesheet" href="https://esm.sh/@xyflow/react@12/dist/style.css">
+
+  <style>
+    /* ============================================================================
+       THEME TOKENS
+       ============================================================================
+       Two palettes (dark default / light) keyed off the [data-theme] attribute on
+       <html>. Every visual surface reads from these vars so the theme toggle is
+       a single attribute swap rather than a CSS recompile.
+    */
+    :root[data-theme="dark"] {
+      color-scheme: dark;
+      --bg: #0e1014;
+      --bg-radial: radial-gradient(ellipse at top, #1a1f2e 0%, #0e1014 60%);
+      --bg-elevated: #181c25;
+      --bg-elevated-2: #20252f;
+      --bg-overlay: rgba(20, 24, 32, 0.85);
+      --border: #262b35;
+      --border-strong: #353c4a;
+      --border-active: #4f5b76;
+      --accent: #7da9ff;
+      --accent-strong: #a8c4ff;
+      --accent-bg: rgba(125, 169, 255, 0.14);
+      --trailhead: #c4a9ff;
+      --trailhead-bg: rgba(196, 169, 255, 0.14);
+      --tree-edge: rgba(220, 226, 240, 0.38);
+      --cross-edge: rgba(220, 226, 240, 0.14);
+      --back-edge: rgba(220, 226, 240, 0.10);
+      --text: #e7eaf0;
+      --text-strong: #ffffff;
+      --text-muted: #7d8597;
+      --text-faint: #565d6e;
+      --shadow-card: 0 1px 2px rgba(0,0,0,0.3), 0 4px 14px rgba(0,0,0,0.18);
+      --shadow-elevated: 0 8px 32px rgba(0,0,0,0.45), 0 2px 6px rgba(0,0,0,0.25);
+      --badge-navigate: #7da9ff;
+      --badge-auth: #ffb86b;
+      --badge-payment: #5eddb0;
+      --badge-search: #d088ff;
+      --badge-support: #ffd166;
+      --badge-legal: #8a93a3;
+      --badge-cancel: #ff7a8a;
+      --badge-account: #95a4c4;
+    }
+    :root[data-theme="light"] {
+      color-scheme: light;
+      --bg: #f8f9fb;
+      --bg-radial: radial-gradient(ellipse at top, #ffffff 0%, #eef1f6 60%);
+      --bg-elevated: #ffffff;
+      --bg-elevated-2: #f4f6fa;
+      --bg-overlay: rgba(255, 255, 255, 0.92);
+      --border: #e4e7ee;
+      --border-strong: #cdd2dc;
+      --border-active: #98a2b3;
+      --accent: #2563eb;
+      --accent-strong: #1e40af;
+      --accent-bg: rgba(37, 99, 235, 0.10);
+      --trailhead: #7c3aed;
+      --trailhead-bg: rgba(124, 58, 237, 0.10);
+      --tree-edge: rgba(20, 24, 32, 0.42);
+      --cross-edge: rgba(20, 24, 32, 0.18);
+      --back-edge: rgba(20, 24, 32, 0.10);
+      --text: #1f2330;
+      --text-strong: #0a0d14;
+      --text-muted: #5b6478;
+      --text-faint: #8b94a6;
+      --shadow-card: 0 1px 2px rgba(15,23,42,0.06), 0 4px 14px rgba(15,23,42,0.06);
+      --shadow-elevated: 0 8px 32px rgba(15,23,42,0.12), 0 2px 6px rgba(15,23,42,0.08);
+      --badge-navigate: #2563eb;
+      --badge-auth: #b45309;
+      --badge-payment: #047857;
+      --badge-search: #7c3aed;
+      --badge-support: #b45309;
+      --badge-legal: #475569;
+      --badge-cancel: #be123c;
+      --badge-account: #475569;
+    }
+
+    * { box-sizing: border-box; }
+    html, body {
+      margin: 0; padding: 0; height: 100vh; width: 100vw;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Inter", "Segoe UI", system-ui, sans-serif;
+      font-feature-settings: "ss01", "cv11";
+      overflow: hidden;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+    #root { height: 100vh; width: 100vw; display: flex; flex-direction: column; }
+
+    /* ============================================================================
+       HEADER (logo / title / mode toggle / counts / theme toggle)
+       ============================================================================ */
+    .app-header {
+      flex: none;
+      padding: 10px 18px;
+      background: var(--bg-elevated);
+      border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 14px;
+      font-size: 13px;
+      z-index: 5;
+    }
+    .app-header .brand {
+      display: flex; align-items: center; gap: 8px;
+      font-weight: 600; font-size: 14px; color: var(--text-strong);
+      letter-spacing: -0.01em;
+    }
+    .app-header .brand .logo {
+      width: 18px; height: 18px;
+      display: inline-flex; align-items: center; justify-content: center;
+      background: var(--accent); color: #fff;
+      border-radius: 5px; font-size: 11px; font-weight: 700;
+    }
+    .app-header .scope {
+      color: var(--text-muted); font-weight: 500;
+      padding-left: 12px; margin-left: 4px;
+      border-left: 1px solid var(--border);
+    }
+    .mode-toggle {
+      display: inline-flex;
+      background: var(--bg-elevated-2);
+      border-radius: 8px;
+      padding: 3px;
+      margin: 0 auto;
+      gap: 2px;
+    }
+    .mode-button {
+      padding: 5px 14px;
+      border-radius: 6px;
+      border: none; background: transparent;
+      color: var(--text-muted);
+      font-family: inherit; font-size: 12px; font-weight: 600;
+      letter-spacing: 0.04em; text-transform: uppercase;
+      cursor: pointer;
+      transition: background 0.15s, color 0.15s;
+    }
+    .mode-button:hover { color: var(--text); }
+    .mode-button.active {
+      background: var(--bg-elevated);
+      color: var(--text-strong);
+      box-shadow: var(--shadow-card);
+    }
+    .mode-button .count {
+      margin-left: 6px;
+      color: var(--text-faint);
+      font-weight: 500;
+      font-size: 11px;
+    }
+    .mode-button.active .count { color: var(--text-muted); }
+
+    .header-counts {
+      display: flex; align-items: center; gap: 14px;
+      font-size: 11px; color: var(--text-muted);
+      letter-spacing: 0.04em; text-transform: uppercase;
+      font-weight: 600;
+    }
+    .header-counts .count-pair { display: flex; align-items: baseline; gap: 6px; }
+    .header-counts .count-pair .num {
+      color: var(--text-strong); font-size: 13px; font-weight: 600;
+      letter-spacing: -0.01em; text-transform: none;
+    }
+
+    .theme-toggle {
+      width: 30px; height: 30px;
+      display: inline-flex; align-items: center; justify-content: center;
+      border: 1px solid var(--border-strong);
+      border-radius: 7px;
+      background: var(--bg-elevated-2);
+      color: var(--text-muted);
+      cursor: pointer;
+      font-size: 14px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .theme-toggle:hover { color: var(--text); border-color: var(--border-active); }
+
+    /* ============================================================================
+       SUBHEADER (filter pills + agentic-angle pill)
+       ============================================================================ */
+    .subheader {
+      flex: none;
+      padding: 8px 18px;
+      background: var(--bg-elevated);
+      border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 8px;
+      font-size: 12px;
+      flex-wrap: wrap;
+    }
+    .filter-label {
+      color: var(--text-muted);
+      font-weight: 500;
+      margin-right: 4px;
+      letter-spacing: 0.02em;
+    }
+    .filter-pill {
+      padding: 4px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--border-strong);
+      background: transparent;
+      color: var(--text-muted);
+      font-size: 12px;
+      font-family: inherit;
+      cursor: pointer;
+      transition: background 0.12s, border-color 0.12s, color 0.12s;
+    }
+    .filter-pill:hover { color: var(--text); border-color: var(--border-active); }
+    .filter-pill.active {
+      background: var(--accent-bg);
+      border-color: var(--accent);
+      color: var(--accent-strong);
+    }
+    .filter-pill .count {
+      color: var(--text-faint);
+      margin-left: 5px;
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+    }
+    .filter-pill.active .count { color: var(--accent); }
+
+    .agentic-pill {
+      margin-left: auto;
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 5px 11px;
+      background: var(--bg-elevated-2);
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      font-size: 11px;
+      color: var(--text-muted);
+      font-variant-numeric: tabular-nums;
+    }
+    .agentic-pill .agentic-icon {
+      display: inline-block;
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--badge-payment);
+      box-shadow: 0 0 6px var(--badge-payment);
+      animation: pulse 2.4s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50% { opacity: 0.4; transform: scale(0.85); }
+    }
+    .agentic-pill strong { color: var(--text); font-weight: 600; }
+
+    /* ============================================================================
+       MAIN LAYOUT (sidebar / canvas / detail panel)
+       ============================================================================ */
+    .main {
+      flex: 1; display: flex; min-height: 0;
+      background: var(--bg);
+      background-image: var(--bg-radial);
+    }
+    .sidebar {
+      flex: none;
+      width: 280px;
+      background: var(--bg-elevated);
+      border-right: 1px solid var(--border);
+      display: flex; flex-direction: column;
+      transition: width 0.22s ease, opacity 0.18s ease;
+      overflow: hidden;
+    }
+    .sidebar.collapsed { width: 0; border-right: none; }
+    .sidebar-header {
+      padding: 14px 16px 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    .sidebar-header h2 {
+      margin: 0; font-size: 11px; font-weight: 700; letter-spacing: 0.08em;
+      text-transform: uppercase; color: var(--text-muted);
+    }
+    .sidebar-header .sub {
+      font-size: 11px; color: var(--text-faint); margin-top: 2px;
+    }
+    .sidebar-list { flex: 1; overflow-y: auto; padding: 6px 8px; }
+    .journey-item {
+      padding: 10px 10px;
+      border-radius: 8px;
+      cursor: pointer;
+      margin-bottom: 2px;
+      border: 1px solid transparent;
+      transition: background 0.12s, border-color 0.12s;
+    }
+    .journey-item:hover { background: var(--bg-elevated-2); }
+    .journey-item.active {
+      background: var(--accent-bg);
+      border-color: var(--accent);
+    }
+    .journey-item .journey-row1 {
+      display: flex; align-items: center; gap: 6px;
+      margin-bottom: 4px;
+    }
+    .journey-item .journey-row2 {
+      font-size: 13px; line-height: 1.4; color: var(--text);
+      font-weight: 500;
+      word-break: break-word;
+    }
+    .journey-item .journey-row3 {
+      margin-top: 4px;
+      font-size: 11px; color: var(--text-muted);
+      word-break: break-word;
+    }
+    .journey-badge {
+      display: inline-block;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-size: 10px; font-weight: 700; letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--bg);
+      background: var(--badge-navigate);
+    }
+    .journey-badge.NAVIGATE { background: var(--badge-navigate); }
+    .journey-badge.AUTH { background: var(--badge-auth); }
+    .journey-badge.PAYMENT { background: var(--badge-payment); }
+    .journey-badge.SEARCH { background: var(--badge-search); }
+    .journey-badge.SUPPORT { background: var(--badge-support); }
+    .journey-badge.LEGAL { background: var(--badge-legal); }
+    .journey-badge.CANCEL { background: var(--badge-cancel); }
+    .journey-badge.ACCOUNT { background: var(--badge-account); }
+    .journey-item .journey-screens {
+      color: var(--text-faint);
+      font-size: 11px;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .canvas-area { flex: 1; position: relative; min-width: 0; min-height: 0; }
+
+    .detail-panel {
+      flex: none;
+      width: 320px;
+      background: var(--bg-elevated);
+      border-left: 1px solid var(--border);
+      display: flex; flex-direction: column;
+      overflow: hidden;
+      box-shadow: var(--shadow-elevated);
+    }
+    .detail-panel-header {
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--border);
+      display: flex; align-items: flex-start; gap: 8px;
+    }
+    .detail-panel-header h3 {
+      margin: 0; font-size: 14px; font-weight: 600;
+      color: var(--text-strong); flex: 1; line-height: 1.3;
+      word-break: break-word;
+    }
+    .detail-panel-header .id {
+      font-family: ui-monospace, "SF Mono", monospace;
+      font-size: 11px; color: var(--text-muted);
+      margin-top: 4px; word-break: break-all;
+    }
+    .detail-close {
+      width: 24px; height: 24px;
+      border: none; background: transparent;
+      color: var(--text-muted);
+      cursor: pointer;
+      border-radius: 4px;
+      font-size: 18px; line-height: 1;
+      display: inline-flex; align-items: center; justify-content: center;
+    }
+    .detail-close:hover { background: var(--bg-elevated-2); color: var(--text); }
+    .detail-content { flex: 1; overflow-y: auto; }
+    .detail-screenshot {
+      padding: 16px;
+      background: var(--bg-elevated-2);
+      display: flex; justify-content: center;
+    }
+    .detail-screenshot img {
+      max-width: 240px; width: 100%;
+      border-radius: 6px;
+      box-shadow: var(--shadow-card);
+      border: 1px solid var(--border);
+    }
+    .detail-section {
+      padding: 12px 16px;
+      border-top: 1px solid var(--border);
+    }
+    .detail-section h4 {
+      margin: 0 0 8px;
+      font-size: 11px; font-weight: 700;
+      text-transform: uppercase; letter-spacing: 0.08em;
+      color: var(--text-muted);
+    }
+    .detail-section p {
+      margin: 0; font-size: 13px; line-height: 1.5;
+      color: var(--text);
+    }
+    .detail-edges {
+      display: flex; flex-direction: column; gap: 4px;
+    }
+    .detail-edge {
+      padding: 6px 8px;
+      background: var(--bg-elevated-2);
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      font-size: 12px;
+      cursor: pointer;
+      transition: border-color 0.12s, background 0.12s;
+    }
+    .detail-edge:hover {
+      border-color: var(--accent);
+      background: var(--accent-bg);
+    }
+    .detail-edge .arrow {
+      color: var(--text-faint);
+      margin: 0 4px;
+      font-family: ui-monospace, monospace;
+    }
+    .detail-edge .target-id {
+      font-family: ui-monospace, "SF Mono", monospace;
+      color: var(--text); font-size: 11px;
+    }
+    .detail-edge .desc {
+      display: block; margin-top: 2px;
+      color: var(--text-muted); font-size: 11px; line-height: 1.4;
+    }
+    .detail-source {
+      padding: 8px 16px 14px;
+      font-family: ui-monospace, "SF Mono", monospace;
+      font-size: 10px; color: var(--text-faint);
+      word-break: break-all;
+    }
+
+    /* Matcher-rule entries — "how does the matcher know this is <id>?".
+       Required entries are bordered in green-ish accent; forbidden in red-ish.
+       Each entry shows the human description and a collapsible YAML preview of
+       the actual selector. */
+    .matcher-entry {
+      padding: 8px 10px;
+      background: var(--bg-elevated-2);
+      border: 1px solid var(--border);
+      border-left: 3px solid var(--badge-payment);
+      border-radius: 5px;
+      margin-bottom: 6px;
+      font-size: 12px;
+    }
+    .matcher-entry.forbidden {
+      border-left-color: var(--badge-cancel);
+    }
+    .matcher-entry .matcher-marker {
+      display: inline-block;
+      width: 14px; height: 14px;
+      line-height: 14px;
+      text-align: center;
+      border-radius: 50%;
+      font-size: 10px; font-weight: 700;
+      margin-right: 6px;
+      vertical-align: -1px;
+      background: var(--badge-payment); color: var(--bg);
+    }
+    .matcher-entry.forbidden .matcher-marker {
+      background: var(--badge-cancel); color: var(--bg);
+    }
+    .matcher-entry .matcher-desc {
+      color: var(--text);
+      line-height: 1.4;
+      display: inline;
+    }
+    .matcher-entry .matcher-fallback {
+      color: var(--text-muted);
+      font-style: italic;
+    }
+    .matcher-entry .matcher-meta {
+      margin-top: 4px;
+      color: var(--text-faint);
+      font-size: 11px;
+      font-family: ui-monospace, "SF Mono", monospace;
+    }
+    .matcher-entry pre {
+      margin: 6px 0 0;
+      padding: 6px 8px;
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      font-family: ui-monospace, "SF Mono", monospace;
+      font-size: 10.5px;
+      line-height: 1.45;
+      color: var(--text);
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+    .matcher-entry summary {
+      cursor: pointer;
+      color: var(--text-muted);
+      font-size: 11px;
+      margin-top: 4px;
+      list-style: none;
+      user-select: none;
+    }
+    .matcher-entry summary::before {
+      content: "▸ ";
+      display: inline-block;
+      margin-right: 2px;
+      font-size: 9px;
+      transition: transform 0.12s;
+    }
+    .matcher-entry details[open] summary::before {
+      transform: rotate(90deg);
+    }
+    .matcher-entry summary:hover { color: var(--text); }
+
+    /* ============================================================================
+       MAP VIEW — node cards
+       ============================================================================ */
+    .waypoint-node {
+      width: 168px;
+      background: var(--bg-elevated);
+      border: 1px solid var(--border-strong);
+      border-radius: 8px;
+      overflow: hidden;
+      transition: border-color 0.12s, box-shadow 0.12s, transform 0.12s;
+      cursor: pointer;
+      box-shadow: var(--shadow-card);
+    }
+    .waypoint-node:hover {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-bg), var(--shadow-card);
+      transform: translateY(-1px);
+    }
+    .waypoint-node.selected {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-bg), var(--shadow-elevated);
+    }
+    .waypoint-title {
+      padding: 8px 10px 6px;
+      font-size: 12px; font-weight: 600;
+      line-height: 1.3;
+      color: var(--text-strong);
+      letter-spacing: -0.005em;
+      border-bottom: 1px solid var(--border);
+      display: -webkit-box;
+      -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+      overflow: hidden;
+      min-height: 38px;
+    }
+    .waypoint-screenshot {
+      width: 100%;
+      aspect-ratio: 9 / 16;
+      object-fit: contain;
+      background: #000;
+      display: block;
+    }
+    .waypoint-no-screenshot {
+      width: 100%;
+      aspect-ratio: 9 / 16;
+      display: flex; align-items: center; justify-content: center;
+      color: var(--text-faint); font-size: 11px;
+      background: var(--bg-elevated-2);
+      background-image: linear-gradient(135deg, var(--bg-elevated-2) 25%, transparent 25%, transparent 50%, var(--bg-elevated-2) 50%, var(--bg-elevated-2) 75%, transparent 75%, transparent);
+      background-size: 16px 16px;
+    }
+    .waypoint-label {
+      padding: 6px 9px 8px;
+      font-family: ui-monospace, "SF Mono", monospace;
+      font-size: 10.5px;
+      line-height: 1.35;
+      word-break: break-word;
+      color: var(--text-muted);
+      border-top: 1px solid var(--border);
+    }
+
+    /* Edge label — tiny floating chip on each shortcut edge that names the
+       action ("tap Withdraw"). Revyl-style; kept compact so it doesn't
+       compete with the screenshots. */
+    .react-flow__edge-textbg {
+      fill: var(--bg-elevated) !important;
+      fill-opacity: 0.92 !important;
+    }
+    .react-flow__edge-text {
+      fill: var(--text-muted) !important;
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif !important;
+      font-size: 9.5px !important;
+      font-weight: 500;
+      pointer-events: none;
+    }
+    /* Back-edge styling — shortcuts pointing at entry points (e.g.
+       Profile → Money tab) are de-emphasized so they don't compete with
+       the tree backbone. Kept visible (the user still sees them) but
+       quiet. */
+    .react-flow__edge.back-edge .react-flow__edge-path {
+      stroke: var(--back-edge) !important;
+      stroke-dasharray: 3 4 !important;
+    }
+    .react-flow__edge.back-edge .react-flow__edge-textbg { fill-opacity: 0.6 !important; }
+    .react-flow__edge.back-edge .react-flow__edge-text { fill: var(--text-faint) !important; }
+    .trailhead-node {
+      padding: 7px 14px;
+      border-radius: 999px;
+      background: var(--trailhead-bg);
+      color: var(--trailhead);
+      border: 1px solid var(--trailhead);
+      font-size: 11px;
+      font-weight: 600;
+      font-family: ui-monospace, "SF Mono", monospace;
+      max-width: 240px;
+      text-align: center;
+      line-height: 1.3;
+      word-break: break-word;
+      box-shadow: var(--shadow-card);
+    }
+    .trailhead-node .trailhead-icon { margin-right: 5px; opacity: 0.85; }
+
+    .empty-state {
+      display: flex; align-items: center; justify-content: center;
+      height: 100%; color: var(--text-muted); flex-direction: column; gap: 8px;
+      padding: 32px;
+    }
+    .empty-state h2 { font-size: 16px; font-weight: 500; margin: 0; color: var(--text); }
+    .empty-state p { font-size: 13px; margin: 0; max-width: 380px; text-align: center; line-height: 1.5; }
+
+    /* React Flow edge & control overrides */
+    .react-flow__edge-path { stroke-linecap: round; }
+    .react-flow__controls button {
+      background: var(--bg-elevated) !important; color: var(--text) !important;
+      border-bottom: 1px solid var(--border) !important;
+    }
+    .react-flow__controls button:hover { background: var(--bg-elevated-2) !important; }
+    .react-flow__minimap {
+      background: var(--bg-elevated) !important;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+    }
+    .react-flow__minimap-mask { fill: rgba(0, 0, 0, 0.4); }
+
+    /* ============================================================================
+       SCREENS VIEW — flat gallery grid of all waypoints
+       ============================================================================ */
+    .screens-view { padding: 18px 22px; overflow-y: auto; height: 100%; }
+    .screens-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+      gap: 14px;
+    }
+    .screen-card {
+      background: var(--bg-elevated);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      overflow: hidden;
+      cursor: pointer;
+      transition: transform 0.12s, border-color 0.12s, box-shadow 0.12s;
+      box-shadow: var(--shadow-card);
+    }
+    .screen-card:hover {
+      transform: translateY(-2px);
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-bg), var(--shadow-card);
+    }
+    .screen-card.selected {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px var(--accent-bg), var(--shadow-elevated);
+    }
+    .screen-card .screen-thumb {
+      width: 100%; aspect-ratio: 9 / 16;
+      background: #000;
+      object-fit: contain;
+      display: block;
+    }
+    .screen-card .screen-no-thumb {
+      width: 100%; aspect-ratio: 9 / 16;
+      display: flex; align-items: center; justify-content: center;
+      background: var(--bg-elevated-2);
+      color: var(--text-faint); font-size: 11px;
+      background-image: linear-gradient(135deg, var(--bg-elevated-2) 25%, transparent 25%, transparent 50%, var(--bg-elevated-2) 50%, var(--bg-elevated-2) 75%, transparent 75%, transparent);
+      background-size: 16px 16px;
+    }
+    .screen-card .screen-meta {
+      padding: 9px 11px;
+      border-top: 1px solid var(--border);
+    }
+    .screen-card .screen-id {
+      font-family: ui-monospace, "SF Mono", monospace;
+      font-size: 11px;
+      line-height: 1.35;
+      color: var(--text);
+      word-break: break-word;
+    }
+    .screen-card .screen-desc {
+      margin-top: 4px;
+      font-size: 11px;
+      color: var(--text-muted);
+      line-height: 1.4;
+      display: -webkit-box;
+      -webkit-line-clamp: 2; -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    /* ============================================================================
+       REPORT VIEW — auto-generated user-flow docs
+       ============================================================================ */
+    .report-view { padding: 26px 32px 80px; overflow-y: auto; height: 100%; }
+    .report-title {
+      font-size: 28px; font-weight: 700;
+      letter-spacing: -0.02em; line-height: 1.15;
+      color: var(--text-strong);
+      margin: 0 0 8px;
+      text-transform: uppercase;
+    }
+    .report-subtitle {
+      color: var(--text-muted); font-size: 13px;
+      margin: 0 0 22px; max-width: 700px; line-height: 1.55;
+    }
+    .report-toc {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: 8px; margin-bottom: 32px;
+      padding-top: 18px;
+      border-top: 1px solid var(--border);
+    }
+    .report-toc-item {
+      padding: 8px 12px;
+      border: 1px solid var(--border);
+      border-radius: 7px;
+      font-size: 11px;
+      color: var(--text-muted);
+      font-family: ui-monospace, "SF Mono", monospace;
+      cursor: pointer;
+      transition: border-color 0.12s, color 0.12s;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .report-toc-item:hover { border-color: var(--accent); color: var(--text); }
+
+    .report-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(440px, 1fr));
+      gap: 14px;
+    }
+    .report-card {
+      background: transparent;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 20px;
+      transition: border-color 0.12s;
+    }
+    .report-card:hover { border-color: var(--border-active); }
+    .report-card .meta-row {
+      display: flex; align-items: center; gap: 10px;
+      margin-bottom: 10px;
+      font-size: 11px; color: var(--text-faint);
+      font-family: ui-monospace, "SF Mono", monospace;
+      letter-spacing: 0.04em; text-transform: uppercase;
+    }
+    .report-card .meta-num {
+      color: var(--text-muted); font-weight: 600;
+    }
+    .report-card h3 {
+      margin: 0 0 8px;
+      font-size: 16px; font-weight: 600;
+      line-height: 1.35;
+      color: var(--text-strong);
+    }
+    .report-card .description {
+      font-size: 12px; line-height: 1.55;
+      color: var(--text-muted);
+      margin: 0 0 14px;
+    }
+    .report-card .screens-strip {
+      display: flex; gap: 8px;
+      overflow-x: auto;
+      padding-bottom: 6px;
+      margin-bottom: 14px;
+    }
+    .report-card .strip-screen {
+      flex: none;
+      width: 92px;
+      cursor: pointer;
+    }
+    .report-card .strip-screen img,
+    .report-card .strip-screen .strip-no-screenshot {
+      width: 92px;
+      aspect-ratio: 9 / 16;
+      object-fit: contain;
+      background: #000;
+      border-radius: 4px;
+      border: 1px solid var(--border);
+      display: block;
+      transition: transform 0.12s, border-color 0.12s;
+    }
+    .report-card .strip-screen .strip-no-screenshot {
+      background: var(--bg-elevated-2);
+      display: flex; align-items: center; justify-content: center;
+      color: var(--text-faint); font-size: 9px;
+    }
+    .report-card .strip-screen:hover img,
+    .report-card .strip-screen:hover .strip-no-screenshot {
+      border-color: var(--accent); transform: translateY(-1px);
+    }
+    .report-card .strip-label {
+      margin-top: 4px;
+      font-family: ui-monospace, "SF Mono", monospace;
+      font-size: 10px; color: var(--text-muted);
+      overflow: hidden; text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .report-card .id-pills {
+      display: flex; gap: 6px; flex-wrap: wrap;
+    }
+    .report-card .id-pill {
+      padding: 3px 8px;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      font-family: ui-monospace, "SF Mono", monospace;
+      font-size: 10px; color: var(--text-muted);
+      max-width: 200px;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+  </style>
+
+  <script type="importmap">
+  {
+    "imports": {
+      "react": "https://esm.sh/react@18.3.1",
+      "react-dom": "https://esm.sh/react-dom@18.3.1",
+      "react-dom/client": "https://esm.sh/react-dom@18.3.1/client",
+      "react/jsx-runtime": "https://esm.sh/react@18.3.1/jsx-runtime",
+      "@xyflow/react": "https://esm.sh/@xyflow/react@12?deps=react@18.3.1,react-dom@18.3.1",
+      "@dagrejs/dagre": "https://esm.sh/@dagrejs/dagre@1"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="root">
+    <div class="empty-state"><p>Loading…</p></div>
+  </div>
+
+  <!-- Graph data is inlined as a JSON literal. The Kotlin renderer replaces the
+       JSON_DATA_PLACEHOLDER token with a JSON-encoded WaypointGraphData. Strict
+       JSON (not JS) so kotlinx.serialization's output drops in unmodified. -->
+  <script>
+    window.WAYPOINT_GRAPH_DATA = /*JSON_DATA_PLACEHOLDER_BEGIN*/ null /*JSON_DATA_PLACEHOLDER_END*/;
+  </script>
+
+  <script type="module">
+    import React, { useState, useMemo, useCallback, useEffect } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import {
+      ReactFlow, Background, Controls, MiniMap,
+      MarkerType, Handle, Position,
+    } from '@xyflow/react';
+    import dagre from '@dagrejs/dagre';
+
+    const NODE_WIDTH = 168;
+    const NODE_HEIGHT = 312;     // title + screenshot + id label
+    const TRAILHEAD_WIDTH = 220;
+    const TRAILHEAD_HEIGHT = 36;
+    const TRAILHEAD_NODE_PREFIX = 'trailhead-node::';
+
+    /* ============================================================================
+       LABEL HELPERS
+       ============================================================================
+       Both helpers extract short human-readable labels from the longer YAML
+       descriptions. The renderer falls back to the id when extraction fails.
+    */
+    function shortNodeTitle(description, id) {
+      if (!description) return id.split('/').slice(1).join(' / ') || id;
+      // Prefer the text up to the first " — " or first sentence, capped at ~50 chars.
+      const dash = description.indexOf(' — ');
+      const period = description.indexOf('. ');
+      let cut = -1;
+      if (dash > 0 && (period < 0 || dash < period)) cut = dash;
+      else if (period > 0) cut = period;
+      let title = cut > 0 ? description.substring(0, cut) : description;
+      // Trim leading "<App> Android" / "<App> iOS" prefixes — they're redundant
+      // with the id's pack/platform segment shown below the screenshot.
+      title = title.replace(/^[A-Z][\w\s]*?\b(?:Android|iOS|Web)\b[,\s]*/i, '').trim();
+      title = title.replace(/^[A-Z][a-z]+ App\b[,\s]*/i, '').trim();
+      title = title.replace(/^,\s+/, '').replace(/^—\s+/, '');
+      if (title.length > 56) title = title.substring(0, 53).trim() + '…';
+      // Capitalize first letter for readability.
+      return title.charAt(0).toUpperCase() + title.slice(1);
+    }
+
+    /* ============================================================================
+       MATCHER RULE RENDERING
+       ============================================================================
+       The required[] / forbidden[] entries on a WaypointDefinition each carry a
+       human description and a TrailblazeNodeSelector — a kitchen-sink shape with
+       optional fields per driver (androidAccessibility, iosAxe, web, etc.) plus
+       spatial relationship pieces. The detail panel renders each entry as a
+       short summary with a collapsible YAML-ish dump of just the populated
+       sub-fields, so the user can see "what does the matcher actually look at."
+    */
+    function selectorSummary(selector) {
+      if (!selector || typeof selector !== 'object') return null;
+      // Pick the driver-specific sub-object that's populated. Listed in priority
+      // so the most informative one wins on the rare entry that sets multiple.
+      const drivers = ['androidAccessibility', 'androidMaestro', 'compose', 'iosAxe', 'iosMaestro', 'web'];
+      for (const d of drivers) {
+        if (selector[d] && typeof selector[d] === 'object') {
+          const fields = Object.entries(selector[d])
+            .filter(([_, v]) => v !== null && v !== undefined && v !== '')
+            .map(([k, v]) => k + '=' + (typeof v === 'object' ? JSON.stringify(v) : v))
+            .join(', ');
+          return d + ' { ' + fields + ' }';
+        }
+      }
+      return null;
+    }
+
+    function selectorYaml(selector) {
+      // Prune null/empty fields recursively so the dump shows only the
+      // fields that actually contribute to the match.
+      function prune(v) {
+        if (v === null || v === undefined || v === '') return undefined;
+        if (Array.isArray(v)) {
+          const filtered = v.map(prune).filter(x => x !== undefined);
+          return filtered.length ? filtered : undefined;
+        }
+        if (typeof v === 'object') {
+          const out = {};
+          let any = false;
+          for (const [k, val] of Object.entries(v)) {
+            const p = prune(val);
+            if (p !== undefined) { out[k] = p; any = true; }
+          }
+          return any ? out : undefined;
+        }
+        return v;
+      }
+      const pruned = prune(selector) || {};
+      return JSON.stringify(pruned, null, 2);
+    }
+
+    function renderMatcherEntry(entry, key, isForbidden) {
+      const summary = selectorSummary(entry.selector);
+      const yaml = selectorYaml(entry.selector);
+      return React.createElement('div', {
+        key: 'm-' + key,
+        className: 'matcher-entry' + (isForbidden ? ' forbidden' : ''),
+      },
+        React.createElement('span', { className: 'matcher-marker' }, isForbidden ? '✕' : '✓'),
+        entry.description
+          ? React.createElement('span', { className: 'matcher-desc' }, entry.description)
+          : React.createElement('span', { className: 'matcher-desc matcher-fallback' }, summary || '(unnamed selector)'),
+        entry.minCount && entry.minCount !== 1
+          ? React.createElement('div', { className: 'matcher-meta' }, 'minCount: ' + entry.minCount)
+          : null,
+        React.createElement('details', null,
+          React.createElement('summary', null, summary || 'show selector'),
+          React.createElement('pre', null, yaml),
+        ),
+      );
+    }
+
+    function shortEdgeAction(description, fromId, toId) {
+      if (description) {
+        // Try "tap [the] X button|tab|row|link|card|cell"
+        const m = description.match(/(tap|swipe|click|press|enter|fill|scroll|long[\- ]press|drag)\s+(?:on\s+)?(?:the\s+)?([\w'+\-]+(?:\s+[\w'+\-]+){0,3}?)\s+(?:button|tab|row|link|card|cell|icon|chip|pill|fab|sheet)\b/i);
+        if (m) {
+          const verb = m[1].toLowerCase();
+          const obj = m[2];
+          return verb + ' ' + obj;
+        }
+        // Try "tap [the] X" up to next punctuation/preposition
+        const m2 = description.match(/(tap|swipe|click|press)\s+(?:on\s+)?(?:the\s+)?([\w'+\-]+(?:\s+[\w'+\-]+){0,2})/i);
+        if (m2) return m2[1].toLowerCase() + ' ' + m2[2];
+      }
+      // Fall back: derive from the to-id's last segment
+      const toLeaf = toId.split('/').pop();
+      return '→ ' + toLeaf;
+    }
+
+    /* ============================================================================
+       JOURNEY DERIVATION
+       ============================================================================
+       We don't (yet) carry trail data through to the graph view, so we derive
+       "user journeys" from the (trailhead, shortcut) graph itself: BFS from each
+       trailhead, then pick interesting (trailhead → reachable-waypoint) pairs
+       and reconstruct a path of length 1–4 between them. Each pair becomes one
+       journey card.
+
+       This deliberately mirrors what trail YAMLs would produce when piped through
+       — once trail data lands, swap derivation for the real thing without
+       touching the rendering layer.
+    */
+    function bfsFromTrailhead(trailheadId, startWaypointId, shortcuts, waypointIds) {
+      // shortest-path BFS, returns { waypointId: [pathOfWaypointIds] }
+      const adj = new Map();
+      shortcuts.forEach(sc => {
+        if (!adj.has(sc.from)) adj.set(sc.from, []);
+        adj.get(sc.from).push({ to: sc.to, sc });
+      });
+      const reached = new Map();
+      reached.set(startWaypointId, [startWaypointId]);
+      const queue = [startWaypointId];
+      while (queue.length > 0) {
+        const cur = queue.shift();
+        const next = adj.get(cur) || [];
+        for (const { to } of next) {
+          if (reached.has(to)) continue;
+          if (!waypointIds.has(to)) continue;
+          reached.set(to, [...reached.get(cur), to]);
+          queue.push(to);
+        }
+      }
+      return reached;
+    }
+
+    function categorizeJourney(path) {
+      // Heuristic: pick the badge from the destination's id segments.
+      const last = path[path.length - 1] || '';
+      const lower = last.toLowerCase();
+      if (lower.includes('sign-in') || lower.includes('login') || lower.includes('auth')) return 'AUTH';
+      if (lower.includes('pay') || lower.includes('payment') || lower.includes('checkout')) return 'PAYMENT';
+      if (lower.includes('search') || lower.includes('find')) return 'SEARCH';
+      if (lower.includes('help') || lower.includes('support')) return 'SUPPORT';
+      if (lower.includes('legal') || lower.includes('terms') || lower.includes('privacy')) return 'LEGAL';
+      if (lower.includes('cancel') || lower.includes('delete')) return 'CANCEL';
+      if (lower.includes('profile') || lower.includes('settings') || lower.includes('account')
+          || lower.includes('linked-banks') || lower.includes('banking')) return 'ACCOUNT';
+      return 'NAVIGATE';
+    }
+
+    function deriveJourneys(waypoints, shortcuts, trailheads) {
+      // For each (trailhead, reachable-waypoint with depth >= 1) pair, build a
+      // journey. Skip the trailhead's direct landing screen (depth 0) since
+      // that's a trivial 1-step path. Cap pairs per trailhead to keep the list
+      // navigable on a real-world dataset.
+      const waypointIds = new Set(waypoints.map(w => w.id));
+      const wpById = new Map(waypoints.map(w => [w.id, w]));
+      const journeys = [];
+      let counter = 1;
+      trailheads.forEach(th => {
+        if (!waypointIds.has(th.to)) return;
+        const reached = bfsFromTrailhead(th.id, th.to, shortcuts, waypointIds);
+        // sort destinations by path length (shortest paths first), then by id
+        const dests = [...reached.entries()]
+          .filter(([id]) => id !== th.to) // skip trivial 1-step "trailhead → its own to"
+          .sort((a, b) => a[1].length - b[1].length || a[0].localeCompare(b[0]));
+        dests.forEach(([destId, path]) => {
+          const dest = wpById.get(destId);
+          journeys.push({
+            num: counter++,
+            id: 'journey::' + th.id + '::' + destId,
+            trailheadId: th.id,
+            trailheadLabel: th.id,
+            destinationId: destId,
+            destinationLabel: dest ? (dest.description?.split('.')[0] || dest.id) : destId,
+            path,
+            screens: path.length,
+            category: categorizeJourney(path),
+          });
+        });
+      });
+      return journeys;
+    }
+
+    /* ============================================================================
+       LAYOUT (SCC condensation + BFS-layered + barycentric ordering)
+       ============================================================================
+       The IA insight: bottom-nav peers in a typical mobile app (the four or
+       five top-level tabs every screen can hop between) are mutually reachable
+       via tap-a-tab shortcuts. In graph theory terms, they form a strongly-
+       connected component (SCC). The user's mental model says these are
+       *peers at the same level* — the same row of the layout, not stacked
+       across multiple rows just because dagre/BFS picks one as the entry and
+       finds the others "one hop away."
+
+       Algorithm:
+        1. Compute SCCs over the full forward graph (Tarjan's, no edge filtering).
+        2. Condense: each SCC is a single super-node. Inter-SCC edges form a DAG.
+        3. BFS-shortest the SCC DAG from entry SCCs (those containing entry
+           points) → each SCC gets a depth.
+        4. Every waypoint inherits its SCC's depth.
+        5. Within each depth row, order nodes by barycentric x (avg parent x
+           from upstream SCCs) to minimize crossings.
+        6. Trailheads anchor above their targets, X-aligned to target center.
+
+       Result: the bottom-nav cluster becomes a single horizontal row of peers,
+       drill-downs flow below as the next layer, deeper drill-downs below those.
+    */
+    function computeLayout(waypoints, shortcuts, trailheads) {
+      const waypointIds = new Set(waypoints.map(w => w.id));
+      const entryPoints = new Set();
+      trailheads.forEach(th => {
+        if (waypointIds.has(th.to)) entryPoints.add(th.to);
+      });
+
+      // Full forward adjacency (no filtering — SCCs need every real edge).
+      const childrenOf = new Map();
+      const parentsOf = new Map();
+      waypoints.forEach(wp => {
+        childrenOf.set(wp.id, []);
+        parentsOf.set(wp.id, []);
+      });
+      shortcuts.forEach(sc => {
+        if (!waypointIds.has(sc.from) || !waypointIds.has(sc.to)) return;
+        childrenOf.get(sc.from).push(sc.to);
+        parentsOf.get(sc.to).push(sc.from);
+      });
+
+      // ---- Tarjan's SCC (iterative, to avoid recursion-depth issues) ----
+      const sccs = []; // array of arrays of waypoint ids
+      const sccIndex = new Map();
+      {
+        const ids = new Map();
+        const low = new Map();
+        const onStack = new Set();
+        const tStack = [];
+        let counter = 0;
+        const callStack = [];
+        waypoints.forEach(wp => {
+          if (ids.has(wp.id)) return;
+          callStack.push({ v: wp.id, phase: 'enter', childIdx: 0, lastChild: null });
+          while (callStack.length > 0) {
+            const frame = callStack[callStack.length - 1];
+            const v = frame.v;
+            if (frame.phase === 'enter') {
+              ids.set(v, counter); low.set(v, counter); counter++;
+              tStack.push(v); onStack.add(v);
+              frame.phase = 'loop';
+            }
+            if (frame.phase === 'returned') {
+              low.set(v, Math.min(low.get(v), low.get(frame.lastChild)));
+              frame.phase = 'loop';
+            }
+            const kids = childrenOf.get(v);
+            let recursed = false;
+            while (frame.childIdx < kids.length && !recursed) {
+              const w = kids[frame.childIdx++];
+              if (!ids.has(w)) {
+                frame.lastChild = w;
+                frame.phase = 'returned';
+                callStack.push({ v: w, phase: 'enter', childIdx: 0, lastChild: null });
+                recursed = true;
+              } else if (onStack.has(w)) {
+                low.set(v, Math.min(low.get(v), ids.get(w)));
+              }
+            }
+            if (!recursed) {
+              if (low.get(v) === ids.get(v)) {
+                const scc = [];
+                let w;
+                do { w = tStack.pop(); onStack.delete(w); scc.push(w); } while (w !== v);
+                const sccI = sccs.length;
+                sccs.push(scc);
+                scc.forEach(id => sccIndex.set(id, sccI));
+              }
+              callStack.pop();
+            }
+          }
+        });
+      }
+
+      // ---- Condensation graph (SCC i → SCC j if any forward edge crosses) ----
+      const sccChildren = new Map();
+      sccs.forEach((_, i) => sccChildren.set(i, new Set()));
+      shortcuts.forEach(sc => {
+        if (!waypointIds.has(sc.from) || !waypointIds.has(sc.to)) return;
+        const i = sccIndex.get(sc.from);
+        const j = sccIndex.get(sc.to);
+        if (i !== j) sccChildren.get(i).add(j);
+      });
+
+      // ---- Entry SCCs: those containing at least one trailhead target ----
+      const entrySCCs = new Set();
+      entryPoints.forEach(ep => {
+        if (sccIndex.has(ep)) entrySCCs.add(sccIndex.get(ep));
+      });
+
+      // ---- BFS-shortest in condensation graph to assign SCC depths ----
+      const sccDepth = new Map();
+      const bfsQueue = [];
+      entrySCCs.forEach(i => { sccDepth.set(i, 0); bfsQueue.push(i); });
+      while (bfsQueue.length > 0) {
+        const cur = bfsQueue.shift();
+        const curDepth = sccDepth.get(cur);
+        sccChildren.get(cur).forEach(next => {
+          if (sccDepth.has(next)) return;
+          sccDepth.set(next, curDepth + 1);
+          bfsQueue.push(next);
+        });
+      }
+      // Orphan SCCs (not reachable from any entry) at depth 0
+      sccs.forEach((_, i) => { if (!sccDepth.has(i)) sccDepth.set(i, 0); });
+
+      // ---- Each waypoint inherits its SCC's depth ----
+      const depth = new Map();
+      waypoints.forEach(wp => {
+        depth.set(wp.id, sccDepth.get(sccIndex.get(wp.id)));
+      });
+
+      // Group by depth
+      const byDepth = new Map();
+      depth.forEach((d, id) => {
+        if (!byDepth.has(d)) byDepth.set(d, []);
+        byDepth.get(d).push(id);
+      });
+      const maxDepth = Math.max(...byDepth.keys(), 0);
+
+      // Within-rank ordering: barycentric. Initialize depth 0 alphabetically
+      // (peers within the same SCC slot in next to each other since they share
+      // a pack-id prefix). For each subsequent depth, sort by avg position of
+      // *upstream* parents only — within-SCC same-depth parents are filtered
+      // out so they don't muddy the heuristic.
+      const orderIndex = new Map();
+      // Cluster depth 0 by SCC so SCC members sit together in the row.
+      const dZero = (byDepth.get(0) || []).slice().sort((a, b) => {
+        const sa = sccIndex.get(a), sb = sccIndex.get(b);
+        return sa - sb || a.localeCompare(b);
+      });
+      dZero.forEach((id, i) => orderIndex.set(id, i));
+      byDepth.set(0, dZero);
+      for (let d = 1; d <= maxDepth; d++) {
+        const inRank = (byDepth.get(d) || []).slice();
+        inRank.sort((a, b) => {
+          const aDepth = depth.get(a);
+          const aParents = parentsOf.get(a)
+            .filter(p => depth.get(p) < aDepth)         // upstream only
+            .map(p => orderIndex.get(p))
+            .filter(x => x !== undefined);
+          const bDepth = depth.get(b);
+          const bParents = parentsOf.get(b)
+            .filter(p => depth.get(p) < bDepth)
+            .map(p => orderIndex.get(p))
+            .filter(x => x !== undefined);
+          const aBary = aParents.length ? aParents.reduce((s, x) => s + x, 0) / aParents.length : 0;
+          const bBary = bParents.length ? bParents.reduce((s, x) => s + x, 0) / bParents.length : 0;
+          // Tie-break: same SCC → cluster together; then alphabetical.
+          if (aBary !== bBary) return aBary - bBary;
+          const sa = sccIndex.get(a), sb = sccIndex.get(b);
+          if (sa !== sb) return sa - sb;
+          return a.localeCompare(b);
+        });
+        inRank.forEach((id, i) => orderIndex.set(id, i));
+        byDepth.set(d, inRank);
+      }
+
+      // Final pixel positions. Each rank's row is centered horizontally
+      // around x=0; rows stack downward.
+      const RANKSEP = 92;
+      const NODESEP = 40;
+      const positions = {};
+      let y = 80;
+      for (let d = 0; d <= maxDepth; d++) {
+        const inRank = byDepth.get(d) || [];
+        const totalWidth = inRank.length * NODE_WIDTH + Math.max(0, inRank.length - 1) * NODESEP;
+        let x = -totalWidth / 2;
+        inRank.forEach(id => {
+          positions[id] = { x, y };
+          x += NODE_WIDTH + NODESEP;
+        });
+        y += NODE_HEIGHT + RANKSEP;
+      }
+
+      // Trailheads above their targets, X-aligned to target center, fanning
+      // horizontally if multiple trailheads share a target.
+      const targetGroups = new Map();
+      trailheads.forEach(th => {
+        if (!waypointIds.has(th.to)) return;
+        if (!targetGroups.has(th.to)) targetGroups.set(th.to, []);
+        targetGroups.get(th.to).push(th);
+      });
+      const TRAILHEAD_GAP_ABOVE = 44;
+      const TRAILHEAD_X_GAP = 18;
+      targetGroups.forEach((ths, targetId) => {
+        const target = positions[targetId];
+        if (!target) return;
+        const targetCenterX = target.x + NODE_WIDTH / 2;
+        const totalWidth = ths.length * TRAILHEAD_WIDTH + Math.max(0, ths.length - 1) * TRAILHEAD_X_GAP;
+        const startX = targetCenterX - totalWidth / 2;
+        const yPos = target.y - TRAILHEAD_HEIGHT - TRAILHEAD_GAP_ABOVE;
+        ths.forEach((th, i) => {
+          const x = startX + i * (TRAILHEAD_WIDTH + TRAILHEAD_X_GAP);
+          positions[TRAILHEAD_NODE_PREFIX + th.id] = { x, y: yPos };
+        });
+      });
+
+      return positions;
+    }
+
+    /* ============================================================================
+       NODE COMPONENTS
+       ============================================================================ */
+    function WaypointNode({ data, selected }) {
+      const cls = 'waypoint-node' + (selected ? ' selected' : '');
+      return React.createElement('div', { className: cls, title: data.sourceLabel || data.label },
+        React.createElement(Handle, {
+          type: 'target', position: Position.Top, isConnectable: false,
+          style: { opacity: 0, top: 0 },
+        }),
+        // Title strip — short human-readable name, derived from the description.
+        // Falls back to the id-leaf when description is missing.
+        React.createElement('div', { className: 'waypoint-title' }, data.title),
+        data.screenshotDataUri
+          ? React.createElement('img', { src: data.screenshotDataUri, className: 'waypoint-screenshot', alt: data.label })
+          : React.createElement('div', { className: 'waypoint-no-screenshot' }, '(no screenshot)'),
+        React.createElement('div', { className: 'waypoint-label' }, data.label),
+        React.createElement(Handle, {
+          type: 'source', position: Position.Bottom, isConnectable: false,
+          style: { opacity: 0, bottom: 0 },
+        }),
+      );
+    }
+
+    function TrailheadNode({ data }) {
+      return React.createElement('div', { title: data.description || data.label },
+        React.createElement('div', { className: 'trailhead-node' },
+          React.createElement('span', { className: 'trailhead-icon' }, '✈'),
+          data.label,
+        ),
+        React.createElement(Handle, {
+          type: 'source', position: Position.Bottom, isConnectable: false,
+          style: { opacity: 0 },
+        }),
+      );
+    }
+
+    const nodeTypes = { waypoint: WaypointNode, trailhead: TrailheadNode };
+
+    /* ============================================================================
+       MAP VIEW
+       ============================================================================ */
+    function MapView({ filtered, selectedWaypoint, onSelectWaypoint, themeKey }) {
+      const positions = useMemo(
+        () => computeLayout(filtered.waypoints, filtered.shortcuts, filtered.trailheads),
+        [filtered.waypoints, filtered.shortcuts, filtered.trailheads],
+      );
+
+      const nodes = useMemo(() => [
+        ...filtered.waypoints.map(wp => ({
+          id: wp.id,
+          type: 'waypoint',
+          position: positions[wp.id] || { x: 0, y: 0 },
+          selected: selectedWaypoint === wp.id,
+          data: {
+            label: wp.id,
+            title: shortNodeTitle(wp.description, wp.id),
+            screenshotDataUri: wp.screenshotDataUri,
+            sourceLabel: wp.sourceLabel,
+          },
+        })),
+        ...filtered.trailheads.map(th => ({
+          id: TRAILHEAD_NODE_PREFIX + th.id,
+          type: 'trailhead',
+          position: positions[TRAILHEAD_NODE_PREFIX + th.id] || { x: 0, y: 0 },
+          data: { label: th.id, description: th.description },
+          draggable: false, selectable: false,
+        })),
+      ], [filtered.waypoints, filtered.trailheads, positions, selectedWaypoint]);
+
+      // Compute the entry-point set once for edge classification — same set
+      // the layout uses to drop back-edges from dagre input. Here we use it
+      // to *style* back-edges differently (faded, dashed) so the user can
+      // still see them but they don't compete with the tree backbone.
+      const entryPoints = useMemo(
+        () => new Set(filtered.trailheads.map(th => th.to)),
+        [filtered.trailheads],
+      );
+      const edges = useMemo(() => [
+        ...filtered.shortcuts.map(sc => {
+          const isBack = entryPoints.has(sc.to);
+          return {
+            id: 'shortcut::' + sc.id,
+            source: sc.from,
+            target: sc.to,
+            type: 'smoothstep',
+            className: isBack ? 'back-edge' : '',
+            // Action label on the edge — short text like "tap Withdraw" —
+            // extracted from the shortcut's description. Hide on back-edges
+            // since the action there is implicit (a back gesture / tab tap).
+            label: isBack ? '' : shortEdgeAction(sc.description, sc.from, sc.to),
+            labelBgPadding: [6, 3],
+            labelBgBorderRadius: 4,
+            markerEnd: { type: MarkerType.ArrowClosed, color: isBack ? 'var(--back-edge)' : 'var(--tree-edge)' },
+            style: {
+              stroke: isBack ? 'var(--back-edge)' : 'var(--tree-edge)',
+              strokeWidth: isBack ? 1 : 1.25,
+            },
+          };
+        }),
+        ...filtered.trailheads.map(th => ({
+          id: 'trailhead::' + th.id,
+          source: TRAILHEAD_NODE_PREFIX + th.id,
+          target: th.to,
+          type: 'smoothstep',
+          label: 'entry',
+          labelBgPadding: [6, 3],
+          labelBgBorderRadius: 4,
+          markerEnd: { type: MarkerType.ArrowClosed, color: 'var(--trailhead)' },
+          style: { stroke: 'var(--trailhead)', strokeWidth: 1.5, strokeDasharray: '6 6' },
+        })),
+      ], [filtered.shortcuts, filtered.trailheads]);
+
+      const onNodeClick = useCallback((_, node) => {
+        if (node.type === 'waypoint') onSelectWaypoint(node.id);
+      }, [onSelectWaypoint]);
+
+      return React.createElement(ReactFlow, {
+        // Re-key on filter/theme change so React Flow flushes layout state and
+        // node positions don't tween between configurations.
+        key: themeKey,
+        nodes, edges, nodeTypes,
+        fitView: true,
+        fitViewOptions: { padding: 0.18 },
+        minZoom: 0.1,
+        nodesConnectable: false,
+        edgesFocusable: false,
+        onNodeClick,
+      },
+        React.createElement(Background, { gap: 24, size: 1, color: 'rgba(220,226,240,0.05)' }),
+        React.createElement(Controls, { showInteractive: false }),
+        React.createElement(MiniMap, { pannable: true, zoomable: true }),
+      );
+    }
+
+    /* ============================================================================
+       SCREENS VIEW — flat gallery
+       ============================================================================ */
+    function ScreensView({ filtered, selectedWaypoint, onSelectWaypoint }) {
+      // Stable order: alphabetical by id. Waypoints with screenshots float above
+      // those without — gallery views look bad with empty placeholders mixed in.
+      const sorted = useMemo(() => {
+        return [...filtered.waypoints].sort((a, b) => {
+          const aHas = !!a.screenshotDataUri, bHas = !!b.screenshotDataUri;
+          if (aHas !== bHas) return aHas ? -1 : 1;
+          return a.id.localeCompare(b.id);
+        });
+      }, [filtered.waypoints]);
+      return React.createElement('div', { className: 'screens-view' },
+        React.createElement('div', { className: 'screens-grid' },
+          sorted.map(wp =>
+            React.createElement('div', {
+              key: wp.id,
+              className: 'screen-card' + (selectedWaypoint === wp.id ? ' selected' : ''),
+              onClick: () => onSelectWaypoint(wp.id),
+              title: wp.sourceLabel || wp.id,
+            },
+              wp.screenshotDataUri
+                ? React.createElement('img', { src: wp.screenshotDataUri, className: 'screen-thumb', alt: wp.id })
+                : React.createElement('div', { className: 'screen-no-thumb' }, '(no screenshot)'),
+              React.createElement('div', { className: 'screen-meta' },
+                React.createElement('div', { className: 'screen-id' }, wp.id),
+                wp.description ? React.createElement('div', { className: 'screen-desc' }, wp.description) : null,
+              ),
+            )
+          ),
+        ),
+      );
+    }
+
+    /* ============================================================================
+       REPORT VIEW — auto-generated user-flow docs
+       ============================================================================ */
+    function ReportView({ filtered, journeys, onSelectWaypoint }) {
+      const wpById = useMemo(
+        () => new Map(filtered.waypoints.map(w => [w.id, w])),
+        [filtered.waypoints],
+      );
+      const targets = [...new Set(filtered.waypoints.map(w => w.id.split('/')[0]))];
+      const titleScope = targets.length === 1 ? targets[0] : 'app';
+
+      return React.createElement('div', { className: 'report-view' },
+        React.createElement('h1', { className: 'report-title' }, titleScope + ' user flows'),
+        React.createElement('p', { className: 'report-subtitle' },
+          'Auto-derived from the waypoint navigation graph: every reachable (trailhead → screen) pair across ',
+          React.createElement('strong', null, filtered.waypoints.length + ' screen' + (filtered.waypoints.length === 1 ? '' : 's')),
+          ', generated from your test corpus and refreshed on every run. Use these for UX teardown work, QA coverage planning, and AI agent navigation context.',
+        ),
+
+        // Table of contents
+        journeys.length > 0 ? React.createElement('div', { className: 'report-toc' },
+          journeys.slice(0, 12).map(j =>
+            React.createElement('div', {
+              key: j.id, className: 'report-toc-item', title: j.destinationLabel,
+            }, (j.num + '').padStart(2, '0') + '  ' + j.destinationId)
+          ),
+        ) : null,
+
+        // Cards
+        React.createElement('div', { className: 'report-grid' },
+          journeys.map(j => {
+            const screensInPath = j.path.map(id => wpById.get(id)).filter(Boolean);
+            return React.createElement('div', { key: j.id, className: 'report-card' },
+              React.createElement('div', { className: 'meta-row' },
+                React.createElement('span', { className: 'meta-num' }, (j.num + '').padStart(2, '0')),
+                React.createElement('span', null, 'Path'),
+                React.createElement('span', { className: 'journey-badge ' + j.category }, j.category),
+                React.createElement('span', null, j.screens + ' screen' + (j.screens === 1 ? '' : 's')),
+              ),
+              React.createElement('h3', null, j.destinationLabel),
+              React.createElement('p', { className: 'description' },
+                'From ' + j.trailheadLabel + ' → ' + j.destinationId + '. ' +
+                'Walks ' + j.screens + ' mapped app ' + (j.screens === 1 ? 'screen' : 'screens') + '. ' +
+                'Use this path for mobile UX teardown work, QA coverage planning, and AI agent navigation context.',
+              ),
+              screensInPath.length > 0 ? React.createElement('div', { className: 'screens-strip' },
+                screensInPath.map((wp, i) =>
+                  React.createElement('div', {
+                    key: i, className: 'strip-screen',
+                    onClick: () => onSelectWaypoint(wp.id),
+                  },
+                    wp.screenshotDataUri
+                      ? React.createElement('img', { src: wp.screenshotDataUri, alt: wp.id })
+                      : React.createElement('div', { className: 'strip-no-screenshot' }, '(no screenshot)'),
+                    React.createElement('div', { className: 'strip-label' }, wp.id),
+                  ),
+                ),
+              ) : null,
+              React.createElement('div', { className: 'id-pills' },
+                screensInPath.map((wp, i) =>
+                  React.createElement('div', { key: i, className: 'id-pill' }, wp.id)
+                ),
+              ),
+            );
+          }),
+        ),
+      );
+    }
+
+    /* ============================================================================
+       SIDEBAR — User Journeys list
+       ============================================================================ */
+    function JourneysSidebar({ journeys, selectedJourneyId, onSelectJourney, mode }) {
+      // The sidebar contributes to MAP and REPORT modes. SCREENS is the gallery
+      // view — a journeys panel next to it would compete visually for no gain.
+      if (mode === 'screens') return null;
+      return React.createElement('aside', { className: 'sidebar' },
+        React.createElement('div', { className: 'sidebar-header' },
+          React.createElement('h2', null, 'User Journeys'),
+          React.createElement('div', { className: 'sub' }, journeys.length + ' path' + (journeys.length === 1 ? '' : 's') + ' discovered'),
+        ),
+        React.createElement('div', { className: 'sidebar-list' },
+          journeys.map(j =>
+            React.createElement('div', {
+              key: j.id,
+              className: 'journey-item' + (selectedJourneyId === j.id ? ' active' : ''),
+              onClick: () => onSelectJourney(j),
+            },
+              React.createElement('div', { className: 'journey-row1' },
+                React.createElement('span', { className: 'journey-badge ' + j.category }, j.category),
+                React.createElement('span', { className: 'journey-screens' }, j.screens + ' scr'),
+              ),
+              React.createElement('div', { className: 'journey-row2' }, j.destinationLabel),
+              React.createElement('div', { className: 'journey-row3' }, 'via ' + j.trailheadLabel),
+            )
+          ),
+        ),
+      );
+    }
+
+    /* ============================================================================
+       DETAIL PANEL — right-side click-to-explore
+       ============================================================================ */
+    function DetailPanel({ waypoint, incoming, outgoing, trailheads, onClose, onSelectWaypoint, allWaypoints }) {
+      if (!waypoint) return null;
+      const wpById = new Map(allWaypoints.map(w => [w.id, w]));
+      return React.createElement('aside', { className: 'detail-panel' },
+        React.createElement('div', { className: 'detail-panel-header' },
+          React.createElement('div', { style: { flex: 1 } },
+            React.createElement('h3', null, waypoint.description?.split('.')[0] || waypoint.id),
+            React.createElement('div', { className: 'id' }, waypoint.id),
+          ),
+          React.createElement('button', { className: 'detail-close', onClick: onClose, 'aria-label': 'Close' }, '×'),
+        ),
+        React.createElement('div', { className: 'detail-content' },
+          waypoint.screenshotDataUri
+            ? React.createElement('div', { className: 'detail-screenshot' },
+                React.createElement('img', { src: waypoint.screenshotDataUri, alt: waypoint.id }),
+              )
+            : null,
+          waypoint.description
+            ? React.createElement('div', { className: 'detail-section' },
+                React.createElement('h4', null, 'Description'),
+                React.createElement('p', null, waypoint.description),
+              )
+            : null,
+          // The "how does the matcher know this is <id>?" sections — required
+          // selectors that must ALL match, plus forbidden selectors that must
+          // NOT match. These are the waypoint's identity, drawn straight from
+          // the *.waypoint.yaml so what's shown is exactly what the runtime
+          // matcher checks.
+          (waypoint.required && waypoint.required.length > 0)
+            ? React.createElement('div', { className: 'detail-section' },
+                React.createElement('h4', null,
+                  'Required (' + waypoint.required.length + ')',
+                ),
+                React.createElement('p', { style: { fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px' } },
+                  'All of these must match the captured tree for the waypoint to be considered identified.',
+                ),
+                ...waypoint.required.map((entry, i) => renderMatcherEntry(entry, i, false)),
+              )
+            : null,
+          (waypoint.forbidden && waypoint.forbidden.length > 0)
+            ? React.createElement('div', { className: 'detail-section' },
+                React.createElement('h4', null,
+                  'Forbidden (' + waypoint.forbidden.length + ')',
+                ),
+                React.createElement('p', { style: { fontSize: '11px', color: 'var(--text-muted)', marginBottom: '8px' } },
+                  'If any of these match, the waypoint is rejected — used to disambiguate visual siblings.',
+                ),
+                ...waypoint.forbidden.map((entry, i) => renderMatcherEntry(entry, i, true)),
+              )
+            : null,
+          waypoint.platform
+            ? React.createElement('div', { className: 'detail-section' },
+                React.createElement('h4', null, 'Platform'),
+                React.createElement('p', null, waypoint.platform),
+              )
+            : null,
+          trailheads.length > 0
+            ? React.createElement('div', { className: 'detail-section' },
+                React.createElement('h4', null, 'Reached from (trailheads)'),
+                React.createElement('div', { className: 'detail-edges' },
+                  trailheads.map(th =>
+                    React.createElement('div', { key: th.id, className: 'detail-edge' },
+                      React.createElement('span', { className: 'arrow' }, '✈'),
+                      React.createElement('span', { className: 'target-id' }, th.id),
+                      th.description ? React.createElement('span', { className: 'desc' }, th.description) : null,
+                    )
+                  ),
+                ),
+              )
+            : null,
+          incoming.length > 0
+            ? React.createElement('div', { className: 'detail-section' },
+                React.createElement('h4', null, 'Incoming shortcuts'),
+                React.createElement('div', { className: 'detail-edges' },
+                  incoming.map(sc =>
+                    React.createElement('div', {
+                      key: sc.id, className: 'detail-edge',
+                      onClick: () => onSelectWaypoint(sc.from),
+                    },
+                      React.createElement('span', { className: 'target-id' }, sc.from),
+                      React.createElement('span', { className: 'arrow' }, '→'),
+                      React.createElement('span', { className: 'target-id' }, 'here'),
+                      sc.description ? React.createElement('span', { className: 'desc' }, sc.description) : null,
+                    )
+                  ),
+                ),
+              )
+            : null,
+          outgoing.length > 0
+            ? React.createElement('div', { className: 'detail-section' },
+                React.createElement('h4', null, 'Outgoing shortcuts'),
+                React.createElement('div', { className: 'detail-edges' },
+                  outgoing.map(sc =>
+                    React.createElement('div', {
+                      key: sc.id, className: 'detail-edge',
+                      onClick: () => onSelectWaypoint(sc.to),
+                    },
+                      React.createElement('span', { className: 'target-id' }, 'here'),
+                      React.createElement('span', { className: 'arrow' }, '→'),
+                      React.createElement('span', { className: 'target-id' }, sc.to),
+                      sc.description ? React.createElement('span', { className: 'desc' }, sc.description) : null,
+                    )
+                  ),
+                ),
+              )
+            : null,
+          waypoint.sourceLabel
+            ? React.createElement('div', { className: 'detail-source' }, waypoint.sourceLabel)
+            : null,
+        ),
+      );
+    }
+
+    /* ============================================================================
+       APP
+       ============================================================================ */
+    function App({ data }) {
+      const [mode, setMode] = useState('map');                  // 'map' | 'screens' | 'report'
+      const [selectedTarget, setSelectedTarget] = useState(null);
+      const [selectedPlatform, setSelectedPlatform] = useState(null);
+      const [selectedWaypoint, setSelectedWaypoint] = useState(null);
+      const [selectedJourneyId, setSelectedJourneyId] = useState(null);
+      const [theme, setTheme] = useState('dark');
+
+      // Theme is mirrored to <html data-theme> so CSS vars cascade everywhere.
+      useEffect(() => {
+        document.documentElement.setAttribute('data-theme', theme);
+      }, [theme]);
+
+      // ----- target/platform filters -----
+      const targets = useMemo(() => {
+        const counts = new Map();
+        data.waypoints.forEach(wp => {
+          const t = wp.id.split('/')[0];
+          counts.set(t, (counts.get(t) || 0) + 1);
+        });
+        return [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+      }, [data.waypoints]);
+
+      const platforms = useMemo(() => {
+        const counts = new Map();
+        data.waypoints.forEach(wp => {
+          if (!wp.platform) return;
+          if (selectedTarget && wp.id.split('/')[0] !== selectedTarget) return;
+          counts.set(wp.platform, (counts.get(wp.platform) || 0) + 1);
+        });
+        return [...counts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+      }, [data.waypoints, selectedTarget]);
+
+      useEffect(() => {
+        if (selectedPlatform && !platforms.some(([p]) => p === selectedPlatform)) {
+          setSelectedPlatform(null);
+        }
+      }, [platforms, selectedPlatform]);
+
+      const filtered = useMemo(() => {
+        if (!selectedTarget && !selectedPlatform) return data;
+        const matches = (wp) => {
+          if (selectedTarget && wp.id.split('/')[0] !== selectedTarget) return false;
+          if (selectedPlatform && wp.platform !== selectedPlatform) return false;
+          return true;
+        };
+        const waypoints = data.waypoints.filter(matches);
+        const wpIds = new Set(waypoints.map(wp => wp.id));
+        const shortcuts = data.shortcuts.filter(sc => wpIds.has(sc.from) && wpIds.has(sc.to));
+        const trailheads = data.trailheads.filter(th => wpIds.has(th.to));
+        return { waypoints, shortcuts, trailheads, generatedNote: data.generatedNote };
+      }, [data, selectedTarget, selectedPlatform]);
+
+      const journeys = useMemo(
+        () => deriveJourneys(filtered.waypoints, filtered.shortcuts, filtered.trailheads),
+        [filtered.waypoints, filtered.shortcuts, filtered.trailheads],
+      );
+
+      // ----- detail-panel data -----
+      const selectedWaypointObj = useMemo(
+        () => selectedWaypoint ? data.waypoints.find(w => w.id === selectedWaypoint) : null,
+        [selectedWaypoint, data.waypoints],
+      );
+      const incomingShortcuts = useMemo(
+        () => selectedWaypoint ? data.shortcuts.filter(sc => sc.to === selectedWaypoint) : [],
+        [selectedWaypoint, data.shortcuts],
+      );
+      const outgoingShortcuts = useMemo(
+        () => selectedWaypoint ? data.shortcuts.filter(sc => sc.from === selectedWaypoint) : [],
+        [selectedWaypoint, data.shortcuts],
+      );
+      const incomingTrailheads = useMemo(
+        () => selectedWaypoint ? data.trailheads.filter(th => th.to === selectedWaypoint) : [],
+        [selectedWaypoint, data.trailheads],
+      );
+
+      // ----- selecting a journey jumps to its destination on the map -----
+      const onSelectJourney = useCallback((j) => {
+        setSelectedJourneyId(j.id);
+        setSelectedWaypoint(j.destinationId);
+        // If we're not in MAP mode, switching there is more useful than staying.
+        if (mode === 'screens') setMode('map');
+      }, [mode]);
+
+      // ----- header strings -----
+      const totalWaypoints = data.waypoints.length;
+      const totalShortcuts = data.shortcuts.length;
+      const totalTrailheads = data.trailheads.length;
+      const scopeLabel = [selectedTarget, selectedPlatform].filter(Boolean).join(' / ') || 'all';
+
+      return React.createElement(React.Fragment, null,
+        // ---- Header ----
+        React.createElement('header', { className: 'app-header' },
+          React.createElement('div', { className: 'brand' },
+            React.createElement('span', { className: 'logo' }, 'T'),
+            'Trailblaze',
+          ),
+          React.createElement('span', { className: 'scope' }, 'Waypoint map · ' + scopeLabel),
+          React.createElement('div', { className: 'mode-toggle' },
+            React.createElement('button', {
+              className: 'mode-button' + (mode === 'map' ? ' active' : ''),
+              onClick: () => setMode('map'),
+            }, 'Map'),
+            React.createElement('button', {
+              className: 'mode-button' + (mode === 'screens' ? ' active' : ''),
+              onClick: () => setMode('screens'),
+            }, 'Screens',
+              React.createElement('span', { className: 'count' }, filtered.waypoints.length),
+            ),
+            React.createElement('button', {
+              className: 'mode-button' + (mode === 'report' ? ' active' : ''),
+              onClick: () => setMode('report'),
+            }, 'Report'),
+          ),
+          React.createElement('div', { className: 'header-counts' },
+            React.createElement('span', { className: 'count-pair' },
+              React.createElement('span', { className: 'num' }, filtered.waypoints.length),
+              'screens',
+            ),
+            React.createElement('span', { className: 'count-pair' },
+              React.createElement('span', { className: 'num' }, journeys.length),
+              'paths',
+            ),
+            React.createElement('span', { className: 'count-pair' },
+              React.createElement('span', { className: 'num' }, filtered.shortcuts.length),
+              'shortcuts',
+            ),
+          ),
+          React.createElement('button', {
+            className: 'theme-toggle',
+            onClick: () => setTheme(t => t === 'dark' ? 'light' : 'dark'),
+            'aria-label': 'Toggle theme',
+            title: 'Toggle dark/light mode',
+          }, theme === 'dark' ? '☀' : '☾'),
+        ),
+
+        // ---- Subheader: filter pills + agentic-angle pill ----
+        React.createElement('div', { className: 'subheader' },
+          targets.length > 1 ? React.createElement(React.Fragment, null,
+            React.createElement('span', { className: 'filter-label' }, 'Target'),
+            React.createElement('button', {
+              className: 'filter-pill' + (selectedTarget === null ? ' active' : ''),
+              onClick: () => setSelectedTarget(null),
+            }, 'All',
+              React.createElement('span', { className: 'count' }, totalWaypoints),
+            ),
+            ...targets.map(([t, count]) =>
+              React.createElement('button', {
+                key: 't::' + t,
+                className: 'filter-pill' + (selectedTarget === t ? ' active' : ''),
+                onClick: () => setSelectedTarget(t),
+              }, t,
+                React.createElement('span', { className: 'count' }, count),
+              ),
+            ),
+          ) : null,
+          platforms.length > 1 ? React.createElement(React.Fragment, null,
+            React.createElement('span', { className: 'filter-label', style: { marginLeft: '12px' } }, 'Platform'),
+            React.createElement('button', {
+              className: 'filter-pill' + (selectedPlatform === null ? ' active' : ''),
+              onClick: () => setSelectedPlatform(null),
+            }, 'All'),
+            ...platforms.map(([p, count]) =>
+              React.createElement('button', {
+                key: 'p::' + p,
+                className: 'filter-pill' + (selectedPlatform === p ? ' active' : ''),
+                onClick: () => setSelectedPlatform(p),
+              }, p,
+                React.createElement('span', { className: 'count' }, count),
+              ),
+            ),
+          ) : null,
+          // Live-dataset pill on the right. The dual-source story (human-authored
+          // canonical waypoints + agent-discovered screens) lives in the tooltip
+          // so the chrome stays factual and avoids competitive-claim phrasing.
+          React.createElement('div', {
+            className: 'agentic-pill',
+            title:
+              'Living waypoint dataset.\n' +
+              'Authored: humans declare canonical waypoints by editing *.waypoint.yaml.\n' +
+              'Discovered: agents propose new waypoints by walking real sessions.\n' +
+              'Both flow into the same map.\n' +
+              (data.generatedNote || ''),
+          },
+            React.createElement('span', { className: 'agentic-icon' }),
+            React.createElement('span', null, 'Living dataset · ',
+              React.createElement('strong', null, totalWaypoints + ' waypoint' + (totalWaypoints === 1 ? '' : 's')),
+              ' · authored + discovered',
+            ),
+          ),
+        ),
+
+        // ---- Main content area ----
+        React.createElement('div', { className: 'main' },
+          React.createElement(JourneysSidebar, {
+            journeys,
+            selectedJourneyId,
+            onSelectJourney,
+            mode,
+          }),
+          React.createElement('div', { className: 'canvas-area' },
+            mode === 'map' ? React.createElement(MapView, {
+              filtered, selectedWaypoint,
+              onSelectWaypoint: setSelectedWaypoint,
+              themeKey: theme + ':' + (selectedTarget || 'all') + ':' + (selectedPlatform || 'all'),
+            }) : null,
+            mode === 'screens' ? React.createElement(ScreensView, {
+              filtered, selectedWaypoint,
+              onSelectWaypoint: setSelectedWaypoint,
+            }) : null,
+            mode === 'report' ? React.createElement(ReportView, {
+              filtered, journeys,
+              onSelectWaypoint: setSelectedWaypoint,
+            }) : null,
+          ),
+          (mode !== 'report' && selectedWaypoint) ? React.createElement(DetailPanel, {
+            waypoint: selectedWaypointObj,
+            incoming: incomingShortcuts,
+            outgoing: outgoingShortcuts,
+            trailheads: incomingTrailheads,
+            allWaypoints: data.waypoints,
+            onClose: () => setSelectedWaypoint(null),
+            onSelectWaypoint: setSelectedWaypoint,
+          }) : null,
+        ),
+      );
+    }
+
+    function EmptyState({ message }) {
+      return React.createElement('div', { className: 'empty-state' },
+        React.createElement('h2', null, 'No waypoints to display'),
+        React.createElement('p', null, message),
+      );
+    }
+
+    const data = window.WAYPOINT_GRAPH_DATA;
+    const root = createRoot(document.getElementById('root'));
+    if (!data || !Array.isArray(data.waypoints) || data.waypoints.length === 0) {
+      root.render(React.createElement(EmptyState, {
+        message: data
+          ? 'The graph data was loaded but contained no waypoints.'
+          : 'No graph data was provided. The page expects window.WAYPOINT_GRAPH_DATA to be set.',
+      }));
+    } else {
+      root.render(React.createElement(App, { data }));
+    }
+  </script>
+</body>
+</html>

--- a/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze-waypoint-graph.txt
+++ b/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze-waypoint-graph.txt
@@ -1,0 +1,28 @@
+# This file is a CHECKED-IN baseline of CLI output rendered by trailblaze-host's CLI helpers.
+# It is NOT a contract — if a test fails here because output drifted, decide whether the
+# drift is intentional. The test always (re)writes this file from the current rendered output,
+# then asserts the working tree is clean. So `git diff` of this file IS the failure message.
+# Reviewers: scrutinize diffs to baselines the same way you would scrutinize a UI screenshot —
+# small wording / spacing changes can be intentional or accidental.
+# ----------------------------------------------------------------------
+Usage: trailblaze waypoint graph [-hV] [-o=<out>] [--root=<root>]
+Render the waypoint navigation graph (waypoints, authored shortcuts, authored
+trailheads) as a single self-contained HTML file. The output bakes in
+screenshots
+as data URIs and loads React Flow + dagre at runtime via esm.sh CDN — open it
+in any
+browser, share it via email/Slack/zip, no Trailblaze install required on the
+viewer's
+side.
+
+For a live, refresh-on-edit view from the running daemon, point your browser at
+http://localhost:<daemon-port>/waypoints/graph instead.
+  -h, --help          Show this help message and exit.
+  -o, --out=<out>     Output HTML file path (default: ./waypoint-graph.html in
+                        the current directory). Parent directories are created
+                        if missing. The file is overwritten if present.
+      --root=<root>   Filesystem directory to scan for *.waypoint.yaml files
+                        (default: ./trails, resolved against the current
+                        working directory). Pack-bundled waypoints from the
+                        classpath are always included regardless of this flag.
+  -V, --version       Print version information and exit.

--- a/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze-waypoint-suggest-selector.txt
+++ b/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze-waypoint-suggest-selector.txt
@@ -1,0 +1,47 @@
+# This file is a CHECKED-IN baseline of CLI output rendered by trailblaze-host's CLI helpers.
+# It is NOT a contract — if a test fails here because output drifted, decide whether the
+# drift is intentional. The test always (re)writes this file from the current rendered output,
+# then asserts the working tree is clean. So `git diff` of this file IS the failure message.
+# Reviewers: scrutinize diffs to baselines the same way you would scrutinize a UI screenshot —
+# small wording / spacing changes can be intentional or accidental.
+# ----------------------------------------------------------------------
+Usage: trailblaze waypoint suggest-selector [-hV] [--anchor=<anchor>]
+       [--max=<max>] --ref=<ref> [--session=<session>] [--step=<step>]
+       [<positionalLogFile>]
+Suggest waypoint-ready selector YAML for a specific element ref in a captured
+screen.
+Pair with `./trailblaze snapshot --all` to see refs, then run this on the
+matching
+session log to translate ref → selector. Returns up to --max named candidates
+(the
+TrailblazeNodeSelectorGenerator strategies that uniquely resolve to the target),
+plus one structural-only candidate at the bottom for forbidden-clause use.
+      [<positionalLogFile>] Path to a *_TrailblazeLlmRequestLog.json (required
+                              unless --session/--step given).
+                            Same shape as the input to `waypoint validate`.
+      --anchor=<anchor>     Compose the leaf selector with an ancestor
+                              predicate. Currently supported:
+                              parent-selected — find the nearest ancestor with
+                              isSelected=true and emit a
+                                selector that matches that ancestor as a `View`
+                              with `isSelected: true`,
+                                using the leaf as `containsChild`. This is the
+                              canonical bottom-nav-tab
+                                waypoint pattern: any app with selectable
+                              bottom-nav tabs uses this to
+                                pin identity to the *currently active* tab
+                              rather than to any tab with the
+                                given label. Without the anchor, the leaf
+                              selector matches a tab regardless
+                                of selection state — fine for tap targets,
+                              wrong for waypoint identity,
+                                because we want to know WHICH tab is currently
+                              active.
+  -h, --help                Show this help message and exit.
+      --max=<max>           Maximum candidate selectors to return (default: 5)
+      --ref=<ref>           Element ref from the captured tree (e.g. 'a812').
+                              Required.
+      --session=<session>   Session log directory (containing
+                              *_TrailblazeLlmRequestLog.json files)
+      --step=<step>         1-based step within --session (default: last step)
+  -V, --version             Print version information and exit.

--- a/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze-waypoint.txt
+++ b/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze-waypoint.txt
@@ -10,13 +10,17 @@ Match named app locations (waypoints) against captured screen state.
   -h, --help      Show this help message and exit.
   -V, --version   Print version information and exit.
 Commands:
-  list             List all waypoint definitions from active packs (workspace +
-                     framework classpath)
-  locate           Given a captured screen state, report which waypoint(s)
-                     match.
-  validate         Validate that a specific waypoint definition matches a
-                     captured screen state.
-  capture-example  Capture a sibling <id>.example.json + screenshot next to the
-                     waypoint YAML.
-  segment          Inspect transitions between waypoints observed in a session
-                     log.
+  list              List all waypoint definitions from active packs (workspace
+                      + framework classpath)
+  locate            Given a captured screen state, report which waypoint(s)
+                      match.
+  validate          Validate that a specific waypoint definition matches a
+                      captured screen state.
+  capture-example   Capture a sibling <id>.example.json + screenshot next to
+                      the waypoint YAML.
+  suggest-selector  Suggest waypoint-ready selector YAML for a specific element
+                      ref in a captured screen.
+  segment           Inspect transitions between waypoints observed in a session
+                      log.
+  graph             Render the waypoint navigation graph (waypoints, authored
+                      shortcuts, authored

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/api/waypoint/WaypointDefinition.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/api/waypoint/WaypointDefinition.kt
@@ -7,20 +7,31 @@ import kotlinx.serialization.Serializable
  * hierarchy. Composed of a list of [required] selector entries (all must match) and a
  * list of [forbidden] selector entries (none may match).
  *
- * ## Pack-scoped id convention
+ * ## Pack-scoped id convention (URL-style)
  *
- * Waypoint [id]s use a `<pack-id>/<local-name>` shape (e.g. `clock/android/alarm_tab`,
- * `gmail/inbox`). The slash is the namespace separator between the owning pack and the
- * waypoint's local name within that pack. On disk, waypoint descriptors live under
- * `trailblaze-config/packs/<pack-id>/waypoints/`, so the leading pack segment maps to
- * the owning pack directory — but the descriptor filename itself does not need to
- * mirror the slash-separated id segments. Pack ownership is implicit by directory
- * layout, so simple local names like `alarm_tab` stay readable and the slash-prefixed
- * form gives an LLM the namespace at a glance.
+ * Waypoint [id]s follow URL conventions: `<pack-id>/<segment>[/<segment>...]`. The slash
+ * is both the pack-namespace separator and the IA hierarchy separator within the pack.
+ * Use `-` for multi-word atoms within a single segment.
  *
- * Three-part ids `<pack-id>/<platform>/<local-name>` are used by packs whose waypoints
- * are platform-specific (e.g. `myapp/android/checkout_keypad`, `myapp/ios/splash`).
- * The platform segment is conventional, not enforced by the loader.
+ * Examples:
+ *  - `myapp/home` — flat, atomic
+ *  - `myapp/withdraw/compose` — composer step within a Withdraw flow
+ *  - `myapp/settings/notifications` — Notifications sub-tab within a Settings tab
+ *  - `myapp/inbox/inventory-upsell` — multi-word atom under an Inbox hub
+ *
+ * **The id is logical, not platform-tagged.** A waypoint named `myapp/home` represents
+ * the conceptual "MyApp home screen" regardless of platform. Today each waypoint YAML
+ * is platform-specific (its selectors are tagged with `androidAccessibility:` or
+ * `iosAccessibility:`), and the file lives under
+ * `packs/<pack-id>/waypoints/<platform>/...` for disk-level organization. When iOS adds
+ * its own home, both files share `id: myapp/home` and the matcher dispatches by
+ * current device platform — a `platforms:` field on this schema is the planned dispatch
+ * mechanism, not yet implemented (no platform-collision exists in the current dataset).
+ *
+ * On disk, waypoint descriptors live under `trailblaze-config/packs/<pack-id>/waypoints/`
+ * with `<platform>/...` subdirectories for platform-specific variants. Filenames mirror
+ * the id's post-pack-segment portion (e.g. id `myapp/withdraw/compose` →
+ * `packs/myapp/waypoints/android/withdraw/compose.waypoint.yaml`).
  *
  * This intentionally diverges from the older underscore tool-naming convention
  * (`2026-01-14-tool-naming-convention.md`), which was driven by serialization needing to

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/model/TrailblazeHostAppTarget.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/model/TrailblazeHostAppTarget.kt
@@ -102,6 +102,20 @@ abstract class TrailblazeHostAppTarget(
   open fun getExcludedYamlToolNamesForDriver(driverType: TrailblazeDriverType): Set<ToolName> = emptySet()
 
   /**
+   * Toolset ids the target *declares* for the given driver — the positive list of toolset
+   * names from `platforms.<key>.tool_sets:` in the target YAML, before any catalog
+   * resolution. Drives pack-positive LLM tool resolution: callers pass the result to
+   * [xyz.block.trailblaze.toolcalls.TrailblazeToolSetCatalog.resolveForDriver] instead of
+   * dumping the entire driver-compatible catalog.
+   *
+   * Empty default for non-YAML targets and for targets that don't declare any toolsets on
+   * a given driver. The implication of an empty list is "use only the catalog's
+   * `always_enabled` toolsets" — that's the explicit, opt-in surface, not a kitchen sink.
+   * Targets that need richer surfaces declare them explicitly.
+   */
+  open fun getDeclaredToolSetIdsForDriver(driverType: TrailblazeDriverType): List<String> = emptyList()
+
+  /**
    * MCP server declarations for this target (Decision 038 / `mcp_servers:` in target YAML).
    *
    * Returns the raw [McpServerConfig] entries declared at the target root. The session-startup

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/yaml/TrailblazeRecordingGenerator.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/yaml/TrailblazeRecordingGenerator.kt
@@ -87,7 +87,7 @@ fun List<TrailblazeLog>.generateRecordedYaml(
           val recording = if (toolWrappers.isNotEmpty()) {
             ToolRecording(
               tools = toolWrappers,
-              autoSatisfied = false
+              autoSatisfied = false,
             )
           } else {
             // Author observed: zero recordable tools fired during this objective window —
@@ -96,7 +96,7 @@ fun List<TrailblazeLog>.generateRecordedYaml(
             // through to AI. See ToolRecording KDoc for replay semantics.
             ToolRecording(
               tools = emptyList(),
-              autoSatisfied = true
+              autoSatisfied = true,
             )
           }
 

--- a/trailblaze-models/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/config/ToolYamlLoader.kt
+++ b/trailblaze-models/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/config/ToolYamlLoader.kt
@@ -115,6 +115,27 @@ object ToolYamlLoader {
       .filter { it.mode == ToolYamlConfig.Mode.TOOLS }
       .associate { ToolName(it.id) to it }
 
+  /**
+   * Discovers all `*.shortcut.yaml` and `*.trailhead.yaml` configs — i.e. every config whose
+   * parsed content carries either a [ToolYamlConfig.shortcut] or [ToolYamlConfig.trailhead]
+   * metadata block. **Both `Mode.CLASS` and `Mode.TOOLS` bodies are returned** because the
+   * navigation-graph view cares about the edge metadata, not whether the body is implemented
+   * as Kotlin or as a YAML composition. ([discoverYamlDefinedTools] filters out class-backed
+   * configs and so silently drops class-bodied trailheads / shortcuts; this method is the
+   * graph view's loader of record.)
+   *
+   * Returned [Map] keys are [ToolName]s; the same id never appears twice because the parser's
+   * duplicate-id detection runs in [discoverAllConfigs] / [parseAllConfigs] before we reach
+   * here. The order of entries is the discovery order — callers that want stable rendering
+   * (e.g. the Map view) should sort downstream.
+   */
+  fun discoverShortcutsAndTrailheads(
+    resourceSource: ConfigResourceSource = platformConfigResourceSource(),
+  ): Map<ToolName, ToolYamlConfig> =
+    discoverAllConfigs(resourceSource)
+      .filter { it.shortcut != null || it.trailhead != null }
+      .associate { ToolName(it.id) to it }
+
   private fun discoverAllConfigs(
     resourceSource: ConfigResourceSource,
   ): List<ToolYamlConfig> {

--- a/trailblaze-report/src/main/java/xyz/block/trailblaze/report/ReportMain.kt
+++ b/trailblaze-report/src/main/java/xyz/block/trailblaze/report/ReportMain.kt
@@ -1,6 +1,7 @@
 package xyz.block.trailblaze.report
 
 import com.github.ajalt.clikt.core.main
+import xyz.block.trailblaze.api.TrailblazeImageFormat
 import xyz.block.trailblaze.llm.LlmLogCostEnricher
 import xyz.block.trailblaze.llm.config.BuiltInLlmModelRegistry
 import xyz.block.trailblaze.logs.client.TrailblazeJsonInstance
@@ -257,7 +258,11 @@ fun moveJsonFilesToSessionDirs(logsDir: File) {
   }
 }
 
-private val IMAGE_EXTENSIONS = setOf("png", "jpg", "jpeg", "webp")
+// Canonical screenshot file extensions, derived from [TrailblazeImageFormat]. Adding a
+// new image format anywhere in the codebase makes it visible to this scanner
+// automatically. The extra "jpeg" entry covers the long-form JPEG extension that
+// TrailblazeImageFormat normalizes to "jpg" for output.
+private val IMAGE_EXTENSIONS = TrailblazeImageFormat.entries.map { it.fileExtension }.toSet() + setOf("jpeg")
 
 fun moveScreenshotsToSessionDirs(logsDir: File) {
   val imageFiles = logsDir.listFiles()?.filter { it.extension in IMAGE_EXTENSIONS } ?: emptyList()

--- a/trailblaze-report/src/main/java/xyz/block/trailblaze/report/utils/LogsRepo.kt
+++ b/trailblaze-report/src/main/java/xyz/block/trailblaze/report/utils/LogsRepo.kt
@@ -3,6 +3,8 @@ package xyz.block.trailblaze.report.utils
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Clock
+import xyz.block.trailblaze.api.ImageFormatDetector
+import xyz.block.trailblaze.api.TrailblazeImageFormat
 import xyz.block.trailblaze.logs.TrailblazeLogsDataProvider
 import xyz.block.trailblaze.logs.client.TrailblazeJsonInstance
 import xyz.block.trailblaze.logs.client.TrailblazeLog
@@ -670,19 +672,26 @@ class LogsRepo(
   /**
    * Saves raw screenshot bytes to disk and returns the filename.
    *
+   * The on-disk file extension comes from sniffing the byte payload via
+   * [ImageFormatDetector] — if the device pipeline returns WebP, the file lands as
+   * `*.webp`, and the same for PNG and JPEG. Don't trust caller-supplied extensions:
+   * historically this was a `String = "png"` parameter that lied for every caller
+   * because the on-device screencap path returns WebP for wire-size, leading to
+   * `.png`-named files containing `RIFF...WEBP` magic bytes scattered across logs/.
+   * Sniffing locally is the single source of truth.
+   *
    * @param sessionId The session ID to save the screenshot under
    * @param bytes The screenshot bytes (PNG, JPEG, or WebP)
-   * @param fileExtension The file extension (e.g. "png", "jpg", "webp")
    * @return The filename of the saved screenshot
    */
   fun saveScreenshotBytes(
     sessionId: SessionId,
     bytes: ByteArray,
-    fileExtension: String = "png",
   ): String {
     if (readOnly) return "noop"
     val sessionDir = getSessionDir(sessionId)
     val timestamp = Clock.System.now().toEpochMilliseconds()
+    val fileExtension = ImageFormatDetector.detectFormat(bytes).fileExtension
     val filename = "${sessionId.value}_${timestamp}.$fileExtension"
     val screenshotFile = File(sessionDir, filename)
     Console.log("Writing Screenshot to ${screenshotFile.absolutePath}")
@@ -691,13 +700,16 @@ class LogsRepo(
   }
 
   /**
-   * Returns a list of image files for the given session.
+   * Returns a list of image files for the given session. Image-vs-non-image is
+   * decided by extension matching the canonical [TrailblazeImageFormat] entries —
+   * adding a new format anywhere in the codebase makes it visible here automatically.
    */
   fun getImagesForSession(sessionId: SessionId): List<File> {
     val sessionDir = File(logsDir, sessionId.value)
     if (!sessionDir.exists()) return emptyList()
+    val imageExtensions = TrailblazeImageFormat.entries.map { it.fileExtension }.toSet() + setOf("jpeg")
     return sessionDir.listFiles()?.filter {
-      it.extension in setOf("png", "jpg", "jpeg", "webp")
+      it.extension.lowercase() in imageExtensions
     }?.sortedBy { it.name }
       ?: emptyList()
   }

--- a/trailblaze-server/src/main/java/xyz/block/trailblaze/logs/server/ServerEndpoints.kt
+++ b/trailblaze-server/src/main/java/xyz/block/trailblaze/logs/server/ServerEndpoints.kt
@@ -10,6 +10,7 @@ import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.request.httpMethod
 import io.ktor.server.request.uri
 import io.ktor.server.response.respond
+import io.ktor.server.routing.Routing
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 import xyz.block.trailblaze.logs.client.TrailblazeJsonInstance
@@ -74,6 +75,18 @@ object ServerEndpoints {
     installContentNegotiation: Boolean = true,
     cliCallbacks: CliEndpointCallbacks? = null,
     resolvedAuths: Map<String, ResolvedProviderAuth>? = null,
+    /**
+     * Optional hook for host-layer modules (trailblaze-host, etc.) to register
+     * additional Ktor routes alongside the server's built-ins. Invoked inside the
+     * `routing { }` block immediately before the 404 catchall, so any path the
+     * callback registers wins over the catchall.
+     *
+     * Used by the desktop's waypoint-graph endpoint, which lives in trailblaze-host
+     * (where waypoint discovery is) but needs to expose itself on the same Ktor
+     * server the daemon already runs. Keeps the dep direction clean (server doesn't
+     * know about host) by inverting registration into a callback.
+     */
+    additionalRouteRegistration: (Routing.() -> Unit)? = null,
   ) {
     val auths = resolvedAuths ?: LlmAuthResolver.resolveAll(LlmConfigLoader.load())
     if (installContentNegotiation) {
@@ -113,6 +126,10 @@ object ServerEndpoints {
         CliStatusEndpoint.register(this, callbacks.statusProvider)
         callbacks.onCliExecRequest?.let { CliExecEndpoint.register(this, it) }
       }
+
+      // Host-layer routes (e.g. waypoint graph view from trailblaze-host) — registered
+      // before the catchall so they can claim paths the server doesn't know about.
+      additionalRouteRegistration?.invoke(this)
 
       route("{...}") {
         handle {

--- a/trailblaze-server/src/main/java/xyz/block/trailblaze/logs/server/TrailblazeMcpServer.kt
+++ b/trailblaze-server/src/main/java/xyz/block/trailblaze/logs/server/TrailblazeMcpServer.kt
@@ -810,6 +810,13 @@ class TrailblazeMcpServer(
     port: Int = TrailblazeDevicePort.TRAILBLAZE_DEFAULT_HTTP_PORT,
     httpsPort: Int = TrailblazeDevicePort.TRAILBLAZE_DEFAULT_HTTPS_PORT,
     wait: Boolean = false,
+    /**
+     * Optional hook to register additional Ktor routes alongside the daemon's
+     * built-ins. Used by host-layer modules (e.g. trailblaze-host's waypoint graph
+     * endpoint) that need to surface UIs on the same server but live in a higher
+     * module than this one. Invoked inside the routing block, before the catchall.
+     */
+    additionalRouteRegistration: (io.ktor.server.routing.Routing.() -> Unit)? = null,
   ): EmbeddedServer<*, *> {
     serverStartTimeMillis = System.currentTimeMillis()
     emitDebugState()
@@ -1046,6 +1053,7 @@ class TrailblazeMcpServer(
             )
           },
         ),
+        additionalRouteRegistration = additionalRouteRegistration,
       )
       routing {
         // STREAMABLE HTTP TRANSPORT ENDPOINT (at /mcp)
@@ -1392,21 +1400,37 @@ class TrailblazeMcpServer(
               .map { it.toTrailblazeToolDescriptor() }
           } else {
           val driverType = mcpBridge.getDriverType()
+          val activeTarget = findCurrentTarget()
           // Ask the bridge for device-appropriate built-in tools.
-          // For WEB/Playwright: returns Playwright-native toolset (complete replacement for Maestro).
-          // For Android/iOS: returns empty → falls back to ALL Maestro tools so that
-          // availableToolsProvider() delivers the complete toolset to StepToolSet.
+          // For WEB/Playwright/Compose/Revyl: returns a driver-specific replacement (no kitchen sink).
+          // For Android/iOS: returns empty → we resolve from the active target's pack `tool_sets:`
+          // declarations via TrailblazeToolSetCatalog.resolveForDriver (driver-aware, target-scoped),
+          // not the catalog-wide kitchen sink. With no active target, the LLM sees only the
+          // catalog's `always_enabled` toolsets — pack authors opt into more by declaring tool_sets.
           val bridgeToolClasses = mcpBridge.getInnerAgentBuiltInToolClasses()
           val usingBridgeTools = bridgeToolClasses.isNotEmpty()
+
+          val packToolSets = if (driverType != null && activeTarget != null) {
+            activeTarget.getDeclaredToolSetIdsForDriver(driverType)
+          } else emptyList()
+          val resolvedFromPack = if (driverType != null) {
+            TrailblazeToolSetCatalog.resolveForDriver(driverType, packToolSets)
+          } else null
+
           val builtInToolClasses = if (usingBridgeTools) {
             bridgeToolClasses
           } else {
-            ToolSetCategoryMapping.getToolClasses(ToolSetCategory.ALL)
+            resolvedFromPack?.toolClasses ?: emptySet()
           }
-          val customToolClasses = customToolClassesProvider()
+          val customToolClasses = if (driverType != null && activeTarget != null) {
+            activeTarget.getCustomToolsForDriver(driverType)
+          } else emptySet()
+          val excludedToolClasses = if (driverType != null && activeTarget != null) {
+            activeTarget.getExcludedToolsForDriver(driverType)
+          } else emptySet()
           // Custom tools first so the LLM sees app-specific tools (e.g., sign-in)
           // before generic alternatives (e.g., launchApp), improving selection.
-          val classDescriptors = (customToolClasses + builtInToolClasses)
+          val classDescriptors = (customToolClasses + builtInToolClasses - excludedToolClasses)
             .mapNotNull { it.toKoogToolDescriptor()?.toTrailblazeToolDescriptor() }
           // Yaml-defined tools only ride along on the fallback (Android/iOS) path — the
           // bridge path is a complete driver-specific replacement (e.g. Playwright), and
@@ -1414,12 +1438,24 @@ class TrailblazeMcpServer(
           val yamlDescriptors = if (usingBridgeTools) {
             emptyList()
           } else {
+            val customYamlNames = if (driverType != null && activeTarget != null) {
+              activeTarget.getCustomYamlToolNamesForDriver(driverType)
+            } else emptySet()
+            val excludedYamlNames = if (driverType != null && activeTarget != null) {
+              activeTarget.getExcludedYamlToolNamesForDriver(driverType)
+            } else emptySet()
+            val builtInYamlNames = resolvedFromPack?.yamlToolNames ?: emptySet()
             KoogToolExt.buildDescriptorsForYamlDefined(
-              ToolSetCategoryMapping.getYamlToolNames(ToolSetCategory.ALL),
+              (customYamlNames + builtInYamlNames - excludedYamlNames).toSet(),
             ).map { it.toTrailblazeToolDescriptor() }
           }
           val allTools = classDescriptors + yamlDescriptors
-          Console.log("[TrailblazeMcpServer] Inner agent total tools: ${allTools.size} (driver=$driverType, custom: ${customToolClasses.size}, yaml: ${yamlDescriptors.size})")
+          Console.log(
+            "[TrailblazeMcpServer] Inner agent total tools: ${allTools.size} (driver=$driverType, " +
+              "target=${activeTarget?.id}, packToolSets=$packToolSets, " +
+              "custom=${customToolClasses.size}, excluded=${excludedToolClasses.size}, " +
+              "yaml=${yamlDescriptors.size})"
+          )
           allTools
           }
         }
@@ -1476,6 +1512,8 @@ class TrailblazeMcpServer(
             val sessionId = activeSessionIdProvider()
               ?: mcpBridge.ensureSessionAndGetId(null)
             if (logsRepo != null && sessionId != null) {
+              // saveScreenshotBytes sniffs the byte payload via [ImageFormatDetector]
+              // and picks the right extension internally — caller doesn't supply it.
               val filename = logsRepo.saveScreenshotBytes(sessionId, bytes)
               val sessionDir = logsRepo.getSessionDir(sessionId)
               java.io.File(sessionDir, filename).absolutePath

--- a/trailblaze-server/src/main/java/xyz/block/trailblaze/mcp/sampling/LocalLlmSamplingSource.kt
+++ b/trailblaze-server/src/main/java/xyz/block/trailblaze/mcp/sampling/LocalLlmSamplingSource.kt
@@ -519,14 +519,11 @@ class LocalLlmSamplingSource(
       inputTokenBreakdown = inputTokenBreakdown,
     )
 
-    // Save screenshot to disk if available
+    // Save screenshot to disk if available. saveScreenshotBytes sniffs the payload
+    // and picks the right extension internally — caller doesn't supply it.
     val screenshotFile = if (screenshotBytes != null && screenshotBytes.isNotEmpty()) {
       try {
-        repo.saveScreenshotBytes(
-          sessionId = sessionId,
-          bytes = screenshotBytes,
-          fileExtension = ImageFormatDetector.detectFormat(screenshotBytes).fileExtension,
-        )
+        repo.saveScreenshotBytes(sessionId, screenshotBytes)
       } catch (e: Exception) {
         Console.log("[LocalLlmSamplingSource] Failed to save screenshot: ${e.message}")
         null

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/waypoints/ShortcutDisplayItem.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/waypoints/ShortcutDisplayItem.kt
@@ -1,0 +1,57 @@
+package xyz.block.trailblaze.ui.waypoints
+
+/**
+ * UI-side mirror of an authored **shortcut tool** — a `ToolYamlConfig` whose
+ * `shortcut: { from, to, variant? }` metadata block is populated. Rendered as a solid
+ * directed edge between waypoint nodes on the map view.
+ *
+ * Lives in commonMain so the JVM Desktop tab and a future WASM target render the same
+ * visualization. The JVM host wiring discovers authored shortcuts/trailheads via
+ * `ToolYamlLoader.discoverShortcutsAndTrailheads()` so entries backed by either
+ * `Mode.CLASS` or `Mode.TOOLS` bodies are preserved (the older `discoverYamlDefinedTools()`
+ * path filtered to `Mode.TOOLS` only and would silently drop class-bodied shortcuts/
+ * trailheads — don't reintroduce that filter), then converts each shortcut
+ * `ToolYamlConfig` into one of these — the conversion is a flat field copy. We do not
+ * pull `ToolYamlConfig` itself across the boundary because its body may carry
+ * kotlinx-json types that we don't need on the visualization side.
+ *
+ * See [`docs/devlog/2026-04-28-shortcuts-as-tools.md`](../../../../../../../../docs/devlog/2026-04-28-shortcuts-as-tools.md)
+ * for the data-model rationale (one type — `ToolYamlConfig` — with optional `shortcut:`
+ * block; no parallel hierarchy).
+ */
+data class ShortcutDisplayItem(
+  /** Tool id from the YAML — registry key, used for de-dup and as a tooltip label. */
+  val id: String,
+  /** Human-readable description from the YAML, if any. */
+  val description: String?,
+  /** Source waypoint id (e.g. `clock/android/alarm_tab`). */
+  val from: String,
+  /** Destination waypoint id. */
+  val to: String,
+  /**
+   * Optional disambiguator for shortcuts that share the same `(from, to)` pair. The
+   * canonical addressing tuple is `(from, to, variant?)` — most shortcuts never need it.
+   */
+  val variant: String?,
+)
+
+/**
+ * UI-side mirror of an authored **trailhead tool** — a `ToolYamlConfig` whose
+ * `trailhead: { to }` metadata block is populated. Rendered as an entry-point glyph
+ * on the map view: the trailhead has no `from` (it bootstraps the agent from any state
+ * to a known waypoint), so it draws as an edge from a virtual "outside" node into
+ * its [to] target.
+ *
+ * Trailheads exist as their own UI shape (rather than `ShortcutDisplayItem` with a
+ * nullable `from`) so the map renderer can keep the operational distinction visible —
+ * gated-on-waypoint shortcuts vs. always-available trailheads — without runtime checks
+ * on a sentinel value.
+ */
+data class TrailheadDisplayItem(
+  /** Tool id from the YAML — registry key, used for de-dup and as a tooltip label. */
+  val id: String,
+  /** Human-readable description from the YAML, if any. */
+  val description: String?,
+  /** Destination waypoint id this trailhead lands at. */
+  val to: String,
+)

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/waypoints/WaypointMapCanvas.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/waypoints/WaypointMapCanvas.kt
@@ -1,0 +1,480 @@
+package xyz.block.trailblaze.ui.waypoints
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FlightTakeoff
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalDensity
+import coil3.compose.AsyncImage
+import xyz.block.trailblaze.ui.composables.SelectableText
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Static graph view ("Map" mode) for the Waypoints tab.
+ *
+ * Renders the navigation graph as a layered DAG:
+ *
+ * - **Nodes** are waypoints, drawn as small cards with the captured example screenshot
+ *   thumbnail and the waypoint id underneath. Same picture as the definition view, just
+ *   smaller and positioned on a grid by [WaypointMapLayout].
+ * - **Solid edges** are authored shortcuts (`*.shortcut.yaml` files — `ToolYamlConfig`
+ *   with a populated `shortcut: { from, to }` block). Drawn `from → to` with an arrowhead.
+ * - **Dashed entry edges** are trailheads (`*.trailhead.yaml` files — `ToolYamlConfig`
+ *   with a populated `trailhead: { to }` block). Drawn from a virtual "outside" glyph at
+ *   the top of the canvas into each trailhead's target waypoint, since trailheads
+ *   bootstrap from any state and have no `from`.
+ *
+ * Today's repo has zero authored shortcuts or trailheads, so the canvas in practice
+ * renders just the node grid. The edge rendering is wired so the moment an author commits
+ * the first `*.shortcut.yaml` or `*.trailhead.yaml`, it appears on the map.
+ *
+ * No session overlay (observed segments) here — that's v2.1 per the issue's milestone
+ * plan.
+ *
+ * ## Multiplatform constraints
+ *
+ * Lives in commonMain so the same composable backs the Desktop tab today and a future
+ * WASM target. Specifically:
+ *  - No `String.format` (use the `formatOneDecimal`-style helper precedent).
+ *  - `LocalDensity` *is* available on both Desktop and WASM, so we use it to convert
+ *    grid coordinates to pixels for the edge canvas.
+ *  - Screenshot rendering reuses the [coil3.compose.AsyncImage] path that
+ *    [WaypointExamplePanel] already established.
+ */
+@Composable
+internal fun WaypointMapCanvas(
+  waypoints: List<WaypointDisplayItem>,
+  shortcuts: List<ShortcutDisplayItem>,
+  trailheads: List<TrailheadDisplayItem>,
+  selectedId: String?,
+  onSelect: (String) -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val itemsById = remember(waypoints) { waypoints.associateBy { it.definition.id } }
+  val layout = remember(waypoints, shortcuts, trailheads) {
+    WaypointMapLayout.compute(
+      waypointIds = waypoints.map { it.definition.id },
+      shortcuts = shortcuts,
+      trailheads = trailheads,
+    )
+  }
+  val resolvedShortcuts = remember(shortcuts, itemsById) {
+    shortcuts.filter { it.from in itemsById && it.to in itemsById }
+  }
+  val resolvedTrailheads = remember(trailheads, itemsById) {
+    trailheads.filter { it.to in itemsById }
+  }
+
+  if (waypoints.isEmpty()) {
+    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+      SelectableText(
+        text = "No waypoints to draw on the map.",
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    return
+  }
+
+  // Reserve a row above layer 0 for the trailhead "outside" glyph when trailheads are
+  // authored, so the dashed entry edges have somewhere to originate. When no trailheads
+  // exist, the row is omitted entirely (no glyph, no extra height) — the canvas sizes
+  // tightly to the waypoint layers and the toggle's mode-button label carries the
+  // "0 trailheads" affordance instead.
+  val hasTrailheads = resolvedTrailheads.isNotEmpty()
+
+  val totalWidthDp = remember(layout) {
+    val cols = layout.maxColumns.coerceAtLeast(1)
+    MAP_HORIZONTAL_PADDING * 2 + NODE_WIDTH * cols + NODE_HORIZONTAL_GAP * (cols - 1)
+  }
+  val totalHeightDp = remember(layout, hasTrailheads) {
+    val layers = layout.layerCount.coerceAtLeast(1)
+    val baseHeight = MAP_VERTICAL_PADDING * 2 +
+      NODE_HEIGHT * layers +
+      NODE_VERTICAL_GAP * (layers - 1)
+    if (hasTrailheads) baseHeight + TRAILHEAD_ROW_HEIGHT else baseHeight
+  }
+
+  val density = LocalDensity.current
+  val edgeColor = MaterialTheme.colorScheme.onSurface
+  val trailheadEdgeColor = MaterialTheme.colorScheme.tertiary
+
+  Box(
+    modifier = modifier
+      .horizontalScroll(rememberScrollState())
+      .verticalScroll(rememberScrollState()),
+  ) {
+    Box(modifier = Modifier.size(width = totalWidthDp, height = totalHeightDp)) {
+      // Edge layer — drawn first so node cards render above the lines. Same parent
+      // sizing as the node layer, so px coordinates line up between the two.
+      Canvas(modifier = Modifier.matchParentSize()) {
+        // Authored shortcut edges (solid).
+        resolvedShortcuts.forEach { shortcut ->
+          val fromPos = layout.positions[shortcut.from] ?: return@forEach
+          val toPos = layout.positions[shortcut.to] ?: return@forEach
+          val fromCenter = nodeBottomCenterPx(fromPos, density, hasTrailheads)
+          val toCenter = nodeTopCenterPx(toPos, density, hasTrailheads)
+          drawEdge(
+            start = fromCenter,
+            end = toCenter,
+            color = edgeColor,
+            strokeWidthPx = with(density) { 1.5.dp.toPx() },
+            dashIntervalPx = null,
+          )
+        }
+        // Trailhead entry edges (dashed) from the virtual "outside" anchor down into
+        // each trailhead's target waypoint. The "outside" anchor is a single point at
+        // the horizontal center of the canvas.
+        if (hasTrailheads) {
+          val outsideAnchor = trailheadOutsideAnchorPx(totalWidthDp, density)
+          resolvedTrailheads.forEach { trailhead ->
+            val toPos = layout.positions[trailhead.to] ?: return@forEach
+            val toCenter = nodeTopCenterPx(toPos, density, hasTrailheads = true)
+            drawEdge(
+              start = outsideAnchor,
+              end = toCenter,
+              color = trailheadEdgeColor,
+              strokeWidthPx = with(density) { 1.5.dp.toPx() },
+              dashIntervalPx = with(density) { 6.dp.toPx() },
+            )
+          }
+        }
+      }
+
+      // Trailhead "outside" glyph at the top of the canvas, centered horizontally.
+      // Always rendered when at least one authored trailhead exists; dropped entirely
+      // otherwise so a graph with zero trailheads doesn't carry orphaned chrome.
+      if (hasTrailheads) {
+        TrailheadOutsideGlyph(
+          totalWidthDp = totalWidthDp,
+          modifier = Modifier.align(Alignment.TopStart),
+        )
+      }
+
+      // Waypoint nodes positioned by grid coords.
+      waypoints.forEach { wp ->
+        val pos = layout.positions[wp.definition.id] ?: return@forEach
+        val (xDp, yDp) = nodeTopLeftDp(pos, hasTrailheads)
+        WaypointNodeCard(
+          item = wp,
+          isSelected = wp.definition.id == selectedId,
+          onClick = { onSelect(wp.definition.id) },
+          modifier = Modifier.offset(x = xDp, y = yDp),
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Outer padding around the whole canvas. Keeps node cards (and edge endpoints) clear of
+ * the scroll container's edge so the first/last node aren't visually cropped.
+ */
+private val MAP_HORIZONTAL_PADDING = 24.dp
+private val MAP_VERTICAL_PADDING = 16.dp
+
+/**
+ * Fixed node card dimensions. Width is screenshot-thumbnail-driven; height includes the
+ * thumbnail (9:16-ish aspect) plus a one-line id label below. These sizes are quoted in
+ * the issue body's v2.0 milestone ("~120×220dp each").
+ */
+private val NODE_WIDTH = 140.dp
+private val NODE_HEIGHT = 240.dp
+
+/**
+ * Spacing between adjacent nodes. Horizontal gap leaves room for the id label without
+ * collisions; vertical gap leaves room for the edge arrowhead between layers.
+ */
+private val NODE_HORIZONTAL_GAP = 28.dp
+private val NODE_VERTICAL_GAP = 64.dp
+
+/**
+ * Vertical band above layer 0 reserved for the trailhead "outside" glyph and the
+ * dashed entry edges from it. Rendered only when at least one authored trailhead
+ * exists; otherwise it would be wasted space.
+ */
+private val TRAILHEAD_ROW_HEIGHT = 64.dp
+
+/** Top-left dp of a waypoint node given its grid position. */
+private fun nodeTopLeftDp(
+  pos: WaypointMapLayout.GridPosition,
+  hasTrailheadRow: Boolean,
+): Pair<Dp, Dp> {
+  val x = MAP_HORIZONTAL_PADDING + (NODE_WIDTH + NODE_HORIZONTAL_GAP) * pos.column
+  val baseY = MAP_VERTICAL_PADDING + (NODE_HEIGHT + NODE_VERTICAL_GAP) * pos.layer
+  val y = if (hasTrailheadRow) baseY + TRAILHEAD_ROW_HEIGHT else baseY
+  return x to y
+}
+
+/**
+ * Pixel-space top-center of a node — the "incoming" anchor point for edges that
+ * terminate on it. Computed from the same grid math as [nodeTopLeftDp] so edges and
+ * node positions line up exactly.
+ */
+private fun nodeTopCenterPx(
+  pos: WaypointMapLayout.GridPosition,
+  density: Density,
+  hasTrailheads: Boolean,
+): Offset {
+  val (xDp, yDp) = nodeTopLeftDp(pos, hasTrailheads)
+  return with(density) {
+    Offset(
+      x = (xDp + NODE_WIDTH / 2).toPx(),
+      y = yDp.toPx(),
+    )
+  }
+}
+
+/** Pixel-space bottom-center of a node — the "outgoing" anchor for outbound edges. */
+private fun nodeBottomCenterPx(
+  pos: WaypointMapLayout.GridPosition,
+  density: Density,
+  hasTrailheads: Boolean,
+): Offset {
+  val (xDp, yDp) = nodeTopLeftDp(pos, hasTrailheads)
+  return with(density) {
+    Offset(
+      x = (xDp + NODE_WIDTH / 2).toPx(),
+      y = (yDp + NODE_HEIGHT).toPx(),
+    )
+  }
+}
+
+/**
+ * Pixel-space anchor for the virtual "outside" node — single point centered horizontally
+ * within the [TRAILHEAD_ROW_HEIGHT] band. Used as the start point for every trailhead's
+ * dashed entry edge.
+ */
+private fun trailheadOutsideAnchorPx(totalWidthDp: Dp, density: Density): Offset {
+  return with(density) {
+    Offset(
+      x = (totalWidthDp / 2).toPx(),
+      y = (MAP_VERTICAL_PADDING + TRAILHEAD_ROW_HEIGHT / 2).toPx(),
+    )
+  }
+}
+
+/**
+ * Renders one waypoint as a click-able card with screenshot thumbnail and id label.
+ * Selection bumps the border color so the user can see which node corresponds to the
+ * detail panel below the canvas.
+ */
+@Composable
+private fun WaypointNodeCard(
+  item: WaypointDisplayItem,
+  isSelected: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  val example = item.example
+  val borderColor = if (isSelected) {
+    MaterialTheme.colorScheme.primary
+  } else {
+    MaterialTheme.colorScheme.outlineVariant
+  }
+  Card(
+    modifier = modifier
+      .size(width = NODE_WIDTH, height = NODE_HEIGHT)
+      .border(
+        width = if (isSelected) 2.dp else 1.dp,
+        color = borderColor,
+        shape = MaterialTheme.shapes.medium,
+      )
+      .clickable(onClick = onClick),
+    colors = CardDefaults.cardColors(
+      containerColor = MaterialTheme.colorScheme.surface,
+    ),
+  ) {
+    Column(modifier = Modifier.fillMaxSize().padding(6.dp)) {
+      // Track decode errors per-node so a corrupt screenshot blob doesn't blank out
+      // every map node sharing the same coil3 codec — same pattern as
+      // [WaypointExamplePanel].
+      var decodeFailed by remember(example) { mutableStateOf(false) }
+      val screenshotBytes = example?.screenshotBytes?.takeIf { it.isNotEmpty() }
+      Box(
+        modifier = Modifier
+          .fillMaxWidth()
+          .aspectRatio(0.5625f) // 9:16 — matches typical phone screenshot framing
+          .clip(MaterialTheme.shapes.small)
+          .background(MaterialTheme.colorScheme.surfaceVariant),
+        contentAlignment = Alignment.Center,
+      ) {
+        if (screenshotBytes != null && !decodeFailed) {
+          AsyncImage(
+            model = screenshotBytes,
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.fillMaxSize(),
+            onError = { _ -> decodeFailed = true },
+          )
+        } else {
+          Text(
+            text = if (decodeFailed) "(decode failed)" else "(no screenshot)",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
+      }
+      Spacer(Modifier.height(4.dp))
+      Text(
+        text = item.definition.id,
+        style = MaterialTheme.typography.labelSmall,
+        fontFamily = FontFamily.Monospace,
+        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+        color = MaterialTheme.colorScheme.onSurface,
+        maxLines = 2,
+      )
+    }
+  }
+}
+
+/**
+ * The "outside" glyph at the top of the canvas — a single chip with a takeoff icon and
+ * the word "trailheads", centered horizontally. Acts as the anchor every trailhead's
+ * dashed entry edge originates from.
+ */
+@Composable
+private fun TrailheadOutsideGlyph(totalWidthDp: Dp, modifier: Modifier = Modifier) {
+  val chipWidth = 140.dp
+  // Center the chip within the canvas width. The dashed edges line up with the chip's
+  // bottom-center — the canvas math centers on totalWidthDp/2, so as long as this chip
+  // is also centered horizontally the visuals connect.
+  val xOffset = (totalWidthDp - chipWidth) / 2
+  val yOffset = MAP_VERTICAL_PADDING + TRAILHEAD_ROW_HEIGHT / 2 - 14.dp
+  Surface(
+    modifier = modifier
+      .offset(x = xOffset, y = yOffset)
+      .width(chipWidth)
+      .height(28.dp),
+    color = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.18f),
+    contentColor = MaterialTheme.colorScheme.tertiary,
+    shape = RoundedCornerShape(14.dp),
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = 10.dp).fillMaxSize(),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.Center,
+    ) {
+      Icon(
+        Icons.Filled.FlightTakeoff,
+        contentDescription = null,
+        modifier = Modifier.size(16.dp),
+      )
+      Spacer(Modifier.width(6.dp))
+      Text(
+        text = "trailheads",
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.SemiBold,
+      )
+    }
+  }
+}
+
+/**
+ * Draws one edge from [start] to [end] as a line with an arrowhead at [end]. Pass a
+ * non-null [dashIntervalPx] to render the line as a dashed pattern (for trailhead
+ * entries); passing null produces a solid line (authored shortcuts).
+ *
+ * The arrowhead is a small filled triangle whose tip sits on the node boundary — the
+ * caller already nudges [end] to the boundary point, so we don't need to inset further
+ * here.
+ */
+private fun DrawScope.drawEdge(
+  start: Offset,
+  end: Offset,
+  color: Color,
+  strokeWidthPx: Float,
+  dashIntervalPx: Float?,
+) {
+  // Line body. Dashed pattern handled via PathEffect when requested; falls back to a
+  // plain drawLine for solid edges (cheaper, no path allocation).
+  if (dashIntervalPx != null) {
+    val pathEffect = androidx.compose.ui.graphics.PathEffect.dashPathEffect(
+      intervals = floatArrayOf(dashIntervalPx, dashIntervalPx),
+      phase = 0f,
+    )
+    drawLine(
+      color = color,
+      start = start,
+      end = end,
+      strokeWidth = strokeWidthPx,
+      pathEffect = pathEffect,
+    )
+  } else {
+    drawLine(
+      color = color,
+      start = start,
+      end = end,
+      strokeWidth = strokeWidthPx,
+    )
+  }
+  // Arrowhead — filled triangle whose tip sits at [end], rotated to align with the
+  // line direction. Size scales loosely with stroke width so thin/thick edges look
+  // proportionate.
+  val arrowLen = strokeWidthPx * 6f
+  val arrowWidth = strokeWidthPx * 4f
+  val angle = atan2(end.y - start.y, end.x - start.x).toDouble()
+  val sinA = sin(angle).toFloat()
+  val cosA = cos(angle).toFloat()
+  val backX = end.x - cosA * arrowLen
+  val backY = end.y - sinA * arrowLen
+  val leftX = backX + sinA * (arrowWidth / 2)
+  val leftY = backY - cosA * (arrowWidth / 2)
+  val rightX = backX - sinA * (arrowWidth / 2)
+  val rightY = backY + cosA * (arrowWidth / 2)
+  val path = Path().apply {
+    moveTo(end.x, end.y)
+    lineTo(leftX, leftY)
+    lineTo(rightX, rightY)
+    close()
+  }
+  // Filled triangle — single drawPath call, no Stroke pass. The earlier version drew
+  // the path twice (once stroked, once filled) which Copilot flagged as redundant
+  // double-render with the same color. The kdoc above already promises a filled tri-
+  // angle; the stroke pass added blur without adding visual signal.
+  drawPath(path = path, color = color)
+}

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/waypoints/WaypointMapLayout.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/waypoints/WaypointMapLayout.kt
@@ -1,0 +1,151 @@
+package xyz.block.trailblaze.ui.waypoints
+
+/**
+ * Pure, testable layout algorithm for the waypoint map canvas. Takes the set of waypoint
+ * ids plus the authored shortcut and trailhead edges, and returns each waypoint's grid
+ * position (`(layer, column)`).
+ *
+ * Lives in commonMain with no Compose dependency so the layout can be exercised by plain
+ * unit tests on JVM and reused as-is on WASM.
+ *
+ * ## Layout strategy
+ *
+ * The issue body picks "**layered DAG** for small graphs (≤30 waypoints), force-directed
+ * if the graph grows past that." For v2.0 we implement just the layered-DAG path —
+ * force-directed lands as a follow-up if and when waypoint counts demand it.
+ *
+ * **Layer assignment** is the longest-path / "as late as possible" walk: a waypoint's
+ * layer is one greater than the deepest layer among any waypoint that has a shortcut
+ * pointing to it. Trailhead targets sit at layer 0 alongside other roots — the virtual
+ * "outside" node renders above the grid as a separate glyph; we don't push trailhead
+ * targets into a phantom layer 1 just to make room for the trailhead arrow, because that
+ * would also push every shortcut chain one row down for no visual benefit.
+ *
+ * **Cycle handling** combines a snapshot-based relaxation with an iteration cap. Each
+ * iteration reads `from` layer values from a snapshot of the previous iteration so a
+ * single round can only bump any node's layer by at most 1 — without that, an in-place
+ * relaxation traverses the cycle multiple times per iteration and grows layers ~quadrat-
+ * ically. With the snapshot the worst case is `waypointIds.size` for an SCC member,
+ * keeping the canvas height linearly bounded. SCC members still land at non-canonical
+ * layers — the proper SCC-condensation pass is a follow-up — but the rendered graph is
+ * never grossly distorted by a cycle.
+ *
+ * **Column assignment** within each layer is alphabetic by waypoint id. Stable across
+ * runs (no Map iteration order surprises on WASM), reproducible in tests, and gives
+ * authors a layout-by-name that matches list-view ordering. Heuristic edge-crossing
+ * minimization (barycenter, median) is a future enhancement when the visual quality
+ * starts to matter.
+ *
+ * ## Input contract
+ *
+ * The shortcut list is allowed to reference waypoint ids that aren't in [waypointIds] —
+ * those references are silently ignored (a shortcut with a `from` or `to` whose waypoint
+ * has been deleted but the YAML still references it). The renderer does not currently
+ * surface a warning for dangling references; the layout step just refuses to position a
+ * node that doesn't exist. Adding a "this YAML references a missing waypoint" diagnostic
+ * to the Map UI is a deferred follow-up.
+ */
+internal object WaypointMapLayout {
+
+  /**
+   * One waypoint's position in the rendered grid.
+   *
+   * - [layer] — 0-based row from top. Roots (waypoints with no incoming shortcut) are
+   *   layer 0; each successive shortcut hop adds one.
+   * - [column] — 0-based position within the layer, alphabetic by waypoint id.
+   */
+  data class GridPosition(val layer: Int, val column: Int)
+
+  /**
+   * Aggregate output: per-waypoint position plus a summary of total grid size that the
+   * canvas renderer uses to pick its scrollable content dimensions.
+   *
+   * - [layerCount] — number of populated layers, i.e. `(max layer) + 1`. Zero when
+   *   [waypointIds] is empty.
+   * - [maxColumns] — the widest layer's column count, used to size the canvas width.
+   *   Zero when [waypointIds] is empty.
+   */
+  data class Layout(
+    val positions: Map<String, GridPosition>,
+    val layerCount: Int,
+    val maxColumns: Int,
+  )
+
+  /**
+   * Computes [Layout] from the input graph. See class kdoc for the algorithm.
+   *
+   * Iteration cap is set to [waypointIds] size to bound work on cyclic inputs — see
+   * "Cycle handling" in the class kdoc.
+   */
+  fun compute(
+    waypointIds: List<String>,
+    shortcuts: List<ShortcutDisplayItem>,
+    @Suppress("UNUSED_PARAMETER") trailheads: List<TrailheadDisplayItem>,
+  ): Layout {
+    if (waypointIds.isEmpty()) {
+      return Layout(positions = emptyMap(), layerCount = 0, maxColumns = 0)
+    }
+    val waypointSet = waypointIds.toSet()
+    // Filter shortcuts to those whose endpoints both exist; dangling references can't
+    // contribute to the layout. The renderer will report them separately.
+    val resolvedShortcuts = shortcuts.filter { it.from in waypointSet && it.to in waypointSet }
+
+    // Initialize every waypoint at layer 0. Roots (no incoming shortcut) and trailhead
+    // targets stay there; nodes downstream of a chain get bumped by the iteration below.
+    val layer = HashMap<String, Int>(waypointIds.size).apply {
+      waypointIds.forEach { put(it, 0) }
+    }
+
+    // Snapshot-based longest-path relaxation. Each iteration reads `from` layers from a
+    // snapshot of the previous iteration's state (not the live, mid-iteration values),
+    // so a single iteration can grow any node's layer by at most 1. On an acyclic graph
+    // this converges in `waypointIds.size` rounds (longest path has at most that many
+    // edges); on a cyclic graph it bounds the SCC's layer values to `waypointIds.size`,
+    // not the ~n² that an in-place Bellman-Ford-style relaxation would produce when
+    // each iteration walks the cycle multiple times. Codex flagged the in-place version
+    // as a runaway-canvas-height risk on cyclic authored shortcuts; the snapshot keeps
+    // the canvas size linearly bounded in the worst case.
+    val maxIterations = waypointIds.size
+    var iter = 0
+    var changed = true
+    while (changed && iter < maxIterations) {
+      iter++
+      changed = false
+      val snapshot = HashMap(layer)
+      for (s in resolvedShortcuts) {
+        val fromLayer = snapshot[s.from] ?: continue
+        val toLayer = layer[s.to] ?: continue
+        val candidate = fromLayer + 1
+        if (candidate > toLayer) {
+          layer[s.to] = candidate
+          changed = true
+        }
+      }
+    }
+
+    // Group by layer, then assign columns by alphabetic waypoint id within each layer.
+    // Sorted list (not Map) because Map.toSortedMap() is JVM-only — visualizer must
+    // compile for wasmJs (same constraint already documented on the target dropdown).
+    val byLayer: List<Pair<Int, List<String>>> = waypointIds
+      .groupBy { layer[it] ?: 0 }
+      .toList()
+      .sortedBy { it.first }
+      .map { (l, ids) -> l to ids.sorted() }
+
+    val positions = HashMap<String, GridPosition>(waypointIds.size)
+    var maxColumns = 0
+    for ((l, idsInLayer) in byLayer) {
+      idsInLayer.forEachIndexed { col, id ->
+        positions[id] = GridPosition(layer = l, column = col)
+      }
+      if (idsInLayer.size > maxColumns) maxColumns = idsInLayer.size
+    }
+
+    val layerCount = (byLayer.maxOfOrNull { it.first } ?: 0) + 1
+    return Layout(
+      positions = positions,
+      layerCount = layerCount,
+      maxColumns = maxColumns,
+    )
+  }
+}

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/waypoints/WaypointVisualizerComposable.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/waypoints/WaypointVisualizerComposable.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -62,6 +63,20 @@ import xyz.block.trailblaze.ui.models.AppIconProvider
  * Loading concerns (filesystem walks, pack discovery) live in JVM-only callers; this
  * composable just renders whatever items it is given plus a small empty/error surface.
  */
+/**
+ * View modes for the Waypoints tab.
+ *
+ * - [Definitions] — the existing master/detail browser: filterable list on the left,
+ *   waypoint detail with selector overlays on the right. Default mode.
+ * - [Map] — the navigation graph view: waypoint nodes on a layered-DAG canvas, with
+ *   authored shortcuts as solid edges and trailheads as dashed entry edges from a
+ *   virtual "outside" anchor.
+ *
+ * Public so the desktop wrapper or a future WASM caller can pin an initial mode (e.g.
+ * deep-link "?mode=map"). The toggle UI lives inside [WaypointVisualizer].
+ */
+enum class WaypointVisualizerMode { Definitions, Map }
+
 @Composable
 fun WaypointVisualizer(
   items: List<WaypointDisplayItem>,
@@ -81,6 +96,21 @@ fun WaypointVisualizer(
    * responsibility to display, not to reorder.
    */
   matchedStepsByWaypoint: Map<String, List<Int>> = emptyMap(),
+  /**
+   * Authored shortcuts (`*.shortcut.yaml` files — `ToolYamlConfig` with a populated
+   * `shortcut: { from, to }` block). Drawn as solid edges between waypoint nodes when
+   * the user picks Map mode. Empty by default (today's repo has no authored shortcuts);
+   * the rendering is wired so the moment any author commits a shortcut, it appears.
+   */
+  shortcuts: List<ShortcutDisplayItem> = emptyList(),
+  /**
+   * Authored trailheads (`*.trailhead.yaml` files — `ToolYamlConfig` with a populated
+   * `trailhead: { to }` block). Drawn as dashed entry edges from a virtual "outside"
+   * anchor into each trailhead's target waypoint when the user picks Map mode.
+   */
+  trailheads: List<TrailheadDisplayItem> = emptyList(),
+  /** Initial mode the visualizer opens in. Default is the existing definitions browser. */
+  initialMode: WaypointVisualizerMode = WaypointVisualizerMode.Definitions,
 ) {
   var query by remember { mutableStateOf("") }
   var selectedId: String? by remember(items) { mutableStateOf(items.firstOrNull()?.definition?.id) }
@@ -137,6 +167,18 @@ fun WaypointVisualizer(
     filtered.firstOrNull { it.definition.id == selectedId } ?: filtered.firstOrNull()
   }
 
+  // Map mode resolves the selection against the *full* item set, not the filter-scoped
+  // [selected]. Otherwise typing a query that excludes the clicked node would cause the
+  // map's onSelect callback to land on `selectedId`, but [selected] would resolve to a
+  // different (filter-included) waypoint or null, and the visible highlight would bounce
+  // back. Codex / Copilot both flagged this — the filter is a Definitions-mode concern,
+  // not a Map-mode one.
+  val mapSelected = remember(items, selectedId) {
+    items.firstOrNull { it.definition.id == selectedId }
+  }
+
+  var mode by remember(initialMode) { mutableStateOf(initialMode) }
+
   Column(modifier = modifier.fillMaxSize()) {
     if (header != null) {
       header()
@@ -148,48 +190,145 @@ fun WaypointVisualizer(
       }
       return@Column
     }
-    Row(modifier = Modifier.fillMaxSize()) {
-      WaypointListPanel(
-        items = filtered,
-        totalCount = items.size,
-        query = query,
-        onQueryChange = { query = it },
-        targetCounts = targetCounts,
-        selectedTarget = selectedTarget,
-        onTargetChange = {
-          selectedTarget = it
-          selectedPlatform = null
-        },
-        platformCounts = platformCounts,
-        selectedPlatform = selectedPlatform,
-        onPlatformChange = { selectedPlatform = it },
-        availableTargets = availableTargets,
-        appIconProvider = appIconProvider,
-        selectedId = selected?.definition?.id,
-        onSelect = { selectedId = it },
-        matchedStepsByWaypoint = matchedStepsByWaypoint,
-        modifier = Modifier
-          .width(320.dp)
-          .fillMaxHeight()
-          .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
-      )
-      if (selected != null) {
-        WaypointDetailPanel(
-          item = selected,
-          matchedSteps = matchedStepsByWaypoint[selected.definition.id].orEmpty(),
-          modifier = Modifier
-            .fillMaxHeight()
-            .fillMaxWidth(),
+    WaypointModeToggle(
+      mode = mode,
+      onModeChange = { mode = it },
+      shortcutCount = shortcuts.size,
+      trailheadCount = trailheads.size,
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+    )
+    HorizontalDivider()
+    when (mode) {
+      WaypointVisualizerMode.Map -> {
+        WaypointMapCanvas(
+          waypoints = items,
+          shortcuts = shortcuts,
+          trailheads = trailheads,
+          selectedId = mapSelected?.definition?.id,
+          onSelect = { selectedId = it },
+          modifier = Modifier.fillMaxSize(),
         )
-      } else {
-        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-          SelectableText(
-            text = "No waypoints match \"$query\".",
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+      }
+      WaypointVisualizerMode.Definitions -> {
+        Row(modifier = Modifier.fillMaxSize()) {
+          WaypointListPanel(
+            items = filtered,
+            totalCount = items.size,
+            query = query,
+            onQueryChange = { query = it },
+            targetCounts = targetCounts,
+            selectedTarget = selectedTarget,
+            onTargetChange = {
+              selectedTarget = it
+              selectedPlatform = null
+            },
+            platformCounts = platformCounts,
+            selectedPlatform = selectedPlatform,
+            onPlatformChange = { selectedPlatform = it },
+            availableTargets = availableTargets,
+            appIconProvider = appIconProvider,
+            selectedId = selected?.definition?.id,
+            onSelect = { selectedId = it },
+            matchedStepsByWaypoint = matchedStepsByWaypoint,
+            modifier = Modifier
+              .width(320.dp)
+              .fillMaxHeight()
+              .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
           )
+          if (selected != null) {
+            WaypointDetailPanel(
+              item = selected,
+              matchedSteps = matchedStepsByWaypoint[selected.definition.id].orEmpty(),
+              modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(),
+            )
+          } else {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+              SelectableText(
+                text = "No waypoints match \"$query\".",
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+              )
+            }
+          }
         }
       }
     }
+  }
+}
+
+/**
+ * Top-of-tab segmented toggle for switching between [WaypointVisualizerMode.Definitions]
+ * and [WaypointVisualizerMode.Map]. Renders edge counts inline on the Map button so
+ * authors get a glanceable signal of "how many shortcuts/trailheads are loaded today"
+ * without switching modes — the issue's guidance was that today's authored set is empty
+ * but should populate as authors create files.
+ *
+ * Implemented with two stacked [Surface]s rather than `SegmentedButton` because the
+ * latter is part of a Material 3 incubator API that lands at different versions across
+ * targets — Surface + clickable is universally available on JVM and WASM.
+ */
+@Composable
+private fun WaypointModeToggle(
+  mode: WaypointVisualizerMode,
+  onModeChange: (WaypointVisualizerMode) -> Unit,
+  shortcutCount: Int,
+  trailheadCount: Int,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier = modifier,
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    WaypointModeChip(
+      label = "Definitions",
+      isSelected = mode == WaypointVisualizerMode.Definitions,
+      onClick = { onModeChange(WaypointVisualizerMode.Definitions) },
+    )
+    val mapLabel = buildString {
+      append("Map")
+      if (shortcutCount > 0 || trailheadCount > 0) {
+        append(" · ")
+        append("$shortcutCount shortcut${if (shortcutCount == 1) "" else "s"}")
+        append(", ")
+        append("$trailheadCount trailhead${if (trailheadCount == 1) "" else "s"}")
+      }
+    }
+    WaypointModeChip(
+      label = mapLabel,
+      isSelected = mode == WaypointVisualizerMode.Map,
+      onClick = { onModeChange(WaypointVisualizerMode.Map) },
+    )
+  }
+}
+
+@Composable
+private fun WaypointModeChip(label: String, isSelected: Boolean, onClick: () -> Unit) {
+  val container = if (isSelected) {
+    MaterialTheme.colorScheme.primary.copy(alpha = 0.18f)
+  } else {
+    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+  }
+  val content = if (isSelected) {
+    MaterialTheme.colorScheme.primary
+  } else {
+    MaterialTheme.colorScheme.onSurfaceVariant
+  }
+  Surface(
+    color = container,
+    contentColor = content,
+    shape = MaterialTheme.shapes.small,
+    modifier = Modifier.clickable(onClick = onClick),
+  ) {
+    Text(
+      text = label,
+      style = MaterialTheme.typography.labelMedium,
+      fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Medium,
+      modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+    )
   }
 }
 

--- a/trailblaze-ui/src/jvmTest/kotlin/xyz/block/trailblaze/ui/waypoints/WaypointVisualizerLogicTest.kt
+++ b/trailblaze-ui/src/jvmTest/kotlin/xyz/block/trailblaze/ui/waypoints/WaypointVisualizerLogicTest.kt
@@ -332,6 +332,136 @@ class WaypointVisualizerLogicTest {
     assertEquals("matched @ –", formatMatchedStepsLabel(emptyList()))
   }
 
+  // ---------- WaypointMapLayout.compute ----------
+
+  @Test
+  fun mapLayout_emptyInputProducesEmptyLayout() {
+    val out = WaypointMapLayout.compute(
+      waypointIds = emptyList(),
+      shortcuts = emptyList(),
+      trailheads = emptyList(),
+    )
+    assertTrue(out.positions.isEmpty())
+    assertEquals(0, out.layerCount)
+    assertEquals(0, out.maxColumns)
+  }
+
+  @Test
+  fun mapLayout_noShortcutsPutsAllNodesAtLayerZero() {
+    // Authored-data-empty case (today's repo): every waypoint sits at layer 0, sorted
+    // alphabetically across columns. Pin both the layer and the column so a future
+    // change to the sort or the initialization can't silently drift the layout.
+    val out = WaypointMapLayout.compute(
+      waypointIds = listOf("c", "a", "b"),
+      shortcuts = emptyList(),
+      trailheads = emptyList(),
+    )
+    assertEquals(WaypointMapLayout.GridPosition(layer = 0, column = 0), out.positions["a"])
+    assertEquals(WaypointMapLayout.GridPosition(layer = 0, column = 1), out.positions["b"])
+    assertEquals(WaypointMapLayout.GridPosition(layer = 0, column = 2), out.positions["c"])
+    assertEquals(1, out.layerCount)
+    assertEquals(3, out.maxColumns)
+  }
+
+  @Test
+  fun mapLayout_simpleChainAssignsIncreasingLayers() {
+    // a → b → c. Longest-path layering: layer(a)=0, layer(b)=1, layer(c)=2.
+    val out = WaypointMapLayout.compute(
+      waypointIds = listOf("a", "b", "c"),
+      shortcuts = listOf(
+        shortcut(from = "a", to = "b"),
+        shortcut(from = "b", to = "c"),
+      ),
+      trailheads = emptyList(),
+    )
+    assertEquals(0, out.positions.getValue("a").layer)
+    assertEquals(1, out.positions.getValue("b").layer)
+    assertEquals(2, out.positions.getValue("c").layer)
+    assertEquals(3, out.layerCount)
+    // Each layer has one node, so max column count is 1.
+    assertEquals(1, out.maxColumns)
+  }
+
+  @Test
+  fun mapLayout_pickLongestPathOverShortest() {
+    // Diamond: a → b → d AND a → d. Longest path to d is 2 hops via b, so layer(d) must
+    // pick the longer path. This is the load-bearing property — without it, edges would
+    // overshoot their target row and cross unnecessarily.
+    val out = WaypointMapLayout.compute(
+      waypointIds = listOf("a", "b", "d"),
+      shortcuts = listOf(
+        shortcut(from = "a", to = "b"),
+        shortcut(from = "b", to = "d"),
+        shortcut(from = "a", to = "d"),
+      ),
+      trailheads = emptyList(),
+    )
+    assertEquals(0, out.positions.getValue("a").layer)
+    assertEquals(1, out.positions.getValue("b").layer)
+    assertEquals(2, out.positions.getValue("d").layer, "longest path wins on diamonds")
+  }
+
+  @Test
+  fun mapLayout_danglingShortcutReferencesAreIgnored() {
+    // YAML may reference a waypoint id that's been removed but not yet cleaned up. The
+    // layout pass must skip such references; the renderer surfaces them separately.
+    // Without this check, the iteration would still run but produce a layer for an
+    // absent waypoint, which would confuse downstream column assignment.
+    val out = WaypointMapLayout.compute(
+      waypointIds = listOf("a"),
+      shortcuts = listOf(shortcut(from = "a", to = "missing")),
+      trailheads = emptyList(),
+    )
+    assertEquals(WaypointMapLayout.GridPosition(layer = 0, column = 0), out.positions["a"])
+    // "missing" must NOT appear in the output map.
+    assertTrue("missing" !in out.positions)
+  }
+
+  @Test
+  fun mapLayout_trailheadsDoNotShiftWaypointLayers() {
+    // Trailheads have no `from` — they target a waypoint via the virtual "outside"
+    // anchor that renders above the grid. The grid layout itself must therefore ignore
+    // trailheads entirely: a trailhead pointing at `home` should NOT push `home` from
+    // layer 0 to layer 1 (which would also push every shortcut chain one row down for
+    // no visual benefit). This pins that the trailhead arg is layout-inert.
+    val out = WaypointMapLayout.compute(
+      waypointIds = listOf("home", "settings"),
+      shortcuts = listOf(shortcut(from = "home", to = "settings")),
+      trailheads = listOf(
+        TrailheadDisplayItem(id = "boot", description = null, to = "home"),
+      ),
+    )
+    assertEquals(0, out.positions.getValue("home").layer)
+    assertEquals(1, out.positions.getValue("settings").layer)
+  }
+
+  @Test
+  fun mapLayout_cyclesAreBoundedByIterationCap() {
+    // a ↔ b. A naive longest-path walker grows layers without bound on a cycle. The
+    // iteration cap prevents that — both nodes land at finite layers within
+    // `waypointIds.size` rounds. We don't pin the exact layers (they're SCC-arbitrary)
+    // but we do pin "the algorithm terminates" and "both nodes are positioned."
+    val out = WaypointMapLayout.compute(
+      waypointIds = listOf("a", "b"),
+      shortcuts = listOf(
+        shortcut(from = "a", to = "b"),
+        shortcut(from = "b", to = "a"),
+      ),
+      trailheads = emptyList(),
+    )
+    assertTrue("a" in out.positions, "cycle node 'a' must still be positioned")
+    assertTrue("b" in out.positions, "cycle node 'b' must still be positioned")
+    assertTrue(out.layerCount > 0)
+  }
+
+  private fun shortcut(from: String, to: String) = ShortcutDisplayItem(
+    id = "$from-to-$to",
+    description = null,
+    from = from,
+    to = to,
+    variant = null,
+  )
+
   // ---------- resolveOverlays — bounds-less matched node ----------
 
   @Test


### PR DESCRIPTION
## Summary

Upstream sync through 2026.05.05, on top of the merged 2026.05.04 baseline. Eight dominant themes:

1. **Waypoint navigation graph view** — new `waypoint graph` CLI + live `/waypoints/graph` daemon endpoint, single-file React Flow HTML. Exposed from the Waypoints tab via an "Open Map view →" chip.
2. **`waypoint suggest-selector` CLI** — translates one element ref (as shown by `./trailblaze snapshot --all`) into pasteable waypoint-selector YAML candidates. Replaces the by-hand ref-to-selector translation that was a documented authoring pitfall.
3. **Waypoint Map visualizer (Compose)** — `WaypointMapCanvas` / `WaypointMapLayout` rework of the visualizer with shortcut + trailhead overlays.
4. **Stuck-detection threshold rework** — per-cycle-length CRITICAL thresholds in `ProgressTracking`; sliding-window grew 12 → 30; cycle-summary preserved in the terminating exception.
5. **Pack-positive LLM tool resolution** — inner-agent tool list builds from the active target's declared `tool_sets:` resolved through `TrailblazeToolSetCatalog.resolveForDriver`, with per-target custom / excluded overrides. No more catalog-wide kitchen sink.
6. **`TapOnByElementSelector` Maestro-fallback optionality** — `selector` is nullable now; accessibility-only recordings carry only `nodeSelector`. Loud-fail replaces silent no-op when nodeSelector dispatch fails and no Maestro selector is set.
7. **Image-format auto-sniffing on save** — `LogsRepo.saveScreenshotBytes` no longer accepts a caller-supplied extension; sniffs bytes via `ImageFormatDetector`. Stops `.png`-named WebP files from leaking into `logs/`.
8. **Server `additionalRouteRegistration` callback** — `ServerEndpoints.start` and `TrailblazeMcpServer.start` accept a `Routing.() -> Unit` so trailblaze-host can register routes on the daemon without inverting the dep direction.

### Waypoint navigation graph view

- New `xyz.block.trailblaze.graph` package: `WaypointGraphData` (Kotlin↔front-end JSON contract), `WaypointGraphBuilder` (waypoints + authored shortcuts/trailheads → graph), `WaypointGraphHtmlRenderer` (data-URI screenshots inlined into a self-contained HTML), `WaypointGraphEndpoint` (Ktor `GET /waypoints/graph` + `/waypoints/graph.json`, with `?root=` override resolved per-request so settings changes reflect without a daemon restart).
- New CLI: `WaypointGraphCommand` registers under `waypoint graph` and writes the same HTML to `--out` (default `./waypoint-graph.html`). Pack-bundled classpath waypoints always included; `--root` overrides the filesystem walk.
- Front-end loads React Flow + dagre at runtime via esm.sh CDN — open the HTML in any browser, share via email/Slack/zip, no Trailblaze install required on the viewer's side. `waypoint-graph-template.html` (1917 lines, checked in) is the renderer template.
- Desktop wiring: `MainTrailblazeApp` passes a `waypointGraphRouteRegistration` callback into `TrailblazeMcpServer.start` for both run modes; `TrailblazeBuiltInTabs` builds a `graphViewUrl` from the daemon's HTTP port; the Waypoints tab chip URL-encodes the current root and opens it in the default browser.

### `waypoint suggest-selector` CLI

- New `WaypointSuggestSelectorCommand` (416 lines) — loads the captured `trailblazeNodeTree` from a session log (same loader as `waypoint validate`), finds the node by short ref (`a812`-style), and runs the same `TrailblazeNodeSelectorGenerator` strategy cascade the runtime uses for tap recordings. Returns up to `--max` named candidates plus one structural-only candidate at the bottom for `forbidden:`-clause use.
- `--anchor parent-selected` composes the leaf selector with an ancestor `isSelected: true` predicate via `containsChild`, the canonical bottom-nav-tab waypoint pattern (pins identity to the *currently active* tab, not any tab with the given label).
- Inputs mirror `waypoint validate`: positional `*_TrailblazeLlmRequestLog.json` OR `--session DIR --step N` (default last step). `--ref` required.
- Registered under `WaypointCommand`'s subcommand list; CLI baselines added (`help-trailblaze-waypoint-suggest-selector.txt`, updated `help-trailblaze-waypoint.txt`); regenerated `docs/CLI.md` section.

### Waypoint Map visualizer (Compose)

- New `WaypointMapCanvas` (480) + `WaypointMapLayout` (151) replace the prior single-file visualizer; `WaypointVisualizerComposable` reworked (+176/-37) to drive the new layout.
- New `ShortcutDisplayItem` (and a `TrailheadDisplayItem` sibling) — commonMain DTOs the canvas overlays as edges. `WaypointsTabComposable` loads them at refresh time via the new `ToolYamlLoader.discoverShortcutsAndTrailheads()` and passes them through.
- Loader catches its own exceptions and returns empty edge lists rather than failing the whole tab on a single bad YAML — the Definitions view continues to function while only the Map's edge layer degrades.
- New `WaypointVisualizerLogicTest` (130 lines) covers the layout / overlay logic.

### Stuck-detection threshold rework

- Per-cycle-length CRITICAL thresholds in `ProgressTracking.kt`: `LENGTH_1_CRITICAL_REPEATS = 30`, `LENGTH_2 = 15`, `LENGTH_3 = 10`. Length-1 tolerates the most repetition because legitimate cases are common (PIN entry, "add the same item N times", scrolling). Multi-step loops (length-2/3) are far less likely to be intentional, so the bar drops, but still leaves a buffer beyond the previous flat `>= 3` threshold so the LLM can recover after the WARNING-level hint.
- All three thresholds intentionally land near 30 raw entries; `STUCK_FINGERPRINT_WINDOW` in `TrailblazeRunner` grew 12 → 30 to match (~6 KB held during a step).
- `MaxCallsLimitReachedException` now embeds the full `<tool> + args + repeat-count` cycle summary instead of collapsing to `[stuck: <toolname> in repeating cycle]` — post-mortem readers see what was looping, not just that something was.

### Pack-positive LLM tool resolution

- `TrailblazeMcpServer`'s `availableToolsProvider` now resolves per-target instead of dumping `ToolSetCategory.ALL`:
  - `target.getDeclaredToolSetIdsForDriver(driverType)` → catalog's `resolveForDriver` → `(toolClasses, yamlToolNames)`.
  - Adds `target.getCustomToolsForDriver` and `getCustomYamlToolNamesForDriver` (custom-first ordering preserved).
  - Subtracts `target.getExcludedToolsForDriver` and `getExcludedYamlToolNamesForDriver`.
  - With no active target, the LLM sees only the catalog's `always_enabled` toolsets — pack authors opt into more by declaring `tool_sets:`.
- New `TrailblazeHostAppTarget.getDeclaredToolSetIdsForDriver` (commonMain), implemented in `YamlBackedHostAppTarget` by walking `platforms.<key>.toolSets` and unioning across driver-compatible platforms.
- Inner-agent log line now reports target id, declared toolsets, custom count, excluded count, and YAML count — actionable when a tool you expected isn't in the LLM's surface.

### `TapOnByElementSelector` Maestro-fallback optionality

- `selector: TrailblazeElementSelector` becomes nullable (default `null`). Accessibility-only recordings (`nodeSelector != null`, `selector == null`) — the correct shape for Android post 100% accessibility cutover — now load and dispatch cleanly.
- `toMaestroCommands` returns `emptyList()` when `selector` is null instead of NPE'ing — the Orchestra path simply has nothing to lower.
- New `runMaestroFallbackOrFail` replaces three `super.execute(...)` call sites in the dispatch switch. When `nodeSelector` dispatch fails *and* no Maestro fallback is set, it returns `TrailblazeToolResult.Error.ExceptionThrown` with a clear message instead of letting Maestro silently no-op.
- Existing recordings that carry both selectors continue to load and dispatch unchanged.

### Image-format auto-sniffing on save

- `LogsRepo.saveScreenshotBytes` no longer takes `fileExtension` — sniffs the bytes via `ImageFormatDetector.detectFormat(bytes).fileExtension`. Historically the parameter defaulted to `"png"` and the on-device screencap path returned WebP, leading to `.png`-named files containing `RIFF...WEBP` magic bytes.
- `WaypointCaptureExampleCommand` switches to the same sniffer for the example screenshot's extension instead of trusting the source file's extension (which carried the same lie).
- `LogsRepo.getImagesForSession` and `ReportMain.IMAGE_EXTENSIONS` migrate to `TrailblazeImageFormat.entries.map { it.fileExtension }.toSet() + setOf("jpeg")` — adding a new format anywhere in the codebase makes it visible to both surfaces automatically.
- `TrailblazeMcpServer`'s screenshot-saving call site updated to drop the redundant extension argument.

### Server `additionalRouteRegistration` callback

- `ServerEndpoints.start` and `TrailblazeMcpServer.start` accept an optional `(Routing.() -> Unit)?` invoked inside the routing block, before the 404 catchall.
- Lets trailblaze-host (which owns waypoint discovery) register `/waypoints/graph[.json]` on the same Ktor server without trailblaze-server gaining a reverse dependency on host-only types.

### Shortcut + trailhead discovery

- New `ToolYamlLoader.discoverShortcutsAndTrailheads()` returns every config carrying a `shortcut:` or `trailhead:` metadata block, regardless of whether the body is `Mode.CLASS` or `Mode.TOOLS`. The existing `discoverYamlDefinedTools` filters out class-mode and was silently dropping class-bodied edges — this method is the graph view's loader of record.
- Repo currently carries zero authored `*.shortcut.yaml` / `*.trailhead.yaml` files, but the wiring is here so the moment any author commits one it shows up on the Map view automatically.

### Waypoint id convention update

- `WaypointDefinition` doc rewritten: ids are URL-style `<pack-id>/<segment>[/<segment>...]`, with `-` for multi-word atoms inside a segment. The id is **logical, not platform-tagged** — `myapp/home` represents the conceptual home screen across platforms, even though each YAML file is currently platform-specific (its selectors are tagged `androidAccessibility:` / `iosAccessibility:`).
- Files continue to live under `packs/<pack-id>/waypoints/<platform>/...` for disk-level organization. A future `platforms:` field on the schema is the planned dispatch mechanism when both Android and iOS variants share one logical id; not yet implemented because no platform-collision exists in the current dataset.

### Misc

- `WaypointsTabComposable.loadWaypoints` widened from `private` to `internal` so the new layout can drive its own load loop.
- `TrailblazeHostYamlRunner` (+5/-2), `TrailGoalPlannerSignatureTest` (+4/-1), `TrailblazeRecordingGenerator` (+2/-2), `LocalLlmSamplingSource` (+3/-6) — small follow-ons to the inner-agent tool resolution and screenshot-sniffing changes.

## Test plan

- [ ] CI green across all suites.
- [ ] `trailblaze waypoint graph` writes a self-contained HTML; opening it in a browser renders waypoints, shortcuts, and trailheads with inlined screenshots.
- [ ] Live `GET /waypoints/graph` from a running daemon renders the same data; `?root=<path>` override scopes the filesystem walk.
- [ ] Desktop Waypoints tab shows the "Open Map view →" chip and launches the browser at the daemon's URL with the current root URL-encoded.
- [ ] `trailblaze waypoint suggest-selector --ref <X> <session-log>` returns up to `--max` named candidates plus one structural-only candidate; `--anchor parent-selected` composes a `containsChild` selector under an `isSelected: true` ancestor.
- [ ] Stuck-detection: length-1 cycles tolerate ~30 consecutive identical actions before CRITICAL; length-2 needs ~15 full repeats; length-3 needs ~10. The terminating `MaxCallsLimitReachedException`'s `objectivePrompt` carries the full cycle summary.
- [ ] Inner-agent tool surface scopes to the active target's declared `tool_sets:` (plus its custom tools, minus its excluded tools); no active target falls back to `always_enabled` toolsets only.
- [ ] Accessibility-only `TapOnByElementSelector` recordings (selector=null, nodeSelector!=null) load and execute on Android; Maestro-only legacy recordings (selector!=null, nodeSelector=null) still execute on non-accessibility runtimes.
- [ ] When nodeSelector dispatch fails and no Maestro fallback is set, the tool returns an explicit error instead of silently no-op.
- [ ] `LogsRepo.saveScreenshotBytes` writes `.webp` for WebP bytes and `.png` for PNG bytes regardless of any caller-supplied hint (no more `.png`-named WebP files in `logs/`).
- [ ] `WaypointCaptureExampleCommand` writes example screenshots with extensions matching the byte payload, even when the source file is mis-extensioned.