### PR TITLE
Run Android on-device checks without waiting for the uber JAR

### DIFF
--- a/.github/pr_generate_trailblaze_report.sh
+++ b/.github/pr_generate_trailblaze_report.sh
@@ -1,15 +1,23 @@
 #!/usr/bin/env bash
 # Generate the CI `trailblaze_report.html` index for the trail run.
 #
-# Runs entirely off the prebuilt Trailblaze CLI installed on $PATH by the
-# upstream `build-uber-jar` job's `install-trailblaze-from-artifact.sh` step.
-# The WASM report template is bundled into the uber JAR's classpath (the
-# build-uber-jar job invokes Gradle with -Ptrailblaze.wasm=true), so there's
-# no separate `:trailblaze-ui:wasmJsBrowserProductionWebpack` /
-# `:trailblaze-report:run` Gradle dance — just one `trailblaze report` call.
+# Uses the prebuilt Trailblaze CLI when a workflow installed one from the
+# `build-uber-jar` artifact. Jobs that intentionally run without that artifact
+# (notably Android on-device instrumentation) fall back to the repo-local
+# `./trailblaze` launcher, which runs from source in GitHub Actions.
 set -e
 
 TRAILBLAZE_LOGS_DIR="$(pwd)/trailblaze-logs"
+TRAILBLAZE_BIN="${TRAILBLAZE_BIN:-trailblaze}"
+if ! command -v "$TRAILBLAZE_BIN" >/dev/null 2>&1; then
+  if [ -x "./trailblaze" ]; then
+    TRAILBLAZE_BIN="./trailblaze"
+  else
+    echo "WARNING: trailblaze command not found and ./trailblaze is not executable - skipping report generation"
+    echo "========================================="
+    exit 0
+  fi
+fi
 
 echo "========================================="
 
@@ -20,7 +28,7 @@ if [ ! -d "$TRAILBLAZE_LOGS_DIR" ] || [ -z "$(ls -A "$TRAILBLAZE_LOGS_DIR" 2>/de
 fi
 
 echo "Generating Trailblaze report..."
-trailblaze report --output-dir "$TRAILBLAZE_LOGS_DIR"
+"$TRAILBLAZE_BIN" report --output-dir "$TRAILBLAZE_LOGS_DIR"
 
 # `trailblaze report --output-dir` writes `report.html` under the canonical name; the
 # downstream artifact step (.github/pr_create_artifacts.sh) and the workflow upload

--- a/.github/pr_generate_trailblaze_report.sh
+++ b/.github/pr_generate_trailblaze_report.sh
@@ -3,21 +3,12 @@
 #
 # Uses the prebuilt Trailblaze CLI when a workflow installed one from the
 # `build-uber-jar` artifact. Jobs that intentionally run without that artifact
-# (notably Android on-device instrumentation) fall back to the repo-local
-# `./trailblaze` launcher, which runs from source in GitHub Actions.
+# (notably Android on-device instrumentation) use the standalone report generator
+# against the pulled logs directory instead of launching the full desktop CLI.
 set -e
 
 TRAILBLAZE_LOGS_DIR="$(pwd)/trailblaze-logs"
 TRAILBLAZE_BIN="${TRAILBLAZE_BIN:-trailblaze}"
-if ! command -v "$TRAILBLAZE_BIN" >/dev/null 2>&1; then
-  if [ -x "./trailblaze" ]; then
-    TRAILBLAZE_BIN="./trailblaze"
-  else
-    echo "WARNING: trailblaze command not found and ./trailblaze is not executable - skipping report generation"
-    echo "========================================="
-    exit 0
-  fi
-fi
 
 echo "========================================="
 
@@ -28,15 +19,25 @@ if [ ! -d "$TRAILBLAZE_LOGS_DIR" ] || [ -z "$(ls -A "$TRAILBLAZE_LOGS_DIR" 2>/de
 fi
 
 echo "Generating Trailblaze report..."
-"$TRAILBLAZE_BIN" report --output-dir "$TRAILBLAZE_LOGS_DIR"
+if command -v "$TRAILBLAZE_BIN" >/dev/null 2>&1; then
+  "$TRAILBLAZE_BIN" report --output-dir "$TRAILBLAZE_LOGS_DIR"
 
-# `trailblaze report --output-dir` writes `report.html` under the canonical name; the
-# downstream artifact step (.github/pr_create_artifacts.sh) and the workflow upload
-# paths still expect the legacy `trailblaze_report.html` name. Rename in place to
-# avoid cascading the change into four workflow files. Best-effort: a missing input
-# means the CLI emitted nothing (already logged above) and we just skip silently.
-if [ -f "$TRAILBLAZE_LOGS_DIR/report.html" ]; then
-  mv -f "$TRAILBLAZE_LOGS_DIR/report.html" "$TRAILBLAZE_LOGS_DIR/trailblaze_report.html"
+  # `trailblaze report --output-dir` writes `report.html` under the canonical name; the
+  # downstream artifact step (.github/pr_create_artifacts.sh) and the workflow upload
+  # paths still expect the legacy `trailblaze_report.html` name. Rename in place to
+  # avoid cascading the change into four workflow files. Best-effort: a missing input
+  # means the CLI emitted nothing (already logged above) and we just skip silently.
+  if [ -f "$TRAILBLAZE_LOGS_DIR/report.html" ]; then
+    mv -f "$TRAILBLAZE_LOGS_DIR/report.html" "$TRAILBLAZE_LOGS_DIR/trailblaze_report.html"
+  fi
+elif [ -x "./gradlew" ]; then
+  ./gradlew :trailblaze-report:generateReportTemplate -Ptrailblaze.wasm=true
+  cp trailblaze-report/build/report-template/trailblaze_report.html trailblaze_report_template.html
+  ./gradlew :trailblaze-report:run -Ptrailblaze.wasm=true --args="$TRAILBLAZE_LOGS_DIR"
+else
+  echo "WARNING: trailblaze command not found and ./gradlew is not executable - skipping report generation"
+  echo "========================================="
+  exit 0
 fi
 
 echo "Checking for generated report..."

--- a/.github/pr_run_android_tests_on_device.sh
+++ b/.github/pr_run_android_tests_on_device.sh
@@ -18,29 +18,34 @@ echo "Starting Android Test Execution (on-device)"
 echo "Working directory: $(pwd)"
 echo "========================================="
 
-# Start Trailblaze server in background. The CLI was installed onto $PATH by
-# the workflow's `install-trailblaze-from-artifact.sh` step (from the upstream
-# `build-uber-jar` job's prebuilt JAR), so `trailblaze` here runs via
-# `java -jar` — no Gradle compile, no daemon start. `app --foreground
-# --headless` keeps the JVM in the foreground so backgrounding with `&` lets
-# us poll the HTTPS port until ready. The `app` subcommand is required —
-# bare `--headless` raises "Unknown option: '--headless'".
+# Start Trailblaze server in background. The on-device instrumentation path
+# only needs a runnable host server; it does not need the release uber JAR
+# artifact. In GitHub Actions, the repo-local `./trailblaze` launcher defaults
+# to Gradle/source mode, so this job can run in parallel with the separate
+# `build-uber-jar` job instead of waiting for the packaged CLI artifact.
+# `app --foreground --headless` keeps the JVM in the foreground so backgrounding
+# with `&` lets us poll the HTTPS port until ready. The `app` subcommand is
+# required — bare `--headless` raises "Unknown option: '--headless'".
 echo "Starting Trailblaze server..."
-trailblaze app --foreground --headless > /tmp/trailblaze.log 2>&1 &
-TRAILBLAZE_PID=$!
-echo "Trailblaze server started with PID: $TRAILBLAZE_PID"
-echo "Waiting for Trailblaze server to be ready on port $TRAILBLAZE_HTTPS_PORT (this may take up to 2 minutes)..."
-sleep 10
-for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-  nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1 && break || (echo "Attempt $attempt/20..." && sleep 5)
-done
-if ! nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1; then
-  echo "ERROR: Trailblaze server failed to start on port $TRAILBLAZE_HTTPS_PORT"
-  echo "=== Trailblaze logs ==="
-  cat /tmp/trailblaze.log
-  TEST_FAILED=true
+if [ "$TEST_FAILED" != "true" ]; then
+  ./trailblaze app --foreground --headless > /tmp/trailblaze.log 2>&1 &
+  TRAILBLAZE_PID=$!
+  echo "Trailblaze server started with PID: $TRAILBLAZE_PID"
+  echo "Waiting for Trailblaze server to be ready on port $TRAILBLAZE_HTTPS_PORT (this may take up to 2 minutes)..."
+  sleep 10
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1 && break || (echo "Attempt $attempt/20..." && sleep 5)
+  done
+  if ! nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1; then
+    echo "ERROR: Trailblaze server failed to start on port $TRAILBLAZE_HTTPS_PORT"
+    echo "=== Trailblaze logs ==="
+    cat /tmp/trailblaze.log
+    TEST_FAILED=true
+  else
+    echo "✓ Trailblaze server is running on port $TRAILBLAZE_HTTPS_PORT!"
+  fi
 else
-  echo "✓ Trailblaze server is running on port $TRAILBLAZE_HTTPS_PORT!"
+  echo "Skipping Trailblaze server startup because setup failed"
 fi
 echo "========================================="
 

--- a/.github/pr_run_android_tests_on_device.sh
+++ b/.github/pr_run_android_tests_on_device.sh
@@ -1,14 +1,9 @@
 #!/usr/bin/env bash
 # On-device path: runs the trail through `connectedDebugAndroidTest` (classic JUnit
 # instrumentation). The test logic executes inside the test process on the emulator
-# and talks to the headless desktop server on the default HTTPS port for agent orchestration.
+# and writes Trailblaze logs/screenshots to the device's Downloads directory.
 # Note: intentionally not using set -e so that log collection always runs even if build/tests fail
 TRAILBLAZE_LOGS_DIR="$(pwd)/trailblaze-logs"
-
-# Must match TrailblazeDevicePort.TRAILBLAZE_DEFAULT_HTTPS_PORT
-# (= TRAILBLAZE_DEFAULT_HTTP_PORT + 1 = 52525 + 1).
-TRAILBLAZE_HTTPS_PORT=52526
-TRAILBLAZE_LOCAL_LOGS_DIR="$HOME/.trailblaze/logs"
 
 # Create logs directory early so it always exists for downstream steps
 mkdir -p "$TRAILBLAZE_LOGS_DIR"
@@ -16,46 +11,6 @@ mkdir -p "$TRAILBLAZE_LOGS_DIR"
 echo "========================================="
 echo "Starting Android Test Execution (on-device)"
 echo "Working directory: $(pwd)"
-echo "========================================="
-
-# Assemble before starting the source-mode host server. `./trailblaze app`
-# launches Gradle in the background in GitHub Actions, and running another
-# Gradle invocation against the same checkout while that compile is still in
-# flight can corrupt Kotlin incremental cache ownership.
-echo "Assembling Android Tests..."
-./gradlew :examples:assembleDebugAndroidTest || TEST_FAILED=true
-echo "========================================="
-
-# Start Trailblaze server in background. The on-device instrumentation path
-# only needs a runnable host server; it does not need the release uber JAR
-# artifact. In GitHub Actions, the repo-local `./trailblaze` launcher defaults
-# to Gradle/source mode, so this job can run in parallel with the separate
-# `build-uber-jar` job instead of waiting for the packaged CLI artifact.
-# `app --foreground --headless` keeps the JVM in the foreground so backgrounding
-# with `&` lets us poll the HTTPS port until ready. The `app` subcommand is
-# required — bare `--headless` raises "Unknown option: '--headless'".
-echo "Starting Trailblaze server..."
-if [ "$TEST_FAILED" != "true" ]; then
-  ./trailblaze app --foreground --headless > /tmp/trailblaze.log 2>&1 &
-  TRAILBLAZE_PID=$!
-  echo "Trailblaze server started with PID: $TRAILBLAZE_PID"
-  echo "Waiting for Trailblaze server to be ready on port $TRAILBLAZE_HTTPS_PORT (this may take several minutes on a cold source build)..."
-  sleep 10
-  for attempt in $(seq 1 120); do
-    nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1 && break || (echo "Attempt $attempt/120..." && sleep 5)
-  done
-  if ! nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1; then
-    echo "ERROR: Trailblaze server failed to start on port $TRAILBLAZE_HTTPS_PORT"
-    echo "=== Trailblaze logs ==="
-    cat /tmp/trailblaze.log
-    kill "$TRAILBLAZE_PID" 2>/dev/null || echo "Trailblaze server already stopped"
-    TEST_FAILED=true
-  else
-    echo "✓ Trailblaze server is running on port $TRAILBLAZE_HTTPS_PORT!"
-  fi
-else
-  echo "Skipping Trailblaze server startup because setup failed"
-fi
 echo "========================================="
 
 # Start capturing logcat
@@ -70,7 +25,7 @@ if [ "$TEST_FAILED" != "true" ]; then
   echo "Running Android Tests..."
   ./gradlew --info :examples:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="xyz.block.trailblaze.examples.clock.ClockTest" || TEST_FAILED=true
 else
-  echo "Skipping test execution because an earlier step (server start or assembly) failed"
+  echo "Skipping test execution because setup failed"
 fi
 
 echo "========================================="
@@ -95,34 +50,12 @@ echo "Checking pulled logs..."
 ls -laR "$TRAILBLAZE_LOGS_DIR"
 echo "Total files pulled: $(find "$TRAILBLAZE_LOGS_DIR" -type f 2>/dev/null | wc -l)"
 
-echo "Checking contents of $TRAILBLAZE_LOCAL_LOGS_DIR..."
-if [ -d "$TRAILBLAZE_LOCAL_LOGS_DIR" ]; then
-  ls -laR "$TRAILBLAZE_LOCAL_LOGS_DIR"
-  echo "Total files in local logs: $(find "$TRAILBLAZE_LOCAL_LOGS_DIR" -type f 2>/dev/null | wc -l)"
-else
-  echo "Directory $TRAILBLAZE_LOCAL_LOGS_DIR does not exist"
-fi
-
-echo "Copying logs from $TRAILBLAZE_LOCAL_LOGS_DIR to $TRAILBLAZE_LOGS_DIR..."
-mkdir -p "$TRAILBLAZE_LOGS_DIR"
-cp -r "$TRAILBLAZE_LOCAL_LOGS_DIR"/* "$TRAILBLAZE_LOGS_DIR/" 2>/dev/null || echo "No logs found in $TRAILBLAZE_LOCAL_LOGS_DIR"
-
-# Copy server log for debugging
-if [ -f /tmp/trailblaze.log ]; then
-  cp /tmp/trailblaze.log "$TRAILBLAZE_LOGS_DIR/trailblaze-server.log"
-  echo "Copied server log to $TRAILBLAZE_LOGS_DIR/trailblaze-server.log"
-fi
-
-# Cleanup: Kill background servers
+# Cleanup: Kill background log collection
 echo "========================================="
 echo "Cleaning up background processes..."
 if [ -n "$LOGCAT_PID" ]; then
   echo "Stopping logcat capture (PID: $LOGCAT_PID)..."
   kill $LOGCAT_PID 2>/dev/null || echo "Logcat capture already stopped"
-fi
-if [ -n "$TRAILBLAZE_PID" ]; then
-  echo "Stopping Trailblaze server (PID: $TRAILBLAZE_PID)..."
-  kill $TRAILBLAZE_PID 2>/dev/null || echo "Trailblaze server already stopped"
 fi
 echo "✓ Cleanup complete"
 echo "========================================="

--- a/.github/pr_run_android_tests_on_device.sh
+++ b/.github/pr_run_android_tests_on_device.sh
@@ -18,6 +18,14 @@ echo "Starting Android Test Execution (on-device)"
 echo "Working directory: $(pwd)"
 echo "========================================="
 
+# Assemble before starting the source-mode host server. `./trailblaze app`
+# launches Gradle in the background in GitHub Actions, and running another
+# Gradle invocation against the same checkout while that compile is still in
+# flight can corrupt Kotlin incremental cache ownership.
+echo "Assembling Android Tests..."
+./gradlew :examples:assembleDebugAndroidTest || TEST_FAILED=true
+echo "========================================="
+
 # Start Trailblaze server in background. The on-device instrumentation path
 # only needs a runnable host server; it does not need the release uber JAR
 # artifact. In GitHub Actions, the repo-local `./trailblaze` launcher defaults
@@ -31,15 +39,16 @@ if [ "$TEST_FAILED" != "true" ]; then
   ./trailblaze app --foreground --headless > /tmp/trailblaze.log 2>&1 &
   TRAILBLAZE_PID=$!
   echo "Trailblaze server started with PID: $TRAILBLAZE_PID"
-  echo "Waiting for Trailblaze server to be ready on port $TRAILBLAZE_HTTPS_PORT (this may take up to 2 minutes)..."
+  echo "Waiting for Trailblaze server to be ready on port $TRAILBLAZE_HTTPS_PORT (this may take several minutes on a cold source build)..."
   sleep 10
-  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
-    nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1 && break || (echo "Attempt $attempt/20..." && sleep 5)
+  for attempt in $(seq 1 120); do
+    nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1 && break || (echo "Attempt $attempt/120..." && sleep 5)
   done
   if ! nc -z localhost "$TRAILBLAZE_HTTPS_PORT" > /dev/null 2>&1; then
     echo "ERROR: Trailblaze server failed to start on port $TRAILBLAZE_HTTPS_PORT"
     echo "=== Trailblaze logs ==="
     cat /tmp/trailblaze.log
+    kill "$TRAILBLAZE_PID" 2>/dev/null || echo "Trailblaze server already stopped"
     TEST_FAILED=true
   else
     echo "✓ Trailblaze server is running on port $TRAILBLAZE_HTTPS_PORT!"
@@ -57,9 +66,6 @@ echo "Logcat capture started with PID: $LOGCAT_PID"
 echo "========================================="
 
 # Run Android Tests
-echo "Assembling Android Tests..."
-./gradlew :examples:assembleDebugAndroidTest || TEST_FAILED=true
-
 if [ "$TEST_FAILED" != "true" ]; then
   echo "Running Android Tests..."
   ./gradlew --info :examples:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class="xyz.block.trailblaze.examples.clock.ClockTest" || TEST_FAILED=true

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -383,7 +383,6 @@ jobs:
   android-tests-on-device:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: build-uber-jar
     env:
       # These CI checks replay recorded trails, so LLM inference is never invoked.
       # A non-empty sentinel value is required to satisfy the provider/client wiring
@@ -411,25 +410,8 @@ jobs:
           distribution: zulu
           java-version: 17
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-
-      - name: Download prebuilt uber JAR
-        uses: actions/download-artifact@v4
-        with:
-          name: trailblaze-uber-jar
-          path: trailblaze-uber-jar/
-
-      - name: Install trailblaze from prebuilt artifact
-        # Lays down `~/.trailblaze/install/trailblaze.jar` + launcher, then
-        # symlinks `trailblaze` onto $PATH. Downstream `trailblaze` CLI
-        # invocations skip Gradle entirely and run `java -jar` directly.
-        env:
-          TRAILBLAZE_ARTIFACT_DIR: ${{ github.workspace }}/trailblaze-uber-jar
-        run: ./scripts/install-trailblaze-from-artifact.sh
 
       - name: Create and start emulator and run tests (Linux)
         if: runner.os == 'Linux'

--- a/trailblaze-desktop/build.gradle.kts
+++ b/trailblaze-desktop/build.gradle.kts
@@ -231,16 +231,6 @@ tasks.matching { it.name == "packageUberJarForCurrentOS" }.configureEach {
   }
 }
 
-// Source-mode launches (`./trailblaze ...` in CI, or `./trailblaze --gradle ...`
-// locally) run this module's Compose Desktop `run` task. The app compiles workspace
-// trailmaps during startup, and meta-only scripted-tool descriptors need the
-// analyzer tooling under `sdks/typescript/node_modules`. Wire the same SDK install
-// task that the packaging/codegen paths use so source launches do not fail before
-// any Android instrumentation work starts.
-tasks.matching { it.name == "run" }.configureEach {
-  dependsOn(":trailblaze-scripting-subprocess:installTrailblazeScriptingSdk")
-}
-
 val releaseArtifacts by tasks.registering(Copy::class) {
   description = "Builds the release JAR artifact for distribution"
   group = "distribution"

--- a/trailblaze-desktop/build.gradle.kts
+++ b/trailblaze-desktop/build.gradle.kts
@@ -231,6 +231,16 @@ tasks.matching { it.name == "packageUberJarForCurrentOS" }.configureEach {
   }
 }
 
+// Source-mode launches (`./trailblaze ...` in CI, or `./trailblaze --gradle ...`
+// locally) run this module's Compose Desktop `run` task. The app compiles workspace
+// trailmaps during startup, and meta-only scripted-tool descriptors need the
+// analyzer tooling under `sdks/typescript/node_modules`. Wire the same SDK install
+// task that the packaging/codegen paths use so source launches do not fail before
+// any Android instrumentation work starts.
+tasks.matching { it.name == "run" }.configureEach {
+  dependsOn(":trailblaze-scripting-subprocess:installTrailblazeScriptingSdk")
+}
+
 val releaseArtifacts by tasks.registering(Copy::class) {
   description = "Builds the release JAR artifact for distribution"
   group = "distribution"


### PR DESCRIPTION
Android on-device PR checks now run like the device-farm path: start an emulator, run the Clock instrumentation test on the device, pull `/sdcard/Download/trailblaze-logs`, and build artifacts from those pulled logs. The instrumentation logger already writes to disk when no log server is available, so this job no longer starts a host Trailblaze daemon or source-mode desktop app.

This keeps `android-tests-on-device` parallel with `build-uber-jar`, while the jobs that do need the packaged artifact (`android-tests-host-rpc`, Wikipedia, and iOS) still depend on it.

The on-device workflow also no longer runs a separate `android-actions/setup-android` step. The emulator-runner action owns SDK/emulator setup for the script it runs, and the extra setup step was hitting a flaky `sdkmanager tools` emulator download/unzip path before tests even started.

Report generation now has two paths: jobs with the packaged CLI keep using `trailblaze report --output-dir`, while jobs without that artifact use the standalone `:trailblaze-report` generator directly against the pulled logs directory. That avoids launching the desktop/source CLI, avoids Playwright browser setup, and reads the correct `trailblaze-logs` directory instead of `~/.trailblaze/logs`.

Implementation details:
- Removed the `build-uber-jar` dependency and artifact install steps from `android-tests-on-device`.
- Removed the redundant standalone Android SDK setup step from `android-tests-on-device`.
- Simplified `.github/pr_run_android_tests_on_device.sh` to run only `connectedDebugAndroidTest`, then pull `/sdcard/Download/trailblaze-logs` from the emulator.
- Removed the on-device job's host daemon startup, readiness polling, local daemon-log copying, and background server cleanup.
- Updated `.github/pr_generate_trailblaze_report.sh` so no-artifact jobs generate the WASM template and run `:trailblaze-report:run` against the pulled logs directory.

Test plan:
- [x] YAML parse for all `.github/workflows/*.yml`
- [x] `bash -n .github/pr_run_android_tests_on_device.sh .github/pr_generate_trailblaze_report.sh`
- [x] `git diff --check`
- [x] `./gradlew :examples:connectedDebugAndroidTest --dry-run -Pandroid.testInstrumentationRunnerArguments.class="xyz.block.trailblaze.examples.clock.ClockTest"`
- [x] `./gradlew :trailblaze-report:generateReportTemplate :trailblaze-report:run -Ptrailblaze.wasm=true --dry-run --args="$(pwd)/trailblaze-logs"`
- [x] Parsed `pr-checks.yml` job dependencies and confirmed `android-tests-on-device` has no `needs` edge while artifact consumers still depend on `build-uber-jar`
- [x] Parsed `android-tests-on-device` steps and confirmed it no longer invokes `android-actions/setup-android`
