### PR TITLE
Use relative report-asset links so the docs gallery renders everywhere, not just on Pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,17 +27,17 @@ from the Android, iOS, and web trails in this repo — no mockups. Click through
 full interactive reports, or browse the [Report Gallery](reports.md) for more.
 
 <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: 1rem; align-items: start; margin: 1.5rem 0;">
-  <a href="/trailblaze/report-assets/clock/report.html" style="display: block; text-decoration: none;">
+  <a href="report-assets/clock/report.html" style="display: block; text-decoration: none;">
     <strong>Android</strong>
-    <img src="/trailblaze/report-assets/clock/timeline.webp" alt="Animated timeline of a recorded Trailblaze run setting an Android Clock alarm" style="display: block; width: 100%; margin-top: .5rem;" />
+    <img src="report-assets/clock/timeline.webp" alt="Animated timeline of a recorded Trailblaze run setting an Android Clock alarm" style="display: block; width: 100%; margin-top: .5rem;" />
   </a>
-  <a href="/trailblaze/report-assets/ios-contacts/report.html" style="display: block; text-decoration: none;">
+  <a href="report-assets/ios-contacts/report.html" style="display: block; text-decoration: none;">
     <strong>iOS</strong>
-    <img src="/trailblaze/report-assets/ios-contacts/timeline.webp" alt="Animated timeline of a recorded Trailblaze run exercising the iOS Contacts app" style="display: block; width: 100%; margin-top: .5rem;" />
+    <img src="report-assets/ios-contacts/timeline.webp" alt="Animated timeline of a recorded Trailblaze run exercising the iOS Contacts app" style="display: block; width: 100%; margin-top: .5rem;" />
   </a>
-  <a href="/trailblaze/report-assets/wikipedia/report.html" style="display: block; text-decoration: none;">
+  <a href="report-assets/wikipedia/report.html" style="display: block; text-decoration: none;">
     <strong>Web</strong>
-    <img src="/trailblaze/report-assets/wikipedia/timeline.webp" alt="Animated timeline of a recorded Trailblaze run against live Wikipedia" style="display: block; width: 100%; margin-top: .5rem;" />
+    <img src="report-assets/wikipedia/timeline.webp" alt="Animated timeline of a recorded Trailblaze run against live Wikipedia" style="display: block; width: 100%; margin-top: .5rem;" />
   </a>
 </div>
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -36,13 +36,13 @@ an emulator via Trailblaze's host-RPC Android driver — no LLM at replay time. 
 
 ### Storyboard
 
-[![Set-alarm clock trail storyboard — every step tiled into a grid](/trailblaze/report-assets/clock/storyboard.webp)](/trailblaze/report-assets/clock/report.html)
+[![Set-alarm clock trail storyboard — every step tiled into a grid](report-assets/clock/storyboard.webp)](report-assets/clock/report.html)
 
 ### Timeline
 
-[![Set-alarm clock trail timeline — animated walkthrough of each step](/trailblaze/report-assets/clock/timeline.webp)](/trailblaze/report-assets/clock/report.html)
+[![Set-alarm clock trail timeline — animated walkthrough of each step](report-assets/clock/timeline.webp)](report-assets/clock/report.html)
 
-[**Open the full interactive report →**](/trailblaze/report-assets/clock/report.html)
+[**Open the full interactive report →**](report-assets/clock/report.html)
 
 ---
 
@@ -54,13 +54,13 @@ verifying a contact — replayed on an iOS simulator, with no LLM at replay time
 
 ### Storyboard
 
-[![iOS Contacts trail storyboard — every step tiled into a grid](/trailblaze/report-assets/ios-contacts/storyboard.webp)](/trailblaze/report-assets/ios-contacts/report.html)
+[![iOS Contacts trail storyboard — every step tiled into a grid](report-assets/ios-contacts/storyboard.webp)](report-assets/ios-contacts/report.html)
 
 ### Timeline
 
-[![iOS Contacts trail timeline — animated walkthrough of each step](/trailblaze/report-assets/ios-contacts/timeline.webp)](/trailblaze/report-assets/ios-contacts/report.html)
+[![iOS Contacts trail timeline — animated walkthrough of each step](report-assets/ios-contacts/timeline.webp)](report-assets/ios-contacts/report.html)
 
-[**Open the full interactive report →**](/trailblaze/report-assets/ios-contacts/report.html)
+[**Open the full interactive report →**](report-assets/ios-contacts/report.html)
 
 ---
 
@@ -72,13 +72,13 @@ Android emulator or iOS simulator required, and no LLM at replay time. Source:
 
 ### Storyboard
 
-[![Wikipedia trail storyboard — every step tiled into a grid](/trailblaze/report-assets/wikipedia/storyboard.webp)](/trailblaze/report-assets/wikipedia/report.html)
+[![Wikipedia trail storyboard — every step tiled into a grid](report-assets/wikipedia/storyboard.webp)](report-assets/wikipedia/report.html)
 
 ### Timeline
 
-[![Wikipedia trail timeline — animated walkthrough of each step](/trailblaze/report-assets/wikipedia/timeline.webp)](/trailblaze/report-assets/wikipedia/report.html)
+[![Wikipedia trail timeline — animated walkthrough of each step](report-assets/wikipedia/timeline.webp)](report-assets/wikipedia/report.html)
 
-[**Open the full interactive report →**](/trailblaze/report-assets/wikipedia/report.html)
+[**Open the full interactive report →**](report-assets/wikipedia/report.html)
 
 *Want this for your own app? Every `trailblaze run` produces a session you can export
 the same way — see the [CLI reference](CLI.md#trailblaze-report) for `trailblaze report`


### PR DESCRIPTION
## What changed

The docs homepage and the Report Gallery now show their trail-report images and links correctly **everywhere the docs are served** — the published site, a local `serve_oss_mkdocs.sh` run, and any downstream mirror — not just on GitHub Pages.

Previously those gallery images/links pointed at absolute `/trailblaze/report-assets/...` paths. That prefix only resolves on the deployed Pages site (which is served under the `/trailblaze/` base). Anywhere else — locally at the site root, or embedded under a different base — the same links 404, so the gallery showed broken images.

This PR switches them back to relative `report-assets/...` links. No layout or content change; only the path prefix.

## Why relative works in every context

- mkdocs rewrites relative **Markdown** links/images per-page for whatever base the site is built with (`reports.md` → `../report-assets/...`), so the gallery on `reports.md` resolves correctly regardless of base.
- The homepage grid is raw HTML, which mkdocs does not rewrite — but it's served at the site root, so a relative `report-assets/...` resolves correctly in the browser on Pages, locally, and when mirrored.

`mkdocs build --strict` does **not** flag absolute links (they're INFO, not an error), which is why the regression slipped through.

## Implementation detail

The absolute paths were introduced in #160. This reverts only the path prefix in `docs/index.md` and `docs/reports.md` (`/trailblaze/report-assets/` → `report-assets/`), leaving #160's responsive Android/iOS/web grid and the CI-workflow changes intact. The two files now match the relative-path version already on the internal monorepo mirror.

## Test plan

- [ ] `mkdocs build --strict`
- [ ] Serve locally at the site root and confirm the homepage grid + Report Gallery images render