### PR TITLE
CI: allow manual dispatches of the GitHub Pages deploy

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -4,6 +4,11 @@ on:
   # Runs after merging to the default branch
   push:
     branches: [ "main" ]
+  # Allow manual redeploys — useful when a trail workflow finishes AFTER the
+  # push-triggered Pages run picked the previous run's artifact (the
+  # one-commit lag documented in the "Fetch report-gallery assets" step), so
+  # rolling the fresh assets to the site doesn't require an empty commit.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to `.github/workflows/github-pages.yml`.

Today the deploy only runs on push to main. The "Fetch report-gallery assets" step is comment-documented to deliberately walk **completed** trail runs newest-first (so the push-triggered Pages run picks the *previous* push's trail artifact — a one-commit lag, since the trail workflow for this push is still in progress). That's fine on a normal cadence, but when a fix lands that's expected to change a freshly-generated asset — like #167, where the iOS Contacts run now produces a real `timeline.webp` instead of a placeholder — the push-triggered Pages deploy still publishes the old artifact, and the only way to roll the fresh one to the live site was an empty commit on main.

With `workflow_dispatch:`, a maintainer can re-run the deploy from the Actions UI once the trail workflow completes, no empty commit needed.

No behavior change for the normal push-to-main path.

## Test plan

- [ ] CI green on this PR (no jobs change shape).
- [ ] After merge, "Run workflow" button appears on the *GitHub Pages Deployment* workflow page; running it against `main` triggers a successful deploy that re-runs the asset fetch.