### PR TITLE
Add a per-platform Report Gallery (Android alarm clock, iOS Contacts, web Wikipedia)

### DIFF
--- a/.github/workflows/clock-trails.yml
+++ b/.github/workflows/clock-trails.yml
@@ -1,0 +1,168 @@
+name: Clock Trails
+
+# Android showcase for the docs Report Gallery: replays the recorded "set a 7:30am
+# alarm" clock trail on an emulator and exports the storyboard / animated-timeline /
+# interactive-report assets the GitHub Pages build embeds at
+# https://block.github.io/trailblaze/reports/.
+#
+# Runs on push to main ONLY — deliberately NOT on pull_request. The same clock trail is
+# already exercised on every PR by the `android-tests-host-rpc` job in pr-checks.yml
+# (its script ends with `trailblaze trail trails/clock/set-alarm-730am/android.trail.yaml`),
+# so PR-level validation is covered there. This workflow exists purely to produce the
+# gallery artifact from a main run, so there's no reason to pay for a second Android
+# emulator boot on every PR.
+on:
+  push:
+    branches: [ "main" ]
+
+# One run per ref; cancel a superseded queued run (mirrors the other trail workflows).
+concurrency:
+  group: clock-trails-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Pre-build the trailblaze uber JAR (with WASM report template embedded) once and
+  # publish it as an artifact for the downstream trails job — identical to the
+  # build-uber-jar job in wikipedia-trails.yml / pr-checks.yml. WASM is what lets
+  # `trailblaze report` emit the full interactive HTML report below.
+  build-uber-jar:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Build trailblaze uber JAR (with WASM template embedded)
+        env:
+          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true
+        run: ./scripts/install-trailblaze-source.sh
+
+      - name: Stage artifact contents
+        run: |
+          mkdir -p trailblaze-uber-jar
+          cp trailblaze-desktop/build/release/trailblaze.jar trailblaze-uber-jar/
+          cp trailblaze-desktop/build/release/trailblaze trailblaze-uber-jar/
+          ls -lh trailblaze-uber-jar/
+
+      - name: Upload uber JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trailblaze-uber-jar
+          path: trailblaze-uber-jar/
+          if-no-files-found: error
+          retention-days: 7
+
+  # Boots an Android emulator and replays the recorded clock trail via the host-RPC path
+  # (the agent loop runs in-process on the host and dispatches device tools over RPC to
+  # the bundled on-device APK). Mirrors the emulator setup of pr-checks.yml's
+  # `android-tests-host-rpc` job — the one that's reliably green — then exports the docs
+  # gallery assets from the resulting session.
+  clock-trails:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: build-uber-jar
+    env:
+      # Recordings-only — the trail has pre-recorded tool sequences, so LLM inference is
+      # never invoked. A non-empty sentinel satisfies the provider/client wiring (same
+      # pattern as android-tests-host-rpc in pr-checks.yml).
+      OPENAI_API_KEY: no-key-set
+
+    steps:
+      - name: Enable KVM group perms
+        if: runner.os == 'Linux'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls /dev/kvm
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Download prebuilt uber JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: trailblaze-uber-jar
+          path: trailblaze-uber-jar/
+
+      - name: Install trailblaze from prebuilt artifact
+        env:
+          TRAILBLAZE_ARTIFACT_DIR: ${{ github.workspace }}/trailblaze-uber-jar
+        run: ./scripts/install-trailblaze-from-artifact.sh
+
+      - name: Install ffmpeg (for the animated-timeline WebP)
+        # The docs gallery's animated timeline.webp is muxed via `ffmpeg -c:v libwebp_anim`
+        # (see pr_generate_report_assets.sh). The storyboard WebP uses bundled libwebp and
+        # does not need ffmpeg, so a missing/older ffmpeg only degrades the animation.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Create and start emulator and run the clock trail (Linux)
+        if: runner.os == 'Linux'
+        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b
+        id: run-trail
+        continue-on-error: true
+        with:
+          api-level: 34
+          arch: x86_64
+          disable-animations: true
+          disk-size: 6000M
+          heap-size: 600M
+          profile: Nexus 6
+          # Reuses the exact host-RPC script the green pr-checks job runs; it ends with
+          # `trailblaze trail trails/clock/set-alarm-730am/android.trail.yaml` and leaves
+          # the session under ~/.trailblaze/logs for the export step below.
+          script: ./.github/pr_run_android_tests_host_rpc.sh
+
+      - name: Generate docs report-gallery assets
+        # Storyboard + animated-timeline WebP + interactive HTML report, exported from the
+        # session the clock trail just produced (read from ~/.trailblaze/logs). Consumed by
+        # the GitHub Pages build for the Report Gallery. continue-on-error so a flaky
+        # encoder never reds the run; the docs fall back to the last-published asset.
+        if: always()
+        continue-on-error: true
+        run: ./.github/pr_generate_report_assets.sh
+
+      - name: Upload docs report-gallery assets
+        # Dedicated, predictably-named artifact the GitHub Pages workflow downloads from the
+        # latest completed run on main (artifact name == docs-report-<slug>).
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-report-clock
+          path: report-assets/
+          if-no-files-found: warn
+
+      - name: Fail if the clock trail failed
+        if: steps.run-trail.outcome == 'failure'
+        run: |
+          echo "Clock trail failed — failing the workflow"
+          exit 1

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -113,7 +113,11 @@ jobs:
               fi
             done
           }
+          # One per gallery platform: web (wikipedia), iOS (contacts), Android (clock).
+          # Each pulls its own docs-report-<slug> artifact from the matching trail workflow.
           fetch_assets "wikipedia-trails.yml" "docs/report-assets/wikipedia"
+          fetch_assets "ios-contacts-trails.yml" "docs/report-assets/ios-contacts"
+          fetch_assets "clock-trails.yml" "docs/report-assets/clock"
 
       - name: Build MkDocs site
         run: mkdocs build --strict

--- a/.github/workflows/ios-contacts-trails.yml
+++ b/.github/workflows/ios-contacts-trails.yml
@@ -162,6 +162,22 @@ jobs:
         continue-on-error: true
         run: ./.github/pr_generate_trailblaze_report.sh
 
+      - name: Install ffmpeg (for the animated-timeline WebP)
+        # macOS runners don't ship ffmpeg; the docs gallery's animated timeline.webp is
+        # muxed via `ffmpeg -c:v libwebp_anim`. The storyboard WebP uses bundled libwebp
+        # and needs no ffmpeg, so a brew hiccup only degrades the animation, never the run.
+        if: always()
+        continue-on-error: true
+        run: brew install ffmpeg
+
+      - name: Generate docs report-gallery assets
+        # Storyboard + animated-timeline WebP + interactive HTML report, consumed by the
+        # GitHub Pages build for the Report Gallery. continue-on-error so a flaky encoder
+        # never reds the trail job; the docs fall back to the last-published asset.
+        if: always()
+        continue-on-error: true
+        run: ./.github/pr_generate_report_assets.sh
+
       - name: Create artifacts
         if: always()
         continue-on-error: true
@@ -175,6 +191,16 @@ jobs:
           path: |
             trailblaze-logs.zip
             trailblaze_report.html
+
+      - name: Upload docs report-gallery assets
+        # Dedicated, predictably-named artifact the GitHub Pages workflow downloads from
+        # the latest completed run on main (artifact name == docs-report-<slug>).
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-report-ios-contacts
+          path: report-assets/
+          if-no-files-found: warn
 
       - name: Fail if trails failed
         if: steps.run-trails.outcome == 'failure'

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -6,9 +6,9 @@ title: Report Gallery
 
 Every Trailblaze run produces a rich, replayable session. The reports below are **not
 mockups** — they are generated automatically by Trailblaze's own CI on each push to
-`main`, exported straight from the example trails in this repository and embedded here
-by the docs build. What you see is exactly what your agent or CI produces locally with
-`trailblaze report`.
+`main`, exported straight from the example and showcase trails in this repository and
+embedded here by the docs build — one per platform (Android, iOS, web). What you see is
+exactly what your agent or CI produces locally with `trailblaze report`.
 
 Three export formats are shown for each trail:
 
@@ -28,6 +28,42 @@ Three export formats are shown for each trail:
     open offline, or attach to a PR; embedding it inline doesn't do it justice, so the
     animations link out to the real thing.
 
+## Set an alarm (Android)
+
+A recorded Android trail driving the system Clock app to set a 7:30 AM alarm, replayed on
+an emulator via Trailblaze's host-RPC Android driver — no LLM at replay time. Source:
+[`trails/clock/set-alarm-730am`](https://github.com/block/trailblaze/tree/main/trails/clock/set-alarm-730am).
+
+### Storyboard
+
+[![Set-alarm clock trail storyboard — every step tiled into a grid](report-assets/clock/storyboard.webp)](report-assets/clock/report.html)
+
+### Timeline
+
+[![Set-alarm clock trail timeline — animated walkthrough of each step](report-assets/clock/timeline.webp)](report-assets/clock/report.html)
+
+[**Open the full interactive report →**](report-assets/clock/report.html)
+
+---
+
+## Contacts (iOS)
+
+A recorded iOS trail exercising the system Contacts app — searching for, opening, and
+verifying a contact — replayed on an iOS simulator, with no LLM at replay time. Source:
+[`examples/ios-contacts`](https://github.com/block/trailblaze/tree/main/examples/ios-contacts).
+
+### Storyboard
+
+[![iOS Contacts trail storyboard — every step tiled into a grid](report-assets/ios-contacts/storyboard.webp)](report-assets/ios-contacts/report.html)
+
+### Timeline
+
+[![iOS Contacts trail timeline — animated walkthrough of each step](report-assets/ios-contacts/timeline.webp)](report-assets/ios-contacts/report.html)
+
+[**Open the full interactive report →**](report-assets/ios-contacts/report.html)
+
+---
+
 ## Wikipedia (web)
 
 A recorded web trail driven through Playwright against live `en.wikipedia.org` — no
@@ -43,11 +79,6 @@ Android emulator or iOS simulator required, and no LLM at replay time. Source:
 [![Wikipedia trail timeline — animated walkthrough of each step](report-assets/wikipedia/timeline.webp)](report-assets/wikipedia/report.html)
 
 [**Open the full interactive report →**](report-assets/wikipedia/report.html)
-
----
-
-More examples — iOS Contacts and the Android sample app — land here as their trail
-workflows are wired into the gallery pipeline.
 
 *Want this for your own app? Every `trailblaze run` produces a session you can export
 the same way — see the [CLI reference](CLI.md#trailblaze-report) for `trailblaze report`

--- a/docs_hooks.py
+++ b/docs_hooks.py
@@ -27,7 +27,8 @@ needed. Add a new trail by listing its slug in `TRAILS`.
 from pathlib import Path
 
 # Trail slugs that have a gallery section. Each maps to docs/report-assets/<slug>/.
-TRAILS = ["wikipedia"]
+# One per platform: web (wikipedia), iOS (ios-contacts), Android (clock).
+TRAILS = ["wikipedia", "ios-contacts", "clock"]
 
 _PENDING_HTML = """<!doctype html>
 <meta charset="utf-8">


### PR DESCRIPTION
## What changed

The docs [Report Gallery](https://block.github.io/trailblaze/reports/) now showcases **one real recorded run per platform** — Android, iOS, and web — instead of just Wikipedia. The lead example is the Android **alarm-clock** trail (set a 7:30 AM alarm on the system Clock app), which is a far better demo of what Trailblaze does than the web trail. Every image is a real CI-generated report (storyboard + animated timeline + interactive HTML), not a mockup; the placeholder only ever appears before a platform's first successful run.

This builds on #154 (fresh-run selection + last-published backfill) — the same durability applies to all three platforms.

## How it works

- **Android (new `clock-trails.yml`)** — replays the recorded `trails/clock/set-alarm-730am` trail on an emulator via the **host-RPC** driver (the reliably-green path, mirroring `pr-checks.yml`'s `android-tests-host-rpc` job — it reuses that job's exact `pr_run_android_tests_host_rpc.sh`, which already ends by running this very trail) and uploads a `docs-report-clock` artifact. **Runs on push to `main` only, not PRs** — the clock trail is already validated on every PR by `android-tests-host-rpc`, so there's no reason to pay for a second emulator boot per PR; this workflow exists purely to produce the gallery asset from a main run.
- **iOS (`ios-contacts-trails.yml`)** — now exports the gallery assets from the existing iOS Contacts trail: added an ffmpeg install (for the animated WebP) plus the storyboard/timeline/report generation and a `docs-report-ios-contacts` upload, mirroring the wikipedia job.
- **Pages build (`github-pages.yml`)** — the asset fetch now pulls all three platforms (`wikipedia` / `ios-contacts` / `clock`), each from its own trail workflow, with the same fresh→last-published→placeholder fallback.
- **Docs** — `docs_hooks.py` `TRAILS` adds `ios-contacts` + `clock` so strict builds get placeholders until real assets land; `docs/reports.md` gains an Android (clock) and iOS (contacts) section, ordered Android → iOS → web.

The trail-agnostic `pr_generate_report_assets.sh` (exports the newest session from `~/.trailblaze/logs`) is reused unchanged for all three.

## Validation (local)

- `mkdocs build --strict` is **green**: `docs_hooks.py` placeholder-fills `clock` + `ios-contacts`, the built site carries all three platforms' assets, and the gallery renders "Set an alarm (Android)" / "Contacts (iOS)" / "Wikipedia (web)".
- All three workflow YAMLs parse; `docs_hooks.py` imports and `TRAILS == ['wikipedia','ios-contacts','clock']`.

## Effect after merge

The first `clock-trails.yml` and updated `ios-contacts-trails.yml` runs on `main` produce their `docs-report-*` artifacts; the next Pages deploy embeds them. Until then the gallery shows the generic placeholder for those two (web is already live).

## Note on the internal mirror

`docs_hooks.py` and `docs/reports.md` also live in `squareup/trailblaze-internal` under `opensource/`; the OSS-downstream automation backports these edits there. The workflow files are OSS-only.

## Test plan

- [ ] After merge, `clock-trails.yml` and `ios-contacts-trails.yml` produce `docs-report-clock` / `docs-report-ios-contacts` artifacts on `main`.
- [ ] Next Pages deploy: fetch log shows `✓ … (fresh, run …)` for clock + ios-contacts; gallery shows three real reports.
- [ ] `docs-build-check` stays green (placeholders cover any not-yet-produced asset).