### PR TITLE
CI: set up Bun for wasm builds + guard against agent branch names

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -41,6 +41,14 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 
+      - name: Setup Bun
+        # `-Ptrailblaze.wasm=true` packages this module's JAR resources, which
+        # runs `:trailblaze-models:bundleTrailblazeSdkDts` to roll up the
+        # `@trailblaze/scripting` declaration bundle. That task `bun install`s the
+        # SDK devDependencies and shells out to esbuild/dts-bundle-generator, so
+        # bun is a hard build prerequisite — without it on PATH the build fails.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,14 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
+      - name: Setup Bun
+        # `-Ptrailblaze.wasm=true` packages `:trailblaze-models`' JAR resources,
+        # which runs `:trailblaze-models:bundleTrailblazeSdkDts` to roll up the
+        # `@trailblaze/scripting` declaration bundle. That task `bun install`s the
+        # SDK devDependencies and shells out to esbuild/dts-bundle-generator, so
+        # bun is a hard build prerequisite — without it on PATH the build fails.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
       - name: Generate WASM Report Template
         run: ./gradlew :trailblaze-report:generateReportTemplate -Ptrailblaze.wasm=true
 

--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -23,6 +23,14 @@ jobs:
           distribution: 'zulu'
           java-version: 17
 
+      - name: Setup Bun
+        # `-Ptrailblaze.wasm=true` packages `:trailblaze-models`' JAR resources,
+        # which runs `:trailblaze-models:bundleTrailblazeSdkDts` to roll up the
+        # `@trailblaze/scripting` declaration bundle. That task `bun install`s the
+        # SDK devDependencies and shells out to esbuild/dts-bundle-generator, so
+        # bun is a hard build prerequisite — without it on PATH the build fails.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
       - name: Generate WASM Report Template
         run: ./gradlew :trailblaze-report:generateReportTemplate -Ptrailblaze.wasm=true
 

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+remote="${1:-}"
+url="${2:-}"
+zero="$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')"
+branch_owner="${USER:-$(whoami)}"
+bad_refs=""
+saw_non_delete_push=0
+
+append_bad_ref() {
+  local label="$1"
+  local branch="$2"
+  local entry="  - ${label}: ${branch}"
+
+  case "$branch" in
+    claude/* | codex/*)
+      case "
+${bad_refs}
+" in
+        *"
+${entry}
+"*) ;;
+        *) bad_refs="${bad_refs}${entry}
+" ;;
+      esac
+      ;;
+  esac
+}
+
+branch_from_ref() {
+  local ref="$1"
+  case "$ref" in
+    refs/heads/*) printf '%s\n' "${ref#refs/heads/}" ;;
+    *) return 1 ;;
+  esac
+}
+
+while read -r local_ref local_oid remote_ref remote_oid; do
+  if [[ -z "${local_ref:-}" ]]; then
+    continue
+  fi
+
+  # Allow cleanup pushes such as `git push origin :codex/foo`.
+  if [[ "$local_oid" == "$zero" ]]; then
+    continue
+  fi
+
+  saw_non_delete_push=1
+
+  if local_branch="$(branch_from_ref "$local_ref")"; then
+    append_bad_ref "local branch" "$local_branch"
+  fi
+
+  if remote_branch="$(branch_from_ref "$remote_ref")"; then
+    append_bad_ref "remote branch" "$remote_branch"
+  fi
+done
+
+if [[ "$saw_non_delete_push" == "1" ]]; then
+  current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  if [[ -n "$current_branch" ]]; then
+    append_bad_ref "current branch" "$current_branch"
+  fi
+fi
+
+if [[ -n "$bad_refs" ]]; then
+  cat >&2 <<EOF
+Refusing to push agent-generated branch names.
+
+Branches prefixed with claude/ or codex/ are temporary agent defaults. Rename the branch to a
+human-readable name before pushing:
+
+  git branch -m ${branch_owner}/<short-description>
+  git push -u ${remote:-origin} HEAD
+
+If this checkout is also in an agent-created worktree, move that worktree to match the new
+branch name before continuing.
+
+Blocked refs:
+${bad_refs}
+EOF
+
+  if [[ -n "$url" ]]; then
+    echo "Remote: ${remote:-<unnamed>} (${url})" >&2
+  fi
+
+  exit 1
+fi

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Installs this repo's Git hooks into the active hooks directory.
+#
+# Currently installs `pre-push`, which refuses to push agent-generated branch
+# names (claude/* and codex/*) so temporary worktree branches don't leak into
+# the public remote. Run once per clone:
+#
+#   ./scripts/install-git-hooks.sh
+#
+# Hooks live in `.git/hooks` (shared across all worktrees of this clone), so a
+# single install covers every worktree. Honors `core.hooksPath` if it's set.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+hooks_path="$(git config --path --get core.hooksPath || true)"
+if [ -n "$hooks_path" ]; then
+  case "$hooks_path" in
+    /*) hook_dir="$hooks_path" ;;
+    *) hook_dir="$repo_root/$hooks_path" ;;
+  esac
+else
+  hook_dir="$(dirname "$(git rev-parse --git-path hooks/pre-push)")"
+fi
+
+mkdir -p "$hook_dir"
+for hook in pre-push; do
+  src="$repo_root/scripts/git-hooks/$hook"
+  dest="$hook_dir/$hook"
+  cp "$src" "$dest"
+  chmod +x "$dest"
+  echo "Installed $hook hook at $dest"
+done


### PR DESCRIPTION
Two CI/tooling fixes.

## 1. Setup Bun in the wasm-bundling workflows

The **Build Desktop JAR** and **Snapshot Release** jobs went red on `main` with:

```
Execution failed for task ':trailblaze-models:bundleTrailblazeSdkDts'.
> Could not launch `bun` ... Cannot run program "bun" ... No such file or directory
```

Building with `-Ptrailblaze.wasm=true` packages `:trailblaze-models`' JAR resources, which hard-depends on `bundleTrailblazeSdkDts`. That task runs `bun install` plus esbuild/dts-bundle-generator to roll up the `@trailblaze/scripting` declaration bundle, so `bun` is a hard build prerequisite (unlike the analyzer-shim task, which has an `onlyIf` PATH guard). These workflows never got the `Setup Bun` step that `pr-checks.yml` already uses everywhere.

Adds the standard `oven-sh/setup-bun` step to:

- `build-desktop.yml` — *Build Desktop JAR* (was failing)
- `snapshot-release.yml` — *Snapshot Release* (was failing)
- `release.yml` — the tag-triggered twin of snapshot-release carrying the identical latent bug (only runs on `v*` tags, so it hadn't fired yet)

`github-pages.yml` and `docs-build-check.yml` don't invoke Gradle, so they're unaffected.

## 2. Pre-push hook rejecting agent-generated branch names

Agent worktrees default to `claude/*` and `codex/*` branch names — throwaway labels that shouldn't reach the public remote. This mirrors the pre-push guard already used in the internal repo: refuse to push any ref whose local, remote, or current branch is prefixed `claude/` or `codex/`, while still allowing cleanup deletes (`git push origin :claude/foo`).

- `scripts/git-hooks/pre-push` — the tracked hook
- `scripts/install-git-hooks.sh` — copies it into the clone's shared hooks dir (honors `core.hooksPath`, resolves the common `.git/hooks` so one install covers every worktree)

Run `./scripts/install-git-hooks.sh` once per clone.