### PR TITLE
Show the Dock icon only while the window is visible

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ androidx-test-monitor = "1.8.0"
 gson = "2.13.2"
 jackson = "2.21.2"
 jansi = "2.4.1"
+jna = "5.14.0"
 jetbrains-compose-multiplatform = "1.11.1"
 # Compose Multiplatform's Material3 module ships on a separate, lagging track from the umbrella
 # version — there is no material3 1.11.0/1.11.1 stable. CMP 1.11.1's paired Material3 release is
@@ -121,6 +122,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
+jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 junit = { module = "junit:junit", version.ref = "junit" }
 junit5-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }

--- a/trailblaze-host/build.gradle.kts
+++ b/trailblaze-host/build.gradle.kts
@@ -109,6 +109,7 @@ dependencies {
   implementation(project(":trailblaze-report"))
   implementation(project(":trailblaze-server"))
   implementation(project(":trailblaze-ui"))
+  implementation(libs.jna)
 
   // Compose dependencies for JVM UI code moved from trailblaze-ui
   implementation(compose.desktop.currentOs)

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/MainTrailblazeApp.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/MainTrailblazeApp.kt
@@ -116,7 +116,11 @@ class MainTrailblazeApp(
      */
     extraDaemonRoutes: (io.ktor.server.routing.Routing.() -> Unit)? = null,
   ) {
+    val initiallyVisible = !headless && ALWAYS_SHOW_WINDOW
     TrailblazeDesktopUtil.setAppConfigForTrailblaze()
+    // Apply this immediately after configuring the Taskbar so a headless daemon never lingers
+    // in the Dock while the rest of the application initializes.
+    TrailblazeDesktopUtil.setDockIconVisible(initiallyVisible)
 
     // Set the logs directory for the FileSystemImageLoader
     setLogsDirectory(logsRepo.logsDir)
@@ -189,8 +193,13 @@ class MainTrailblazeApp(
       val currentServerState by trailblazeSavedSettingsRepo.serverStateFlow.collectAsState()
       
       // Window visibility state - starts hidden in headless mode, visible otherwise.
-      // ALWAYS_SHOW_WINDOW overrides headless to improve app discoverability on macOS.
-      var windowVisible by remember { mutableStateOf(if (headless) false else ALWAYS_SHOW_WINDOW) }
+      var windowVisible by remember { mutableStateOf(initiallyVisible) }
+
+      // On macOS, a hidden window makes Trailblaze an accessory app (tray icon only). Restoring
+      // the regular policy when the window is shown also restores its Dock/app-switcher icon.
+      LaunchedEffect(windowVisible) {
+        TrailblazeDesktopUtil.setDockIconVisible(windowVisible)
+      }
       
       // Track the AWT window for bringing to front
       var awtWindow by remember { mutableStateOf<Window?>(null) }

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/TrailblazeDesktopUtil.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/ui/TrailblazeDesktopUtil.kt
@@ -3,6 +3,9 @@ package xyz.block.trailblaze.ui
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import com.charleskorn.kaml.YamlMap
+import com.sun.jna.NativeLibrary
+import com.sun.jna.NativeLong
+import com.sun.jna.Pointer
 import xyz.block.trailblaze.bundle.yaml.YamlEmitter
 import xyz.block.trailblaze.util.DesktopOsType
 import xyz.block.trailblaze.devices.TrailblazeDevicePort
@@ -24,6 +27,10 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import xyz.block.trailblaze.util.Console
 
 object TrailblazeDesktopUtil {
+
+  private val trailblazeAppIcon by lazy {
+    ImageIO.read(TrailblazeDesktopUtil::class.java.classLoader.getResource("icons/icon.png"))
+  }
 
   /**
    * Aborts startup with a clear error if the current OS+arch is not one we ship
@@ -181,10 +188,36 @@ object TrailblazeDesktopUtil {
   fun setAppConfigForTrailblaze() {
     if (Taskbar.isTaskbarSupported()) {
       // This sets the icon shown in the macOS Dock and app switcher
+      Taskbar.getTaskbar().iconImage = trailblazeAppIcon
+    }
+  }
 
-      Taskbar.getTaskbar().apply {
-        iconImage = ImageIO.read(TrailblazeDesktopUtil::class.java.classLoader.getResource("icons/icon.png"))
+  /**
+   * Shows or hides Trailblaze in the macOS Dock and app switcher.
+   *
+   * A hidden Trailblaze window should behave as a menu-bar accessory: the daemon and tray icon
+   * keep running, but there is no inert Dock icon. Switching back to the regular activation
+   * policy before showing the window restores normal Dock and app-switcher behavior.
+   *
+   * AWT exposes APIs for setting the Dock icon image, but not for changing the application's
+   * activation policy. Use the Objective-C runtime to call `NSApplication.setActivationPolicy`.
+   * Other desktop platforms intentionally keep their existing taskbar behavior.
+   */
+  internal fun setDockIconVisible(visible: Boolean) {
+    if (DesktopOsType.current() != DesktopOsType.MAC_OS) return
+
+    try {
+      MacOsApplication.setActivationPolicy(
+        if (visible) MacOsApplication.REGULAR else MacOsApplication.ACCESSORY,
+      )
+      if (visible) {
+        // Switching from accessory back to regular recreates the Dock tile with the JVM
+        // executable's generic icon. Reapply Trailblaze's image after the policy transition.
+        setAppConfigForTrailblaze()
       }
+    } catch (e: Exception) {
+      // Losing the dynamic Dock behavior should not take down the daemon or its tray icon.
+      Console.log("Unable to update the macOS Dock icon visibility: ${e.message}")
     }
   }
 
@@ -404,5 +437,33 @@ object TrailblazeDesktopUtil {
     val gooseUrl = "goose://recipe?config=$recipeEncoded"
     Console.log(gooseUrl)
     openInDefaultBrowser(gooseUrl)
+  }
+
+  private object MacOsApplication {
+    const val REGULAR = 0L
+    const val ACCESSORY = 1L
+
+    private val objectiveC by lazy { NativeLibrary.getInstance("objc") }
+    private val getClass by lazy { objectiveC.getFunction("objc_getClass") }
+    private val registerSelector by lazy { objectiveC.getFunction("sel_registerName") }
+    private val sendMessage by lazy { objectiveC.getFunction("objc_msgSend") }
+
+    fun setActivationPolicy(policy: Long) {
+      val applicationClass = getClass.invokePointer(arrayOf("NSApplication"))
+      check(applicationClass != Pointer.NULL) { "NSApplication class is unavailable" }
+
+      val application = sendMessage.invokePointer(
+        arrayOf(applicationClass, selector("sharedApplication")),
+      )
+      check(application != Pointer.NULL) { "NSApplication.sharedApplication is unavailable" }
+
+      val succeeded = sendMessage.invokeInt(
+        arrayOf(application, selector("setActivationPolicy:"), NativeLong(policy)),
+      ) != 0
+      check(succeeded) { "NSApplication rejected activation policy $policy" }
+    }
+
+    private fun selector(name: String): Pointer =
+      registerSelector.invokePointer(arrayOf(name))
   }
 }


### PR DESCRIPTION
Use JNA to switch macOS between accessory and regular activation policies as window visibility changes. This keeps the daemon available through its system tray icon without leaving an inert Dock icon when the window is closed.

Reapply `icons/icon.png` after restoring the regular policy because macOS recreates the Dock tile with the generic JVM executable icon.