### PR TITLE
Stop writing the deprecated `selector` field on new `tapOnElementBySelector` recordings

### DIFF
--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/TapTrailblazeTool.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/TapTrailblazeTool.kt
@@ -225,7 +225,6 @@ data class TapTrailblazeTool(
           return listOf(
             TapOnByElementSelector(
               reason = reasoning,
-              selector = nodeSelector.toTrailblazeElementSelector(),
               longPress = longPress,
               nodeSelector = nodeSelector,
             ),
@@ -240,7 +239,6 @@ data class TapTrailblazeTool(
           return listOf(
             TapOnByElementSelector(
               reason = reasoning,
-              selector = nodeSelector.toTrailblazeElementSelector(),
               longPress = longPress,
               nodeSelector = nodeSelector,
             ),


### PR DESCRIPTION
## What changed for you

Recordings generated by Trailblaze for the `tapOnElementBySelector` tool used to emit *both* the legacy Maestro-shaped `selector:` block and the rich driver-native `nodeSelector:` block in the produced YAML, even though the `selector` field has been `@Deprecated` for a while. From this PR on, fresh recordings only emit `nodeSelector:` — the deprecated `selector:` is no longer written.

Concretely, a recording that previously looked like:

```yaml
- tapOnElementBySelector:
    selector:
      textRegex: Close Level up your checkout
    nodeSelector:
      iosMaestro:
        accessibilityTextRegex: Close Level up your checkout
```

now looks like:

```yaml
- tapOnElementBySelector:
    nodeSelector:
      iosMaestro:
        accessibilityTextRegex: Close Level up your checkout
```

This was spotted while debugging a Square iOS promo-dismissal trail — a fresh recording emitted the dual-shape form even though the `selector` field's own kdoc says new tool construction should use `nodeSelector` exclusively.

Existing recordings on disk are unaffected. The `selector` field stays nullable + serializable on the data class, so any committed YAML carrying a `selector:` block (alongside `nodeSelector:` or solo) continues to load unchanged. The deprecation, and the migration off of the legacy field for new recordings, is tracked alongside the broader selector → nodeSelector workstream — this PR closes the "but new recordings keep emitting it" leak.

## Implementation detail

`TapTrailblazeTool.toExecutableTrailblazeTools` in `trailblaze-common` was constructing `TapOnByElementSelector(...)` with `selector = nodeSelector.toTrailblazeElementSelector(), … nodeSelector = nodeSelector` on two new-construction branches:

- `NodeSelectorMode.FORCE_NODE_SELECTOR` (every-platform new path)
- `NodeSelectorMode.PREFER_NODE_SELECTOR` (iOS new path)

Both `selector = …` lines are dropped. The third construction site (the legacy `TapSelectorV2` branch lower down) is intentionally left alone — that's the only path that produces the legacy Maestro-shaped selector via `TapSelectorV2`, and its existing `nodeSelector = if (mode == FORCE_LEGACY) null else nodeSelector` matrix is still correct (FORCE_LEGACY → pure legacy; FORCE_NODE_SELECTOR only falls through to this branch when `nodeSelector` is null anyway; PREFER_NODE_SELECTOR non-iOS keeps both shapes for the intentional dual-shape cross-driver-portable recording).

### Runtime safety

`TapOnByElementSelector.toMaestroCommands` already lowers `nodeSelector → selector` on demand via `lowerToMaestroSelector(selector, nodeSelector)` in `MaestroSelectorLowering.kt`, so the iOS-Maestro replay path resolves the same selector at runtime whether or not the legacy field was written into the YAML. `runMaestroFallbackOrFail` only fails when *both* fields are null, so a recording with only `nodeSelector` set is well-formed end-to-end.

## Test plan

- [x] `:trailblaze-common:check` (171 tasks, includes `TapOnByElementSelectorTest` + `TapOnTrailblazeToolTest`) — green
- [x] `:trailblaze-host:test --tests WaypointMigrateTrailCommandTest` — green (covers the `TapOnByElementSelector(selector = null)` deserialization path; see test at line 149)
- [x] `./scripts/scan_opensource_sensitive_terms.sh` — baseline matches
- [x] `./gradlew spotlessApply`
- [ ] Snapshot the Square iOS "Level up your checkout" modal locally, `./trailblaze tool tap --device ios -s "…" ref=<the f337 ref>`, read the resulting `*DelegatingTrailblazeToolLog.json`, confirm only `nodeSelector` is present in the emitted recording