### PR TITLE
Add top-level daemon stop flag

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -62,6 +62,7 @@ It does not reap device-scoped per-device sessions; use `app --stop` for those.
 
 | Option | Description | Default |
 |--------|-------------|---------|
+| `--stop` | Stop the running daemon and exit. | - |
 | `-h`, `--help` | Show this help message and exit. | - |
 | `-V`, `--version` | Print version information and exit. | - |
 

--- a/scripts/trailblaze
+++ b/scripts/trailblaze
@@ -4,6 +4,7 @@
 #
 # Usage:
 #   ./trailblaze                     - Launch desktop GUI
+#   ./trailblaze --stop              - Stop the daemon
 #   ./trailblaze app --headless      - Start headless daemon
 #   ./trailblaze app --stop          - Stop the daemon
 #   ./trailblaze blaze "objective"   - Take a UI action (auto-starts daemon)
@@ -588,7 +589,7 @@ elif ([ "$1" = "trail" ] || [ "$1" = "run" ] || [ "$1" = "blaze" ] || [ "$1" = "
     RUN_EXIT=$?
 
     # Keep daemon alive for all commands so subsequent runs reuse it.
-    # Use `./trailblaze app --stop` to shut it down explicitly.
+    # Use `./trailblaze --stop` to shut it down explicitly.
     exit $RUN_EXIT
 elif [ ${#ARGS_ARRAY[@]} -gt 0 ]; then
     # CLI command mode (config, auth, etc.)

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/TrailblazeCli.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/TrailblazeCli.kt
@@ -44,6 +44,7 @@ internal const val RECORDING_LOG_STABILITY_POLL_MS = 2_000L
  *
  * Usage:
  *   trailblaze                     - Show help
+ *   trailblaze --stop              - Stop the daemon
  *   trailblaze app                 - Launch desktop GUI
  *   trailblaze app --headless      - Start headless daemon
  *   trailblaze config target myapp                                 - Set target app
@@ -462,6 +463,12 @@ class TrailblazeCliCommand(
   )
   internal var showAll: Boolean = false
 
+  @CommandLine.Option(
+    names = ["--stop"],
+    description = ["Stop the running daemon and exit."],
+  )
+  internal var stop: Boolean = false
+
   /**
    * Returns the effective HTTP port.
    *
@@ -486,6 +493,10 @@ class TrailblazeCliCommand(
   }
 
   override fun call(): Int {
+    if (stop) {
+      return shutdownDaemonAndWait(getEffectivePort())
+    }
+
     // No subcommand → show help. Use `trailblaze app` to launch the desktop GUI.
     //
     // Mirror the renderer wiring that `TrailblazeCli.run` and `executeForDaemon` apply to

--- a/trailblaze-host/src/test/java/xyz/block/trailblaze/cli/CliCommandValidationTest.kt
+++ b/trailblaze-host/src/test/java/xyz/block/trailblaze/cli/CliCommandValidationTest.kt
@@ -26,6 +26,18 @@ import kotlin.test.assertTrue
  */
 class CliCommandValidationTest {
 
+  @Test
+  fun `root parses --stop as a daemon shutdown request`() {
+    val root = TrailblazeCliCommand(
+      appProvider = { error("appProvider must not be invoked during option parsing") },
+      configProvider = { error("configProvider must not be invoked during option parsing") },
+    )
+
+    CommandLine(root).parseArgs("--stop")
+
+    assertTrue(root.stop, "`trailblaze --stop` must route through the root shutdown path")
+  }
+
   /**
    * Runs [block] with `trailblaze.appdata.dir` pointed at a fresh, throwaway
    * directory so the test can mutate `CliConfigHelper` without leaking state to

--- a/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze.txt
+++ b/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze.txt
@@ -5,9 +5,10 @@
 # Reviewers: scrutinize diffs to baselines the same way you would scrutinize a UI screenshot —
 # small wording / spacing changes can be intentional or accidental.
 # ----------------------------------------------------------------------
-Usage: trailblaze [-hV] [COMMAND]
+Usage: trailblaze [-hV] [--stop] [COMMAND]
 Trailblaze - AI-powered device automation
   -h, --help      Show this help message and exit.
+      --stop      Stop the running daemon and exit.
   -V, --version   Print version information and exit.
 
   step, blaze  Run one step — describe what you want, the built-in agent picks


### PR DESCRIPTION
Route `trailblaze --stop` through the same shutdown-and-wait path as `trailblaze app --stop`, giving the CLI a Gradle-style way to terminate the background process. Surface the flag in launcher guidance and root help.