### PR TITLE
CI: install ffmpeg-full on macOS so the iOS timeline.webp renders

### DIFF
--- a/.github/workflows/ios-contacts-trails.yml
+++ b/.github/workflows/ios-contacts-trails.yml
@@ -171,13 +171,21 @@ jobs:
         continue-on-error: true
         run: ./.github/pr_generate_trailblaze_report.sh
 
-      - name: Install ffmpeg (for the animated-timeline WebP)
-        # macOS runners don't ship ffmpeg; the docs gallery's animated timeline.webp is
-        # muxed via `ffmpeg -c:v libwebp_anim`. The storyboard WebP uses bundled libwebp
-        # and needs no ffmpeg, so a brew hiccup only degrades the animation, never the run.
+      - name: Install ffmpeg-full (for the animated-timeline WebP)
+        # macOS runners don't ship ffmpeg, and homebrew-core's plain `ffmpeg` formula
+        # is NOT built against libwebp — so the `libwebp_anim` encoder the docs gallery's
+        # animated timeline.webp needs is missing, and `pr_generate_report_assets.sh`
+        # silently falls back to publishing the committed placeholder. The sister
+        # `ffmpeg-full` formula depends on `webp` and provides the encoder. It's
+        # keg-only (so it doesn't collide with a system `ffmpeg`), so prepend its bin
+        # dir to GITHUB_PATH so the report-asset step picks it up.
+        # The storyboard WebP uses bundled libwebp and needs no ffmpeg, so a brew
+        # hiccup only degrades the animation, never the run.
         if: always()
         continue-on-error: true
-        run: brew install ffmpeg
+        run: |
+          brew install ffmpeg-full
+          echo "$(brew --prefix ffmpeg-full)/bin" >> "$GITHUB_PATH"
 
       - name: Generate docs report-gallery assets
         # Storyboard + animated-timeline WebP + interactive HTML report, consumed by the


### PR DESCRIPTION
## Summary

The iOS tile on the docs landing page (https://block.github.io/trailblaze/) has been stuck on the green "report generating in CI" placeholder for every deploy, even though the iOS Contacts trail itself runs green and publishes a real interactive report. The Report Gallery page looks fine because it also embeds the storyboard, but the landing page only embeds the animated timeline.

**Root cause:** the iOS Contacts trail job runs on `macos-26` and uses `brew install ffmpeg`. homebrew-core's plain `ffmpeg` formula is not built against libwebp — its dependency list omits `webp` — so the `libwebp_anim` encoder is missing. `pr_generate_report_assets.sh`'s preflight (`ffmpeg -encoders | grep libwebp_anim`) silently fails and skips the animated-timeline export. The docs hook then fills in the committed placeholder for `report-assets/ios-contacts/timeline.webp`.

The byte sizes on the live site confirm it:

| file | size |
|---|---|
| `images/report-pending.webp` (placeholder) | 5040 B |
| `report-assets/ios-contacts/timeline.webp` | **5040 B** ← byte-identical |
| `report-assets/ios-contacts/storyboard.webp` | 265 KB ← real |
| `report-assets/clock/timeline.webp` | 603 KB ← real |
| `report-assets/wikipedia/timeline.webp` | 175 KB ← real |

**Fix:** swap to `ffmpeg-full`, the homebrew-core sister formula that depends on `webp` and ships `libwebp_anim`. It's keg-only (so it doesn't collide with any system `ffmpeg`), hence the GITHUB_PATH prepend so the next step finds the right binary. The Linux trail jobs (clock, wikipedia) are unaffected — apt-get's `ffmpeg` already links libwebp.

After this merges, the next push to main will (1) trigger an `ios-contacts-trails.yml` run that produces a real `timeline.webp` artifact, and (2) the following `github-pages.yml` deploy will fetch it via the tier-1 path, so the landing-page iOS tile finally matches the Android and Web tiles.

## Test plan

- [ ] CI green on this PR (build-uber-jar runs; the install-ffmpeg step itself doesn't run on PR — only on push to main / workflow_dispatch).
- [ ] After merge, watch the `iOS Contacts Trails` workflow on main: the "Install ffmpeg-full" step succeeds, and the "Generate docs report-gallery assets" step logs `✓ ffmpeg with libwebp_anim found` (instead of the `WARNING: ffmpeg with libwebp_anim not found` it logs today).
- [ ] After the next `GitHub Pages Deployment` run, `curl -sI https://block.github.io/trailblaze/report-assets/ios-contacts/timeline.webp | grep -i content-length` returns something much larger than 5040 bytes, and the iOS tile on https://block.github.io/trailblaze/ renders the animated walkthrough.