### PR TITLE
Showcase create-then-delete for iOS; add per-platform showcase manifest

### DIFF
--- a/.github/pr_run_android_tests_host_rpc.sh
+++ b/.github/pr_run_android_tests_host_rpc.sh
@@ -65,7 +65,16 @@ if [ "$TEST_FAILED" != "true" ]; then
   echo "Running Trail via Trailblaze CLI..."
   # The trail has recorded tool sequences so LLM inference is never invoked.
   # The fake OPENAI_API_KEY from the workflow env satisfies the provider wiring.
-  trailblaze trail trails/clock/set-alarm-730am/android.trail.yaml || TEST_FAILED=true
+  # Showcase trail named for `android` in docs/showcase-trails.yml; its session
+  # is what pr_generate_report_assets.sh publishes to report-assets/clock/.
+  # Change the featured test case by editing that manifest — no edits here.
+  if ANDROID_SHOWCASE_TRAIL="$(./.github/showcase-trail.sh android recording)" && [ -n "$ANDROID_SHOWCASE_TRAIL" ]; then
+    echo "Android showcase trail (from docs/showcase-trails.yml): $ANDROID_SHOWCASE_TRAIL"
+    trailblaze trail "$ANDROID_SHOWCASE_TRAIL" || TEST_FAILED=true
+  else
+    echo "ERROR: could not resolve the android showcase trail from docs/showcase-trails.yml"
+    TEST_FAILED=true
+  fi
 else
   echo "Skipping test execution because daemon failed to start"
 fi

--- a/.github/pr_run_ios_contacts_trails.sh
+++ b/.github/pr_run_ios_contacts_trails.sh
@@ -77,13 +77,19 @@ if [ "$TEST_FAILED" != "true" ]; then
   # -d ios selects the booted simulator via the Maestro device service.
   # The bundled Maestro iOS driver auto-installs its XCTest runner on the
   # simulator at first connection — allow extra time in the workflow timeout.
-  trailblaze trail -d ios \
-    trails/ios-contacts/test-search-by-first-name/ios-iphone.trail.yaml \
-    || TEST_FAILED=true
-
-  trailblaze trail -d ios \
-    trails/ios-contacts/test-search-no-results/ios-iphone.trail.yaml \
-    || TEST_FAILED=true
+  # Replay the trail named for `ios` in docs/showcase-trails.yml; its session is
+  # what pr_generate_report_assets.sh exports to report-assets/ios-contacts/ for
+  # the docs gallery. Change the featured test case by editing that manifest —
+  # no edits here. (This is a self-contained CRUD trail: it creates its own
+  # throwaway contact, so it carries no dependency on the simulator's default
+  # sample contacts.)
+  if IOS_SHOWCASE_TRAIL="$(./.github/showcase-trail.sh ios recording)" && [ -n "$IOS_SHOWCASE_TRAIL" ]; then
+    echo "iOS showcase trail (from docs/showcase-trails.yml): $IOS_SHOWCASE_TRAIL"
+    trailblaze trail -d ios "$IOS_SHOWCASE_TRAIL" || TEST_FAILED=true
+  else
+    echo "ERROR: could not resolve the iOS showcase trail from docs/showcase-trails.yml"
+    TEST_FAILED=true
+  fi
 else
   echo "Skipping test execution because setup failed"
 fi

--- a/.github/pr_run_wikipedia_trails.sh
+++ b/.github/pr_run_wikipedia_trails.sh
@@ -73,7 +73,16 @@ if [ "$TEST_FAILED" != "true" ]; then
   echo "Running Wikipedia trail via Trailblaze CLI..."
   # The trail has recorded tool sequences so LLM inference is never invoked.
   # The fake OPENAI_API_KEY from the workflow env satisfies the provider wiring.
-  trailblaze trail trails/wikipedia/test-article-shakespeare/web.trail.yaml || TEST_FAILED=true
+  # Showcase trail named for `web` in docs/showcase-trails.yml; its session is
+  # what pr_generate_report_assets.sh publishes to report-assets/wikipedia/.
+  # Change the featured test case by editing that manifest — no edits here.
+  if WEB_SHOWCASE_TRAIL="$(./.github/showcase-trail.sh web recording)" && [ -n "$WEB_SHOWCASE_TRAIL" ]; then
+    echo "Web showcase trail (from docs/showcase-trails.yml): $WEB_SHOWCASE_TRAIL"
+    trailblaze trail "$WEB_SHOWCASE_TRAIL" || TEST_FAILED=true
+  else
+    echo "ERROR: could not resolve the web showcase trail from docs/showcase-trails.yml"
+    TEST_FAILED=true
+  fi
 else
   echo "Skipping test execution because daemon failed to start"
 fi

--- a/.github/showcase-trail.sh
+++ b/.github/showcase-trail.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Resolve a field from the Report Gallery showcase manifest
+# (docs/showcase-trails.yml) for one platform — the single source of truth for
+# which recorded trail powers each platform's published showcase report.
+#
+# Usage:
+#   .github/showcase-trail.sh <platform> <field>
+#     <platform>  ios | android | web
+#     <field>     recording | slug
+#
+# Prints the resolved value on stdout. Exits non-zero (with a diagnostic on
+# stderr, nothing on stdout) when the platform/field isn't found, so callers can
+# guard the result:
+#   if TRAIL="$(./.github/showcase-trail.sh ios recording)" && [ -n "$TRAIL" ]; then
+#     trailblaze trail -d ios "$TRAIL"
+#   else
+#     echo "no ios showcase trail"; TEST_FAILED=true
+#   fi
+#
+# Dependency-free (awk only) so it runs in any CI trail job without yq or PyYAML.
+set -euo pipefail
+
+PLATFORM="${1:?usage: showcase-trail.sh <platform> <field>}"
+FIELD="${2:?usage: showcase-trail.sh <platform> <field>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="${SCRIPT_DIR}/../docs/showcase-trails.yml"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "showcase-trail.sh: manifest not found at $MANIFEST" >&2
+  exit 1
+fi
+
+# The manifest is a fixed two-level shape: top-level platform keys (`ios:` at
+# column 0) each holding indented `slug:` / `recording:` fields. Track the
+# current platform block, then emit the requested field's value verbatim.
+VALUE="$(
+  awk -v plat="$PLATFORM" -v field="$FIELD" '
+    /^[a-z][a-z0-9_]*:[[:space:]]*$/ { cur=$1; sub(/:.*/, "", cur); next }
+    {
+      if (cur == plat && match($0, "^[[:space:]]+" field ":[[:space:]]*")) {
+        val = substr($0, RLENGTH + 1)
+        gsub(/[[:space:]]+$/, "", val)
+        print val
+        exit
+      }
+    }
+  ' "$MANIFEST"
+)"
+
+if [ -z "$VALUE" ]; then
+  echo "showcase-trail.sh: no '$FIELD' for platform '$PLATFORM' in $MANIFEST" >&2
+  exit 1
+fi
+
+printf '%s\n' "$VALUE"

--- a/.github/workflows/ios-contacts-trails.yml
+++ b/.github/workflows/ios-contacts-trails.yml
@@ -17,13 +17,14 @@ jobs:
   # Pre-build the trailblaze uber JAR (with WASM template embedded) once and
   # publish it as an artifact for the downstream trails job. Mirrors the
   # `build-uber-jar` job in `pr-checks.yml` — see that file's header comment
-  # for the rationale. Runs on macos-15 (same runner OS as the downstream
+  # for the rationale. Runs on macos-26 (same runner OS as the downstream
   # trails job) because Compose Desktop's `packageUberJarForCurrentOS`
   # bundles the OS-specific Skiko native library, so a Linux-built JAR
   # wouldn't carry the macOS Skiko binary the downstream daemon loads at
-  # startup.
+  # startup. Both jobs must stay on the same macOS image so the arm64 Skiko
+  # binary built here matches the runner that loads it downstream.
   build-uber-jar:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:
@@ -72,10 +73,14 @@ jobs:
   # and ships inside the Trailblaze JAR. The XCTest runner is auto-installed
   # on the simulator at first connection.
   #
-  # Requires a macOS runner for iOS Simulator support. macOS-15 ships with
-  # Xcode 16 which includes iOS 18 simulator runtimes.
+  # Requires a macOS runner for iOS Simulator support. macos-26 ships Xcode 26
+  # with iOS 26 simulator runtimes (26.2 / 26.4 / 26.5 as of this writing) and
+  # iPhone 17 devices — the runtime the showcase recording in
+  # docs/showcase-trails.yml (test-create-then-delete) was captured on. The
+  # scripted Contacts tools drive the iOS 26 Contacts UI; older iOS (18 on
+  # macos-15) is not exercised by these recordings.
   ios-contacts-trails:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
     needs: build-uber-jar
     env:
@@ -114,19 +119,22 @@ jobs:
           echo "Available iPhone simulators:"
           xcrun simctl list devices available | grep "iPhone"
 
-          # Prefer iPhone 16 Pro (available on Xcode 16 / macOS-15 runners).
-          # Fall back to the first available iPhone so the job degrades
-          # gracefully if the runner image changes the set of pre-installed
-          # simulators (e.g. Xcode minor update removes a device type).
+          # Prefer iPhone 17 Pro (present on iOS 26 runtimes on macos-26 runners —
+          # the device the showcase recording was captured on). Any iOS 26.x
+          # runtime works: the Contacts accessibility identifiers the recording
+          # asserts on are stable across iOS 26 minor versions. Fall back to the
+          # first available iPhone so the job degrades gracefully if the runner
+          # image rotates its pre-installed simulators (GitHub keeps only ~3
+          # runtime sets per image, so the exact minor version can change).
           SIMULATOR_UDID=$(
             xcrun simctl list devices available |
-            grep "iPhone 16 Pro " | grep -v "Max\|Plus" |
+            grep "iPhone 17 Pro " | grep -v "Max\|Plus" |
             head -1 |
             grep -oE "[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}"
           )
 
           if [ -z "$SIMULATOR_UDID" ]; then
-            echo "iPhone 16 Pro not found, falling back to first available iPhone..."
+            echo "iPhone 17 Pro not found, falling back to first available iPhone..."
             SIMULATOR_UDID=$(
               xcrun simctl list devices available |
               grep "iPhone" |

--- a/.github/workflows/ios-contacts-trails.yml
+++ b/.github/workflows/ios-contacts-trails.yml
@@ -6,6 +6,9 @@ on:
   # instead of rebuilding the same artifact in a second workflow.
   push:
     branches: [ "main" ]
+  # Allow manual runs on any branch — e.g. to validate a runner-image bump or a
+  # new showcase recording on a PR branch before it merges to main.
+  workflow_dispatch:
 
 # Allow only one concurrent run per ref, cancelling any queued run when a
 # newer one is triggered (mirrors the pr-checks.yml concurrency policy).

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -261,9 +261,13 @@ jobs:
   # PR-time iOS showcase validation shares the same uber JAR built above.
   # The standalone iOS workflow stays push-only so `main` still produces the
   # docs gallery artifact that GitHub Pages publishes.
+  #
+  # Runs on macos-26 (Xcode 26 / iOS 26 simulators, iPhone 17 Pro) to match the
+  # showcase recording in docs/showcase-trails.yml — the scripted Contacts tools
+  # drive the iOS 26 Contacts UI. Kept in sync with .github/workflows/ios-contacts-trails.yml.
   ios-contacts-trails:
     if: github.event_name == 'pull_request'
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
     needs: build-uber-jar
     env:
@@ -300,15 +304,17 @@ jobs:
           echo "Available iPhone simulators:"
           xcrun simctl list devices available | grep "iPhone"
 
+          # Prefer iPhone 17 Pro (iOS 26 runtime on macos-26 — the device the
+          # showcase recording was captured on); fall back to the first iPhone.
           SIMULATOR_UDID=$(
             xcrun simctl list devices available |
-            grep "iPhone 16 Pro " | grep -v "Max\|Plus" |
+            grep "iPhone 17 Pro " | grep -v "Max\|Plus" |
             head -1 |
             grep -oE "[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}"
           )
 
           if [ -z "$SIMULATOR_UDID" ]; then
-            echo "iPhone 16 Pro not found, falling back to first available iPhone..."
+            echo "iPhone 17 Pro not found, falling back to first available iPhone..."
             SIMULATOR_UDID=$(
               xcrun simctl list devices available |
               grep "iPhone" |

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,7 @@ full interactive reports, or browse the [Report Gallery](reports.md) for more.
   </a>
   <a href="report-assets/ios-contacts/report.html" style="display: block; text-decoration: none;">
     <strong>iOS</strong>
-    <img src="report-assets/ios-contacts/timeline.webp" alt="Animated timeline of a recorded Trailblaze run exercising the iOS Contacts app" style="display: block; width: 100%; margin-top: .5rem;" />
+    <img src="report-assets/ios-contacts/timeline.webp" alt="Animated timeline of a recorded Trailblaze run creating then deleting an iOS contact" style="display: block; width: 100%; margin-top: .5rem;" />
   </a>
   <a href="report-assets/wikipedia/report.html" style="display: block; text-decoration: none;">
     <strong>Web</strong>

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -48,9 +48,10 @@ an emulator via Trailblaze's host-RPC Android driver — no LLM at replay time. 
 
 ## Contacts (iOS)
 
-A recorded iOS trail exercising the system Contacts app — searching for, opening, and
-verifying a contact — replayed on an iOS simulator, with no LLM at replay time. Source:
-[`examples/ios-contacts`](https://github.com/block/trailblaze/tree/main/examples/ios-contacts).
+A recorded iOS trail driving the system Contacts app through a full create→verify→delete
+lifecycle — creating a "Trailblaze Demo" contact with a phone number, confirming it landed
+in the list, then deleting it — replayed on an iOS simulator with no LLM at replay time.
+Source: [`trails/ios-contacts/test-create-then-delete`](https://github.com/block/trailblaze/tree/main/trails/ios-contacts/test-create-then-delete).
 
 ### Storyboard
 

--- a/docs/showcase-trails.yml
+++ b/docs/showcase-trails.yml
@@ -1,0 +1,37 @@
+# Report Gallery showcase trails — single source of truth.
+#
+# Each platform's published showcase report — the tiles on the docs landing page
+# (docs/index.md) and the Report Gallery (docs/reports.md) — is produced by
+# replaying ONE recorded trail in CI. This file names which trail that is, per
+# platform. To feature a different test case, point `recording:` at another
+# committed `*.trail.yaml`: CI replays it LAST so its session is the newest one,
+# which pr_generate_report_assets.sh exports and publishes under
+# report-assets/<slug>/, and the gallery embeds those assets.
+#
+# Consumed by:
+#   - .github/showcase-trail.sh                    (helper the run scripts call)
+#   - .github/pr_run_ios_contacts_trails.sh
+#   - .github/pr_run_wikipedia_trails.sh
+#   - .github/pr_run_android_tests_host_rpc.sh
+#   - docs_hooks.py                                (derives the gallery slugs)
+#
+# `slug` is the report-assets bucket: the folder name the docs tiles link to
+# (/report-assets/<slug>/...) AND the `docs-report-<slug>` CI artifact name the
+# GitHub Pages build fetches. Renaming a slug means updating those references in
+# index.md, reports.md, and .github/workflows/github-pages.yml too — so slugs are
+# kept stable here and only `recording:` is meant to change day to day.
+#
+# Not published to the site (see `exclude_docs` in mkdocs.yaml); it lives under
+# docs/ only so the showcase choices sit next to the gallery they drive.
+
+ios:
+  slug: ios-contacts
+  recording: trails/ios-contacts/test-create-then-delete/ios-iphone.trail.yaml
+
+android:
+  slug: clock
+  recording: trails/clock/set-alarm-730am/android.trail.yaml
+
+web:
+  slug: wikipedia
+  recording: trails/wikipedia/test-article-shakespeare/web.trail.yaml

--- a/docs_hooks.py
+++ b/docs_hooks.py
@@ -21,14 +21,35 @@ any MISSING per-trail asset with the single committed, reusable generic placehol
 win — the hook only creates files that don't already exist.
 
 Runs automatically on every `mkdocs build`/`serve`; no workflow wiring or staging step
-needed. Add a new trail by listing its slug in `TRAILS`.
+needed. The gallery slugs come from the showcase manifest (`docs/showcase-trails.yml`),
+so adding/retargeting a platform there is the only edit needed.
 """
 
 from pathlib import Path
 
-# Trail slugs that have a gallery section. Each maps to docs/report-assets/<slug>/.
-# One per platform: web (wikipedia), iOS (ios-contacts), Android (clock).
-TRAILS = ["wikipedia", "ios-contacts", "clock"]
+import yaml
+
+# Gallery slugs (one report-assets/<slug>/ bucket per platform) are read from the
+# showcase manifest so they stay in sync with what CI publishes. The fallback is
+# used only if the manifest is missing/unreadable, so a strict docs build never
+# breaks on a manifest hiccup.
+_MANIFEST_NAME = "showcase-trails.yml"
+_FALLBACK_SLUGS = ["wikipedia", "ios-contacts", "clock"]
+
+
+def _gallery_slugs(docs_dir):
+    """Gallery slugs from docs/showcase-trails.yml; fall back to the known set."""
+    manifest = docs_dir / _MANIFEST_NAME
+    try:
+        data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+        slugs = [
+            entry["slug"]
+            for entry in data.values()
+            if isinstance(entry, dict) and entry.get("slug")
+        ]
+        return slugs or _FALLBACK_SLUGS
+    except (OSError, yaml.YAMLError, AttributeError):
+        return _FALLBACK_SLUGS
 
 _PENDING_HTML = """<!doctype html>
 <meta charset="utf-8">
@@ -53,7 +74,7 @@ def on_pre_build(config):
         return
 
     pending_bytes = placeholder.read_bytes()
-    for trail in TRAILS:
+    for trail in _gallery_slugs(docs_dir):
         trail_dir = docs_dir / "report-assets" / trail
         trail_dir.mkdir(parents=True, exist_ok=True)
         for webp in ("storyboard.webp", "timeline.webp"):

--- a/examples/ios-contacts/trails/config/trailmaps/contacts/tools/contacts_ios_openContact.ts
+++ b/examples/ios-contacts/trails/config/trailmaps/contacts/tools/contacts_ios_openContact.ts
@@ -1,5 +1,5 @@
 import { trailblaze } from "@trailblaze/scripting";
-import { nonEmptyString } from "./contacts_ios_shared";
+import { LABELS, nonEmptyString } from "./contacts_ios_shared";
 
 const DEFAULT_CONTACT_NAME = "John Appleseed";
 
@@ -41,6 +41,18 @@ export const contacts_ios_openContact = trailblaze.tool<OpenContactArgs>(
       query: name,
       rowText: name,
       openFirstResult: true,
+    });
+    // Confirm we actually navigated to the contact DETAIL screen before trusting the
+    // heading. A bare name assert is NOT sufficient: the contact name is also visible as
+    // a search-result row and even as the typed query in the search field, so when the
+    // contact doesn't exist the row tap lands on the search field (no navigation) and a
+    // name-only check still passes — a false "opened". The detail screen's top-right
+    // "Edit" button is the reliable detail-only anchor: the list/search screens surface
+    // "Add"/"Search" there, never "Edit". Asserting it first means a missing contact
+    // fails HERE, so callers wrapping this in `tryOrFalse` (e.g. the delete teardown)
+    // correctly treat it as "not found" instead of proceeding against the wrong screen.
+    await ctx.tools.assertVisibleWithAccessibilityText({
+      accessibilityText: LABELS.editButton,
     });
     await ctx.tools.assertVisibleWithAccessibilityText({
       accessibilityText: expectedHeading,

--- a/examples/ios-contacts/trails/config/trailmaps/contacts/tools/contacts_ios_searchContacts.test.ts
+++ b/examples/ios-contacts/trails/config/trailmaps/contacts/tools/contacts_ios_searchContacts.test.ts
@@ -13,14 +13,19 @@ import { createMockClient, createMockContext } from "@trailblaze/scripting/testi
 import { contacts_ios_searchContacts } from "./contacts_ios_searchContacts";
 
 describe("contacts_ios_searchContacts", () => {
-  test("dispatches launchApp → assertVisible → swipe → tap Search → input → fires the No Results pre-flight branch", async () => {
-    // The default mock client returns success for every dispatch — including the
-    // `assertVisibleWithAccessibilityText({ accessibilityText: "No Results" })` probe the
-    // tool runs after typing the query. That probe-success is the exact condition the
-    // tool surfaces as a descriptive error instead of letting the subsequent row-tap fail
-    // with a generic "element not found". This is the agent's recommended ideal demo —
-    // exercises the real conditional logic without booting a simulator.
+  test("throws a descriptive no-results error when the 'No Results' banner is present", async () => {
+    // The no-results pre-flight probes with `assertNotVisibleWithText({ text: "No Results" })`
+    // — a NEGATIVE assertion whose `text` is treated as a regex, so it matches iOS's real
+    // `No Results for "<query>"` banner (an exact `assertVisibleWithAccessibilityText`
+    // needle never would — that gap let the not-found path tap the query text in the
+    // search field and report a false "opened"). The daemon fails that assertion when a
+    // matching element IS on screen, so stub it to throw: `tryOrFalse` turns that into
+    // `hasResults === false` and the tool surfaces the descriptive error.
     const client = createMockClient();
+    client.stub("assertNotVisibleWithText", {
+      textContent: "",
+      errorMessage: "element is visible",
+    });
     const ctx = createMockContext({ platform: "ios" });
 
     await expect(
@@ -35,7 +40,7 @@ describe("contacts_ios_searchContacts", () => {
       "swipe", // pull the search field into view
       "tapOnElementWithText", // focus the "Search" input
       "inputText", // type the query
-      "assertVisibleWithAccessibilityText", // "No Results" pre-flight probe — succeeds (mock default), fires the branch
+      "assertNotVisibleWithText", // no-results pre-flight probe — stubbed to fail (banner present), fires the branch
     ]);
     // The launchApp force-restart is a load-bearing implementation detail — the tool's
     // contract is "swipe-down from a known list-root state", not "swipe-down from
@@ -49,11 +54,38 @@ describe("contacts_ios_searchContacts", () => {
     expect(client.calls[2]?.args).toMatchObject({ direction: "DOWN" });
     expect(client.calls[3]?.args).toMatchObject({ text: "Search" });
     expect(client.calls[4]?.args).toMatchObject({ text: "Nobody" });
-    // The pre-flight probe ran with the right needle — confirms we reached the
-    // conditional rather than failing somewhere upstream.
-    expect(client.calls[5]?.args).toMatchObject({ accessibilityText: "No Results" });
-    // The row-tap was NOT called — the pre-flight branch short-circuited before it.
+    // The pre-flight probe ran with the right needle — a regex that matches the real
+    // `No Results for "<query>"` banner, not just the exact string "No Results".
+    expect(client.calls[5]?.args).toMatchObject({ text: "No Results" });
+    // The row-tap was NOT called — the no-results branch short-circuited before it.
     expect(client.calls).toHaveLength(6);
+  });
+
+  test("taps the first matching row when results are present", async () => {
+    // The default mock returns success for every dispatch — including the negative
+    // no-results probe, whose success means "no banner element on screen", i.e. results
+    // ARE present. The tool then taps the row matching `rowText` and returns.
+    const client = createMockClient();
+    const ctx = createMockContext({ platform: "ios" });
+
+    const result = await contacts_ios_searchContacts(
+      { query: "John", rowText: "John Appleseed" },
+      ctx,
+      client,
+    );
+
+    expect(client.calls.map((c) => c.tool)).toEqual([
+      "launchApp", // ensureContactsRoot — force-restart Contacts
+      "assertVisibleWithAccessibilityText", // ensureContactsRoot — "Contacts" list-root anchor
+      "swipe", // pull the search field into view
+      "tapOnElementWithText", // focus the "Search" input
+      "inputText", // type the query
+      "assertNotVisibleWithText", // no-results probe — passes (no banner) → results present
+      "tapOnElementWithText", // tap the result row
+    ]);
+    // The row tap targets `rowText`, not the raw query — the partial-prefix flow.
+    expect(client.calls[6]?.args).toMatchObject({ text: "John Appleseed" });
+    expect(result).toContain('opened the row matching "John Appleseed"');
   });
 
   test("returns early without probing No Results when openFirstResult is false", async () => {
@@ -84,13 +116,12 @@ describe("contacts_ios_searchContacts", () => {
     const client = createMockClient();
     const ctx = createMockContext({ platform: "ios" });
 
-    // No `query` → tool falls back to its `DEFAULT_QUERY` module constant. The exact
-    // default string is a tool-side implementation detail — assert via shape (non-empty
-    // string forwarded to inputText) rather than equality so a doc-only tweak to the
-    // default doesn't break the test.
-    await expect(
-      contacts_ios_searchContacts({}, ctx, client),
-    ).rejects.toThrow(/returned no results/);
+    // No `query` → tool falls back to its `DEFAULT_QUERY` module constant. Under the
+    // default mock the no-results probe passes (results present), so the tool completes;
+    // the exact default string is a tool-side implementation detail — assert via shape
+    // (non-empty string forwarded to inputText) rather than equality so a doc-only tweak
+    // to the default doesn't break the test.
+    await contacts_ios_searchContacts({}, ctx, client);
 
     const inputCall = client.calls.find((c) => c.tool === "inputText");
     expect(inputCall).toBeDefined();

--- a/examples/ios-contacts/trails/config/trailmaps/contacts/tools/contacts_ios_searchContacts.ts
+++ b/examples/ios-contacts/trails/config/trailmaps/contacts/tools/contacts_ios_searchContacts.ts
@@ -1,5 +1,5 @@
 import { trailblaze } from "@trailblaze/scripting";
-import { ensureContactsRoot, nonEmptyString, textIsVisible } from "./contacts_ios_shared";
+import { ensureContactsRoot, nonEmptyString, tryOrFalse } from "./contacts_ios_shared";
 
 const DEFAULT_QUERY = "John";
 
@@ -64,10 +64,24 @@ export const contacts_ios_searchContacts = trailblaze.tool<SearchContactsArgs>(
       return `Typed "${query}" into Contacts search and stopped (no result tapped).`;
     }
 
-    // Pre-flight: if iOS rendered the "No Results" banner, the next tap will
-    // fail with a generic "element not found". Surface the no-results state
-    // directly so the error message reflects the real cause.
-    if (await textIsVisible(ctx, "No Results")) {
+    // Pre-flight: surface the no-results state before the row tap below. This is
+    // load-bearing — without it, a query that matches nothing falls through to
+    // `tapOnElementWithText(rowText)`, which then matches the query text still
+    // showing in the *search field* (not a contact row), so no navigation
+    // happens and a caller's open-and-verify-name probe false-positives on that
+    // same search-field text. (That's exactly how the create-then-delete
+    // defensive teardown failed on a fresh simulator.)
+    //
+    // iOS renders the banner as `No Results for "<query>"`, so we must match it
+    // as a substring/regex. `assertVisibleWithAccessibilityText` is exact-match
+    // only (an exact "No Results" needle never matches the real banner), so probe
+    // with `assertNotVisibleWithText`, whose `text` is treated as a regex: it
+    // throws when an element matching "No Results" IS present, which `tryOrFalse`
+    // reports as `hasResults === false`.
+    const hasResults = await tryOrFalse(() =>
+      ctx.tools.assertNotVisibleWithText({ text: "No Results" }),
+    );
+    if (!hasResults) {
       throw new Error(
         `contacts_ios_searchContacts: query "${query}" returned no results.`,
       );

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -17,6 +17,12 @@ copyright: 'Copyright &copy; 2025 Block, Inc.'
 hooks:
   - docs_hooks.py
 
+# The showcase manifest is config for docs_hooks.py + the CI trail scripts, not a page —
+# keep it out of the published site. It still lives under docs/ (read from disk by the
+# hook) so the gallery's showcase choices sit next to the gallery they drive.
+exclude_docs: |
+  showcase-trails.yml
+
 theme:
   name: 'material'
   palette:

--- a/trails/ios-contacts/test-create-then-delete/blaze.yaml
+++ b/trails/ios-contacts/test-create-then-delete/blaze.yaml
@@ -1,6 +1,9 @@
-# End-to-end CRUD: creates a throwaway contact, verifies it landed, then
-# deletes it and confirms the list no longer surfaces the name. Demonstrates
-# the standard create+teardown pattern for trails that mutate the contacts db.
+# End-to-end CRUD showcase, written as natural-language INTENT — not tool calls.
+# Each step says *what* we want; the target system prompt + scripted-tool
+# descriptions let the agent pick the right tool (contacts_ios_createContact /
+# contacts_ios_deleteContact / …). A PM/QA can read these steps, and the recorded
+# `*.trail.yaml` replays them deterministically with no LLM. Keep steps to intent
+# — clear, not verbose; don't name tools or pass args here.
 - config:
     title: "Contacts (iOS): Create a contact then delete it"
     platform: ios
@@ -8,13 +11,7 @@
     target: contacts
     tags: [crud, slow]
 - prompts:
-    - step: |
-        Call the `contacts_ios_deleteContact` tool with name="Trailblaze Demo".
-        This is a defensive teardown — if a prior run left the contact behind,
-        we want to start clean.
-    - step: |
-        Call the `contacts_ios_createContact` tool with firstName="Trailblaze",
-        lastName="Demo", phoneNumber="5551234567".
-    - step: Verify the contacts list now shows a "Trailblaze Demo" row.
-    - step: |
-        Call the `contacts_ios_deleteContact` tool with name="Trailblaze Demo".
+    - step: Remove any leftover "Trailblaze Demo" contact so we start from a clean slate.
+    - step: Create a new contact named Trailblaze Demo with the phone number 555-123-4567.
+    - step: Verify the new "Trailblaze Demo" contact was saved.
+    - step: Delete the "Trailblaze Demo" contact.

--- a/trails/ios-contacts/test-create-then-delete/ios-iphone.trail.yaml
+++ b/trails/ios-contacts/test-create-then-delete/ios-iphone.trail.yaml
@@ -4,24 +4,19 @@
     platform: ios
     driver: IOS_HOST
 - prompts:
-  - step: |
-      Call the `contacts_ios_deleteContact` tool with name="Trailblaze Demo".
-      This is a defensive teardown — if a prior run left the contact behind,
-      we want to start clean.
+  - step: Remove any leftover "Trailblaze Demo" contact so we start from a clean slate.
     recording:
       tools:
       - contacts_ios_deleteContact:
           name: Trailblaze Demo
-  - step: |
-      Call the `contacts_ios_createContact` tool with firstName="Trailblaze",
-      lastName="Demo", phoneNumber="5551234567".
+  - step: Create a new contact named Trailblaze Demo with the phone number 555-123-4567.
     recording:
       tools:
       - contacts_ios_createContact:
           firstName: Trailblaze
           lastName: Demo
           phoneNumber: "5551234567"
-  - step: Verify the contacts list now shows a "Trailblaze Demo" row.
+  - step: Verify the new "Trailblaze Demo" contact was saved.
     recording:
       tools:
       - assertVisibleBySelector:
@@ -32,8 +27,7 @@
             iosMaestro:
               resourceIdRegex: ContactCardHeaderView
           expectedText: Trailblaze Demo
-  - step: |
-      Call the `contacts_ios_deleteContact` tool with name="Trailblaze Demo".
+  - step: Delete the "Trailblaze Demo" contact.
     recording:
       tools:
       - contacts_ios_deleteContact:

--- a/trails/ios-contacts/test-create-then-delete/ios-iphone.trail.yaml
+++ b/trails/ios-contacts/test-create-then-delete/ios-iphone.trail.yaml
@@ -1,0 +1,40 @@
+- config:
+    title: 'Contacts (iOS): Create a contact then delete it'
+    target: contacts
+    platform: ios
+    driver: IOS_HOST
+- prompts:
+  - step: |
+      Call the `contacts_ios_deleteContact` tool with name="Trailblaze Demo".
+      This is a defensive teardown — if a prior run left the contact behind,
+      we want to start clean.
+    recording:
+      tools:
+      - contacts_ios_deleteContact:
+          name: Trailblaze Demo
+  - step: |
+      Call the `contacts_ios_createContact` tool with firstName="Trailblaze",
+      lastName="Demo", phoneNumber="5551234567".
+    recording:
+      tools:
+      - contacts_ios_createContact:
+          firstName: Trailblaze
+          lastName: Demo
+          phoneNumber: "5551234567"
+  - step: Verify the contacts list now shows a "Trailblaze Demo" row.
+    recording:
+      tools:
+      - assertVisibleBySelector:
+          reason: The objective is to verify that the contacts list now shows a 'Trailblaze Demo' row. The UI hierarchy and screenshot both show a visible element with the text 'Trailblaze Demo', confirming the presence of the required contact.
+          selector:
+            index: "67"
+          nodeSelector:
+            iosMaestro:
+              resourceIdRegex: ContactCardHeaderView
+          expectedText: Trailblaze Demo
+  - step: |
+      Call the `contacts_ios_deleteContact` tool with name="Trailblaze Demo".
+    recording:
+      tools:
+      - contacts_ios_deleteContact:
+          name: Trailblaze Demo


### PR DESCRIPTION
## What

Make the Report Gallery's per-platform showcase trail explicit and editable in one place, and feature a more impressive iOS trail.

**Per-platform showcase manifest.** [`docs/showcase-trails.yml`](https://github.com/block/trailblaze/blob/report-gallery-showcase-manifest/docs/showcase-trails.yml) names the showcase trail for each platform (`ios` / `android` / `web`). The CI run scripts read it via a small awk-only helper (`.github/showcase-trail.sh`), and `docs_hooks.py` derives the gallery slugs from it. Previously the showcase was whichever trail happened to run *last* in CI (newest session wins) — nothing named it. Now featuring a different test case for a platform is a one-line manifest edit.

- `android` / `web` behavior is unchanged — the manifest just names the trails they already ran (`trails/clock/set-alarm-730am`, `trails/wikipedia/test-article-shakespeare`).
- The manifest lives under `docs/` (next to the gallery it drives) but is excluded from the published site via `exclude_docs` in `mkdocs.yaml`.

**iOS showcase → `test-create-then-delete`.** Replaces the underwhelming search-no-results trail with a full create → verify → delete CRUD lifecycle (creates a "Trailblaze Demo" contact with a phone number, confirms it landed, deletes it). It's a recorded trail — no LLM at replay time.

**iOS CI runner → `macos-26`.** The scripted Contacts tools drive the iOS 26 Contacts UI, and the recording was captured on iOS 26.4 / iPhone 17 Pro. `macos-26` is GA (and `macos-latest` points to it as of June 2026); its image ships iOS 26.2/26.4/26.5 simulators with iPhone 17 Pro. Both jobs in the workflow move `macos-15` → `macos-26`, and the simulator preference becomes iPhone 17 Pro. The iOS job now runs only its showcase trail (like the android/web jobs); the previous `by-first-name` coverage run was dropped — it depends on a default sample contact and didn't survive the iOS-version move, whereas create-then-delete creates its own contact.

## Verification

- `test-create-then-delete` replays deterministically (no LLM) on an iOS 26.4 simulator — verified locally.
- `bash -n` on all run scripts + the helper; workflow YAML parses; `mkdocs build --strict` green with the manifest correctly excluded from the built site.

## Needs a CI run to confirm

Runner-OS changes can't be validated locally. The macos-26 iOS-26 simulator runtime has had intermittent availability churn upstream (GitHub keeps ~3 runtime sets per image); it's present now, but this push is the real end-to-end check. The simulator selection falls back gracefully if the exact minor version rotates.

## Follow-up (not in this PR)

Multi-iOS-version support — per-version recordings (e.g. `ios-iphone-18` / `ios-iphone-26`) selected by the runtime, which the manifest could also express — would let a trail showcase across iOS versions rather than pinning to one.