### PR TITLE
Publish Android library variants for KMP modules

### DIFF
--- a/trailblaze-common/build.gradle.kts
+++ b/trailblaze-common/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
   }
 
   androidTarget {
+    publishLibraryVariants("release", "debug")
     compilerOptions {
       jvmTarget = JvmTarget.JVM_17
     }

--- a/trailblaze-models/build.gradle.kts
+++ b/trailblaze-models/build.gradle.kts
@@ -113,6 +113,7 @@ kotlin {
   }
 
   androidTarget {
+    publishLibraryVariants("release", "debug")
     compilerOptions {
       jvmTarget = JvmTarget.JVM_17
     }

--- a/trailblaze-quickjs-tools/build.gradle.kts
+++ b/trailblaze-quickjs-tools/build.gradle.kts
@@ -61,6 +61,7 @@ android {
 
 kotlin {
   androidTarget {
+    publishLibraryVariants("release", "debug")
     compilerOptions {
       jvmTarget = JvmTarget.JVM_17
     }

--- a/trailblaze-scripting-bundle/build.gradle.kts
+++ b/trailblaze-scripting-bundle/build.gradle.kts
@@ -50,6 +50,7 @@ android {
 
 kotlin {
   androidTarget {
+    publishLibraryVariants("release", "debug")
     compilerOptions {
       jvmTarget = JvmTarget.JVM_17
     }

--- a/trailblaze-scripting-mcp-common/build.gradle.kts
+++ b/trailblaze-scripting-mcp-common/build.gradle.kts
@@ -21,6 +21,7 @@ android {
 
 kotlin {
   androidTarget {
+    publishLibraryVariants("release", "debug")
     compilerOptions {
       jvmTarget = JvmTarget.JVM_17
     }


### PR DESCRIPTION
## Problem

The KMP modules that apply the vanniktech maven-publish plugin declare an `androidTarget` but never call `publishLibraryVariants()` (with the exception of `trailblaze-tracing`). As a result, only the `-jvm` variants are published to Maven Central — no Android AAR variants exist for:

- `trailblaze-common`
- `trailblaze-models`
- `trailblaze-quickjs-tools`
- `trailblaze-scripting-bundle`
- `trailblaze-scripting-mcp-common`

Consumers that resolve these coordinates from Maven for **on-device** Android instrumentation tests get the JVM variant via Gradle's fallback matching, and the test APK crashes at runtime with `NoClassDefFoundError` on `androidMain`-only classes (e.g. `xyz.block.trailblaze.AdbCommandUtil`). The bug is invisible inside this repo because internal consumers use `project(...)` dependencies, which bypass publication entirely.

## Change

Add `publishLibraryVariants("release", "debug")` to the `androidTarget` block of the five affected modules, matching the existing convention in `trailblaze-tracing`.

Verified with `./gradlew :trailblaze-common:tasks --all`: the `androidDebug` and `androidRelease` Maven publications now exist alongside `jvm` and `kotlinMultiplatform`.

## Note: stable releases

Even with correct artifacts, external consumers can't durably pin trailblaze today because only snapshots are published, and Maven Central snapshots are subject to ~90-day retention — pinned CI builds eventually break when the snapshot ages out. Tagged stable releases on Maven Central would remove the last reason to vendor. Happy to discuss if there's an existing plan here.