### PR TITLE
report: compress idle gaps in animated timeline export (#173)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -78,7 +78,7 @@ It does not reap device-scoped per-device sessions; use `app --stop` for those.
 | `toolbox` | Browse available tools by target app and platform |
 | `run` | Run a trail file (.trail.yaml) — execute a scripted test on a device. |
 | `session` | Manage the current device session — save it as a replayable trail, inspect steps, end it |
-| `report` | Generate an HTML report for session recordings, plus a best-effort JSON summary, and optionally MP4/GIF/WebP exports for a single session. JSON-only failures log a warning and still exit 0 — HTML is the primary artifact and is what gates the exit code. |
+| `report` | Generate an HTML report for session recordings, plus a best-effort JSON summary, and optionally MP4/GIF/WebP exports for a single session. JSON-only failures log a warning and still exit 0 — HTML is the primary artifact and is what gates the exit code. Animated exports collapse long idle gaps between steps so their length tracks the number of steps, not the session's real wall-clock. The capture window for all three (--gif/--webp/--video) is bounded by the MAX_PLAYBACK_WAIT_MS environment variable (milliseconds, default 600000); if playback overruns it, a best-effort truncated artifact is still written with a warning. |
 | `waypoint` | Match named app locations (waypoints) against captured screen state. |
 | `results` | Query the persisted test-result index for a test case. Passing a positional `<case-id>` (e.g. `trailblaze results C12345 --device android-phone`) is equivalent to the explicit `trailblaze results show <case-id>` form — picocli routes the bare case-id straight to the `show` subcommand. |
 | `config` | View and set configuration (target app, device defaults, AI provider) |
@@ -570,7 +570,7 @@ trailblaze session end [OPTIONS]
 
 ### `trailblaze report`
 
-Generate an HTML report for session recordings, plus a best-effort JSON summary, and optionally MP4/GIF/WebP exports for a single session. JSON-only failures log a warning and still exit 0 — HTML is the primary artifact and is what gates the exit code.
+Generate an HTML report for session recordings, plus a best-effort JSON summary, and optionally MP4/GIF/WebP exports for a single session. JSON-only failures log a warning and still exit 0 — HTML is the primary artifact and is what gates the exit code. Animated exports collapse long idle gaps between steps so their length tracks the number of steps, not the session's real wall-clock. The capture window for all three (--gif/--webp/--video) is bounded by the MAX_PLAYBACK_WAIT_MS environment variable (milliseconds, default 600000); if playback overruns it, a best-effort truncated artifact is still written with a warning.
 
 **Synopsis:**
 

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/PlaywrightReportCapture.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/PlaywrightReportCapture.kt
@@ -23,8 +23,30 @@ import xyz.block.trailblaze.util.Console
  */
 internal object PlaywrightReportCapture {
 
-  /** Upper bound on how long we'll wait for the timeline's playback-ended signal. */
-  internal const val MAX_PLAYBACK_WAIT_MS: Long = 10 * 60 * 1000L
+  /** Default upper bound on how long we'll wait for the timeline's playback-ended signal. */
+  internal const val DEFAULT_MAX_PLAYBACK_WAIT_MS: Long = 10 * 60 * 1000L
+
+  /** Environment variable that overrides the playback-wait ceiling (milliseconds). */
+  internal const val MAX_PLAYBACK_WAIT_ENV: String = "MAX_PLAYBACK_WAIT_MS"
+
+  /**
+   * Resolved playback-wait ceiling in ms. Overridable via the [MAX_PLAYBACK_WAIT_ENV]
+   * environment variable so all three exporters (`--gif`, `--webp`, `--video`) honor the
+   * same escape hatch the timeout message advertises — previously `--video` ignored it and
+   * hit a hardcoded Playwright timeout (issue #173). Non-numeric or non-positive values
+   * fall back to [DEFAULT_MAX_PLAYBACK_WAIT_MS]. With idle-gap compression in the autoplay
+   * timeline this ceiling is rarely reached, but it remains the documented manual override.
+   */
+  internal val maxPlaybackWaitMs: Long
+    get() = resolveMaxPlaybackWaitMs(System.getenv(MAX_PLAYBACK_WAIT_ENV))
+
+  /**
+   * Pure resolver for [maxPlaybackWaitMs] — split out from the `System.getenv` read so the
+   * parsing/fallback rules are unit-testable without mutating process environment. A
+   * non-numeric or non-positive [raw] override falls back to [DEFAULT_MAX_PLAYBACK_WAIT_MS].
+   */
+  internal fun resolveMaxPlaybackWaitMs(raw: String?): Long =
+    raw?.trim()?.toLongOrNull()?.takeIf { it > 0 } ?: DEFAULT_MAX_PLAYBACK_WAIT_MS
 
   /**
    * Capture cadence — `page.screenshot()` synchronously costs roughly 50–150ms per frame
@@ -84,6 +106,8 @@ internal object PlaywrightReportCapture {
     tag: String,
   ): CaptureResult {
     val onInstallProgress = makeInstallProgressLogger(tag)
+    // Resolve the wait ceiling once so the deadline and the timeout warning can't disagree.
+    val waitMs = maxPlaybackWaitMs
     var manager: PlaywrightBrowserManager? = null
     var capturedFrames = 0
     var playbackEnded = false
@@ -108,7 +132,7 @@ internal object PlaywrightReportCapture {
           .setFullPage(false)
           .setAnimations(ScreenshotAnimations.DISABLED)
         captureStartMs = System.currentTimeMillis()
-        val deadline = captureStartMs + MAX_PLAYBACK_WAIT_MS
+        val deadline = captureStartMs + waitMs
         var nextFrameTime = captureStartMs
         while (System.currentTimeMillis() < deadline) {
           val now = System.currentTimeMillis()
@@ -132,14 +156,17 @@ internal object PlaywrightReportCapture {
       runCatching { manager?.close() }
     }
 
+    if (capturedFrames == 0) error("No frames were captured — Playwright produced zero screenshots.")
     if (!playbackEnded) {
-      error(
-        "Timeline playback did not signal completion within " +
-          "${MAX_PLAYBACK_WAIT_MS / 1000}s — the captured output would be truncated. " +
-          "Try increasing MAX_PLAYBACK_WAIT_MS or shortening the session.",
+      // Fail soft: emit the best-effort truncated artifact rather than aborting with no
+      // output (issue #173). With idle-gap compression a timeout here is unusual, so call
+      // it out loudly and point at the override.
+      Console.log(
+        "[$tag] WARNING: timeline playback did not signal completion within " +
+          "${waitMs / 1000}s — writing a truncated $capturedFrames-frame artifact. " +
+          "Set $MAX_PLAYBACK_WAIT_ENV (ms) higher to capture the full timeline.",
       )
     }
-    if (capturedFrames == 0) error("No frames were captured — Playwright produced zero screenshots.")
 
     val measuredFps = computeFps(capturedFrames, captureEndMs - captureStartMs)
     return CaptureResult(frameCount = capturedFrames, measuredFps = measuredFps)
@@ -174,12 +201,29 @@ internal object PlaywrightReportCapture {
     return "$base${separator}autoplay=1"
   }
 
+  /** Nominal capture rate from the fixed [FRAME_INTERVAL_MS] cadence (5fps at 200ms). */
+  private val NOMINAL_FPS: Int get() = (1000 / FRAME_INTERVAL_MS).toInt().coerceAtLeast(1)
+
   /**
    * Convert measured frame count + elapsed wall time into a whole-number fps for ffmpeg.
-   * `coerceAtLeast(1)` guards the degenerate "captured one frame in <1s" case.
+   * Encoding at the *measured* rate (rather than the nominal [NOMINAL_FPS]) makes the
+   * artifact play back at real-time speed even when `page.screenshot()` ran slower than the
+   * interval — common on a cold CI runner, where it honestly under-reports and the clip
+   * plays at the slower true rate rather than fast-forwarding.
+   *
+   * The bounds only catch values that aren't physically meaningful, so a legitimate
+   * measurement is never distorted:
+   *  - `coerceAtLeast(1)` floors the degenerate "one frame in <1s" case (ffmpeg needs a
+   *    positive integer fps).
+   *  - the upper bound catches a non-physical spike — e.g. a near-empty capture or clock
+   *    skew making `elapsedMs` ~0 — which would otherwise yield a hundreds-of-fps blur.
+   *    It sits at `4 * NOMINAL_FPS` (20fps at the 200ms cadence), comfortably above the
+   *    real ceiling: each screenshot costs ~50ms+, so a genuine capture can't sustain past
+   *    ~20fps, and a fast tail passes through unclamped. Independent of the truncated-capture
+   *    fail-soft path — `frames / elapsed` is the right rate either way.
    */
-  private fun computeFps(frameCount: Int, elapsedMs: Long): Int {
-    if (elapsedMs <= 0) return (1000 / FRAME_INTERVAL_MS).toInt().coerceAtLeast(1)
-    return (frameCount * 1000.0 / elapsedMs).toInt().coerceAtLeast(1)
+  internal fun computeFps(frameCount: Int, elapsedMs: Long): Int {
+    if (elapsedMs <= 0) return NOMINAL_FPS
+    return (frameCount * 1000.0 / elapsedMs).toInt().coerceIn(1, 4 * NOMINAL_FPS)
   }
 }

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/ReportCommand.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/ReportCommand.kt
@@ -39,7 +39,12 @@ import kotlin.system.exitProcess
   description = [
     "Generate an HTML report for session recordings, plus a best-effort JSON summary, and " +
       "optionally MP4/GIF/WebP exports for a single session. JSON-only failures log a warning " +
-      "and still exit 0 — HTML is the primary artifact and is what gates the exit code.",
+      "and still exit 0 — HTML is the primary artifact and is what gates the exit code. " +
+      "Animated exports collapse long idle gaps between steps so their length tracks the " +
+      "number of steps, not the session's real wall-clock. The capture window for all three " +
+      "(--gif/--webp/--video) is bounded by the MAX_PLAYBACK_WAIT_MS environment variable " +
+      "(milliseconds, default 600000); if playback overruns it, a best-effort truncated " +
+      "artifact is still written with a warning.",
   ]
 )
 class ReportCommand : Callable<Int> {

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/ReportVideoExporter.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/ReportVideoExporter.kt
@@ -1,6 +1,7 @@
 package xyz.block.trailblaze.cli
 
 import com.microsoft.playwright.Page
+import com.microsoft.playwright.TimeoutError
 import com.microsoft.playwright.options.LoadState
 import java.io.File
 import java.util.UUID
@@ -36,9 +37,6 @@ import xyz.block.trailblaze.util.Console
  * or `LogsRepo`. The only artifact is the MP4 at [outputMp4].
  */
 object ReportVideoExporter {
-
-  /** Upper bound on how long we'll wait for the timeline's playback-ended signal. */
-  private const val MAX_PLAYBACK_WAIT_MS: Double = 10 * 60 * 1000.0
 
   /**
    * @param reportHtml The generated `trailblaze_report*.html` (single-session reports are
@@ -115,12 +113,25 @@ object ReportVideoExporter {
         page.waitForLoadState(LoadState.DOMCONTENTLOADED)
 
         Console.log("[ReportVideoExporter] waiting for timeline playback to finish...")
-        page.waitForFunction(
-          "() => globalThis.__tbPlaybackEnded === true",
-          null,
-          Page.WaitForFunctionOptions().setTimeout(MAX_PLAYBACK_WAIT_MS),
-        )
-        Console.log("[ReportVideoExporter] timeline reported playback complete")
+        // Honors the same MAX_PLAYBACK_WAIT_MS override as the GIF/WebP path (issue #173).
+        val waitMs = PlaywrightReportCapture.maxPlaybackWaitMs
+        try {
+          page.waitForFunction(
+            "() => globalThis.__tbPlaybackEnded === true",
+            null,
+            Page.WaitForFunctionOptions().setTimeout(waitMs.toDouble()),
+          )
+          Console.log("[ReportVideoExporter] timeline reported playback complete")
+        } catch (_: TimeoutError) {
+          // Fail soft: the WebM has been recording continuously, so let the finally block
+          // finalize a best-effort truncated MP4 rather than aborting with no output.
+          Console.log(
+            "[ReportVideoExporter] WARNING: timeline playback did not signal completion " +
+              "within ${waitMs / 1000}s — finalizing a truncated MP4. Set " +
+              "${PlaywrightReportCapture.MAX_PLAYBACK_WAIT_ENV} (ms) higher to capture the " +
+              "full timeline.",
+          )
+        }
       }
     } finally {
       // Order matters: close the browser first (flushes the in-progress `.webm`), then

--- a/trailblaze-host/src/test/java/xyz/block/trailblaze/cli/PlaywrightReportCaptureTest.kt
+++ b/trailblaze-host/src/test/java/xyz/block/trailblaze/cli/PlaywrightReportCaptureTest.kt
@@ -1,0 +1,55 @@
+package xyz.block.trailblaze.cli
+
+import kotlin.test.assertEquals
+import org.junit.Test
+
+/**
+ * Covers the `MAX_PLAYBACK_WAIT_MS` override resolution shared by all three exporters
+ * (`--gif`, `--webp`, `--video`) — the escape hatch the timeout warnings advertise.
+ * `--video` previously ignored it and hit a hardcoded Playwright timeout (issue #173).
+ */
+class PlaywrightReportCaptureTest {
+
+  private val default = PlaywrightReportCapture.DEFAULT_MAX_PLAYBACK_WAIT_MS
+
+  @Test fun `null and blank fall back to the default`() {
+    assertEquals(default, PlaywrightReportCapture.resolveMaxPlaybackWaitMs(null))
+    assertEquals(default, PlaywrightReportCapture.resolveMaxPlaybackWaitMs(""))
+    assertEquals(default, PlaywrightReportCapture.resolveMaxPlaybackWaitMs("   "))
+  }
+
+  @Test fun `non-numeric and non-positive fall back to the default`() {
+    assertEquals(default, PlaywrightReportCapture.resolveMaxPlaybackWaitMs("soon"))
+    assertEquals(default, PlaywrightReportCapture.resolveMaxPlaybackWaitMs("0"))
+    assertEquals(default, PlaywrightReportCapture.resolveMaxPlaybackWaitMs("-1000"))
+  }
+
+  @Test fun `a valid positive override wins`() {
+    assertEquals(1_800_000L, PlaywrightReportCapture.resolveMaxPlaybackWaitMs("1800000"))
+    assertEquals(1_800_000L, PlaywrightReportCapture.resolveMaxPlaybackWaitMs("  1800000  "))
+  }
+
+  // computeFps — frames are emitted on a fixed 200ms (5fps) cadence; the rate is measured
+  // from real elapsed time and clamped to [1, 20] so a degenerate window can't produce a
+  // non-physical encode rate. Relevant to the truncated fail-soft capture path (#173).
+
+  @Test fun `computeFps returns the nominal rate when no time elapsed`() {
+    assertEquals(5, PlaywrightReportCapture.computeFps(frameCount = 1, elapsedMs = 0))
+  }
+
+  @Test fun `computeFps measures real-time rate for a normal capture`() {
+    // 30 frames over 6s = 5fps.
+    assertEquals(5, PlaywrightReportCapture.computeFps(frameCount = 30, elapsedMs = 6_000))
+    // A slow capture (screenshots lagged the cadence) under-reports honestly, not clamped up.
+    assertEquals(2, PlaywrightReportCapture.computeFps(frameCount = 12, elapsedMs = 6_000))
+    // A fast tail (e.g. 8fps) is within the physical ceiling and passes through unclamped.
+    assertEquals(8, PlaywrightReportCapture.computeFps(frameCount = 48, elapsedMs = 6_000))
+  }
+
+  @Test fun `computeFps clamps the degenerate slow and non-physical fast extremes`() {
+    // One frame over a long truncated window -> floor of 1, never 0.
+    assertEquals(1, PlaywrightReportCapture.computeFps(frameCount = 1, elapsedMs = 60_000))
+    // A non-physical spike (clock skew / near-empty capture) -> capped at 4x nominal (20).
+    assertEquals(20, PlaywrightReportCapture.computeFps(frameCount = 50, elapsedMs = 100))
+  }
+}

--- a/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze-report.txt
+++ b/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze-report.txt
@@ -15,7 +15,12 @@ Usage: trailblaze report [-hV] [--current] [--no-gif] [--no-webp] [--open] [--
 Generate an HTML report for session recordings, plus a best-effort JSON
 summary, and optionally MP4/GIF/WebP exports for a single session. JSON-only
 failures log a warning and still exit 0 — HTML is the primary artifact and is
-what gates the exit code.
+what gates the exit code. Animated exports collapse long idle gaps between
+steps so their length tracks the number of steps, not the session's real
+wall-clock. The capture window for all three (--gif/--webp/--video) is bounded
+by the MAX_PLAYBACK_WAIT_MS environment variable (milliseconds, default
+600000); if playback overruns it, a best-effort truncated artifact is still
+written with a warning.
       [<session-id>]         Session ID to narrow the report to (positional
                                form of --id). Prefix matching is supported.
                                Mutually exclusive with --id and --current.

--- a/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze.txt
+++ b/trailblaze-host/src/test/resources/cli-output-baselines/help-trailblaze.txt
@@ -28,7 +28,13 @@ Trailblaze - AI-powered device automation
                  best-effort JSON summary, and optionally MP4/GIF/WebP exports
                  for a single session. JSON-only failures log a warning and
                  still exit 0 — HTML is the primary artifact and is what gates
-                 the exit code.
+                 the exit code. Animated exports collapse long idle gaps
+                 between steps so their length tracks the number of steps, not
+                 the session's real wall-clock. The capture window for all
+                 three (--gif/--webp/--video) is bounded by the
+                 MAX_PLAYBACK_WAIT_MS environment variable (milliseconds,
+                 default 600000); if playback overruns it, a best-effort
+                 truncated artifact is still written with a warning.
   waypoint     Match named app locations (waypoints) against captured screen
                  state.
   results      Query the persisted test-result index for a test case. Passing a

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/tabs/session/PlaybackTimeline.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/tabs/session/PlaybackTimeline.kt
@@ -1,0 +1,206 @@
+package xyz.block.trailblaze.ui.tabs.session
+
+/**
+ * Maps autoplay's "compressed" elapsed time onto absolute session timestamps so that
+ * exported timelines (`trailblaze report --gif/--webp/--video`) scale with the number of
+ * recorded steps rather than the session's real wall-clock.
+ *
+ * The autoplay loop in [SessionCombinedView] advances the scrubber by
+ * `wallClockElapsed * playbackSpeed`. Without compression that makes export duration
+ * proportional to `sessionEnd - sessionStart`, so a session recorded interactively over
+ * a long period (a handful of actions spread across, say, 100 minutes — see issue #173)
+ * produces a 100+ minute animation that no fixed capture window can accommodate and that
+ * would be an enormous artifact even if it could.
+ *
+ * This collapses the dead air: gaps between consecutive [anchorsMs] longer than
+ * [maxGapMs] are played back as if they were exactly [maxGapMs]; shorter gaps (the
+ * meaningful intra-step activity) play 1:1. The result is a piecewise-linear mapping from
+ * compressed playback time to absolute session time. During a collapsed gap the scrubber
+ * still slides across the real timestamps — only faster — but since no event occurs in a
+ * gap the displayed frame is unchanged anyway, so the only visible effect is that idle
+ * stretches no longer waste capture time.
+ *
+ * Built once per export from the session's log timestamps. Used only on the export
+ * autoplay path; interactive playback keeps real (speed-scaled) timing.
+ */
+internal class PlaybackTimeline private constructor(
+  /** Sorted absolute session timestamps (ms) of the anchor points. */
+  private val absAnchors: LongArray,
+  /** Compressed playback offset (ms, from 0) corresponding to each anchor. */
+  private val compAnchors: LongArray,
+) {
+  // [absAnchors] and [compAnchors] are index-aligned: compAnchors[i] is the compressed
+  // playback offset at which the scrubber sits on absAnchors[i]. The private constructor
+  // is the only producer, so the alignment + "absAnchors strictly increasing" invariants
+  // hold for every instance.
+
+  /** Total compressed playback duration in ms — the loop runs until elapsed reaches this. */
+  val totalCompressedMs: Long get() = compAnchors[compAnchors.size - 1]
+
+  /** First/last absolute timestamps the timeline spans (the real session start/end). */
+  val startAbsMs: Long get() = absAnchors[0]
+  val endAbsMs: Long get() = absAnchors[absAnchors.size - 1]
+
+  /**
+   * Absolute session timestamp to show at [compressedMs] of compressed playback,
+   * interpolating linearly within the segment that [compressedMs] falls in. Clamps to the
+   * first/last anchor outside the `[0, totalCompressedMs]` range.
+   */
+  fun absoluteAt(compressedMs: Long): Long {
+    val n = absAnchors.size
+    if (compressedMs <= 0L) return absAnchors[0]
+    if (compressedMs >= totalCompressedMs) return absAnchors[n - 1]
+
+    // Largest i such that compAnchors[i] <= compressedMs (segment [i, i+1]).
+    var lo = 0
+    var hi = n - 1
+    while (lo < hi) {
+      val mid = (lo + hi + 1) ushr 1
+      if (compAnchors[mid] <= compressedMs) lo = mid else hi = mid - 1
+    }
+    val i = lo
+    val compSpan = compAnchors[i + 1] - compAnchors[i]
+    if (compSpan <= 0L) return absAnchors[i]
+    val frac = (compressedMs - compAnchors[i]).toDouble() / compSpan.toDouble()
+    val absSpan = absAnchors[i + 1] - absAnchors[i]
+    return absAnchors[i] + (absSpan * frac).toLong()
+  }
+
+  /**
+   * Inverse of [absoluteAt]: the compressed playback offset at which the scrubber sits on
+   * [absoluteMs]. Lets a play loop anchor its compressed clock on the *current* scrub
+   * position rather than always assuming playback began at the session start — so a
+   * mid-run relaunch (e.g. a playback-speed change) resumes from where it was instead of
+   * jumping back to the start. Clamps outside `[startAbsMs, endAbsMs]`.
+   */
+  fun compressedAt(absoluteMs: Long): Long {
+    val n = absAnchors.size
+    if (absoluteMs <= absAnchors[0]) return 0L
+    if (absoluteMs >= absAnchors[n - 1]) return totalCompressedMs
+
+    // Largest i such that absAnchors[i] <= absoluteMs (segment [i, i+1]).
+    var lo = 0
+    var hi = n - 1
+    while (lo < hi) {
+      val mid = (lo + hi + 1) ushr 1
+      if (absAnchors[mid] <= absoluteMs) lo = mid else hi = mid - 1
+    }
+    val i = lo
+    val absSpan = absAnchors[i + 1] - absAnchors[i]
+    if (absSpan <= 0L) return compAnchors[i]
+    val frac = (absoluteMs - absAnchors[i]).toDouble() / absSpan.toDouble()
+    val compSpan = compAnchors[i + 1] - compAnchors[i]
+    return compAnchors[i] + (compSpan * frac).toLong()
+  }
+
+  /**
+   * If [absoluteMs] falls within a gap that was actually collapsed (its real span exceeded
+   * the cap, so compressed playback fast-forwards across it), returns that gap's *real*
+   * duration in ms; otherwise null. Lets the player caption a fast-forwarded idle stretch
+   * ("» 37m later") so a compressed gap isn't silently invisible in the exported animation —
+   * the duration is preserved as a label even though it isn't spent as playback time.
+   *
+   * A gap `[i, i+1]` was collapsed iff its absolute span is wider than its compressed span
+   * (`min(realGap, cap) < realGap`), so no cap value needs to be retained to detect it.
+   */
+  fun collapsedGapMsAt(absoluteMs: Long): Long? {
+    val n = absAnchors.size
+    if (absoluteMs < absAnchors[0] || absoluteMs >= absAnchors[n - 1]) return null
+
+    // Largest i such that absAnchors[i] <= absoluteMs (segment [i, i+1]).
+    var lo = 0
+    var hi = n - 1
+    while (lo < hi) {
+      val mid = (lo + hi + 1) ushr 1
+      if (absAnchors[mid] <= absoluteMs) lo = mid else hi = mid - 1
+    }
+    val i = lo
+    val absSpan = absAnchors[i + 1] - absAnchors[i]
+    val compSpan = compAnchors[i + 1] - compAnchors[i]
+    return if (absSpan > compSpan) absSpan else null
+  }
+
+  companion object {
+    /**
+     * Build a timeline from [anchorsMs] (any order, duplicates tolerated), collapsing any
+     * gap longer than [maxGapMs]. Returns null when there's nothing to compress — fewer
+     * than two distinct anchors, or a non-positive cap — so callers fall back to the
+     * uncompressed linear path.
+     */
+    fun build(anchorsMs: List<Long>, maxGapMs: Long): PlaybackTimeline? {
+      if (maxGapMs <= 0L) return null
+      val sorted = anchorsMs.distinct().sorted().toLongArray()
+      if (sorted.size < 2) return null
+
+      val comp = LongArray(sorted.size)
+      comp[0] = 0L
+      for (i in 1 until sorted.size) {
+        val gap = sorted[i] - sorted[i - 1]
+        comp[i] = comp[i - 1] + minOf(gap, maxGapMs)
+      }
+      return PlaybackTimeline(sorted, comp)
+    }
+  }
+}
+
+/** One autoplay step: where to put the scrubber next, and whether playback has ended. */
+internal data class PlaybackTick(val targetAbsMs: Long, val reachedEnd: Boolean)
+
+/**
+ * Compute the next scrubber position for an autoplay loop. Shared by both the video and
+ * screenshot panels in [SessionCombinedView] so the compressed-vs-linear branch (and the
+ * "snap to the real end on the last frame" behavior) lives in exactly one place.
+ *
+ * @param elapsedMs `monotonicElapsed * playbackSpeed` since the loop (re)started.
+ * @param playStartAbsMs the absolute scrub position the loop started from.
+ * @param endAbsMs the absolute end the *uncompressed* path stops at (the video/screenshot
+ *   panels source this differently — `videoMetadata.endTimestampMs` vs `effectiveEndMs`).
+ * @param timeline idle-gap compression for the export path, or null for 1:1 playback.
+ *
+ * With a [timeline], the compressed clock is anchored on [playStartAbsMs] (via
+ * [PlaybackTimeline.compressedAt]) and the end-snap lands on the timeline's own endpoint —
+ * never [endAbsMs], which the compressed mapping doesn't cover. Without one, playback
+ * advances 1:1 and snaps to [endAbsMs].
+ *
+ * The timeline endpoint is the last log timestamp (`effectiveEndMs`), which can differ from
+ * the video panel's [endAbsMs] (`videoMetadata.endTimestampMs`) in either direction, and
+ * compression intentionally follows the timeline either way:
+ *  - video ends *after* the last log (a trailing event-less tail): we stop at the last
+ *    event rather than playing dead tail — the whole point of idle compression.
+ *  - video ends *before* the last log: we scrub to `effectiveEndMs`; the frame cache clamps
+ *    to its last available frame for that sliver. Both are benign because completion is
+ *    signaled off the `isVideoPlaying` transition, not off reaching a specific timestamp.
+ */
+internal fun computePlaybackTick(
+  elapsedMs: Long,
+  playStartAbsMs: Long,
+  endAbsMs: Long,
+  timeline: PlaybackTimeline?,
+): PlaybackTick {
+  if (timeline == null) {
+    val target = playStartAbsMs + elapsedMs
+    return if (target >= endAbsMs) PlaybackTick(endAbsMs, true) else PlaybackTick(target, false)
+  }
+  val compressedNow = timeline.compressedAt(playStartAbsMs) + elapsedMs
+  return if (compressedNow >= timeline.totalCompressedMs) {
+    PlaybackTick(timeline.endAbsMs, true)
+  } else {
+    PlaybackTick(timeline.absoluteAt(compressedNow), false)
+  }
+}
+
+/**
+ * The anchor timestamps an export [PlaybackTimeline] is built from: the session window
+ * bounds plus every log timestamp that falls inside it. Pulled out of [SessionCombinedView]
+ * so the windowing rule (logs outside `[startMs, endMs]` are dropped; the bounds are always
+ * present so an event-less session still has the two endpoints) is unit-testable.
+ */
+internal fun exportPlaybackAnchors(
+  logTimestampsMs: List<Long>,
+  startMs: Long,
+  endMs: Long,
+): List<Long> = buildList {
+  add(startMs)
+  addAll(logTimestampsMs)
+  add(endMs)
+}.filter { it in startMs..endMs }

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/tabs/session/SessionCombinedView.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/tabs/session/SessionCombinedView.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -85,6 +86,7 @@ import xyz.block.trailblaze.ui.loadNetworkLogs
 import xyz.block.trailblaze.ui.openVideoInSystemPlayer
 import xyz.block.trailblaze.ui.resolveImageModel
 import xyz.block.trailblaze.ui.utils.FormattingUtils
+import xyz.block.trailblaze.ui.utils.FormattingUtils.formatCompactDuration
 import xyz.block.trailblaze.ui.utils.FormattingUtils.formatDuration
 
 /** Polling interval for refreshing device-log and network capture files during live sessions. */
@@ -319,6 +321,27 @@ internal fun SessionCombinedView(
   val eventMarkers =
     remember(logs, effectiveStartMs, effectiveEndMs) {
       buildEventMarkers(logs, effectiveStartMs, effectiveEndMs)
+    }
+
+  // Export-only: a dwell-capped mapping from compressed playback time to absolute session
+  // time, so `--gif/--webp/--video` autoplay scales with step count rather than the
+  // session's real wall-clock (issue #173). Null for interactive viewing — only the
+  // `?autoplay=1` export path collapses idle gaps. Anchored on every log timestamp plus
+  // the window bounds so meaningful intra-step activity still plays 1:1.
+  // isExportAutoplayRequested() reads the immutable report URL (constant for the page's
+  // lifetime), so it's a guard inside the block, not a remember key.
+  val exportPlaybackTimeline =
+    remember(logs, effectiveStartMs, effectiveEndMs) {
+      if (!isExportAutoplayRequested()) {
+        null
+      } else {
+        val anchors = exportPlaybackAnchors(
+          logTimestampsMs = logs.map { it.timestamp.toEpochMilliseconds() },
+          startMs = effectiveStartMs,
+          endMs = effectiveEndMs,
+        )
+        PlaybackTimeline.build(anchors, TimelineConstants.MAX_EXPORT_STEP_DWELL_MS)
+      }
     }
 
   // Flat navigation list built from visible child events — matches exactly what's on screen.
@@ -633,6 +656,7 @@ internal fun SessionCombinedView(
             currentTimestamp = currentTimestamp,
             effectiveStartMs = effectiveStartMs,
             effectiveEndMs = effectiveEndMs,
+            exportPlaybackTimeline = exportPlaybackTimeline,
             activeDriverLog = activeDriverLog,
             sessionId = sessionId,
             imageLoader = imageLoader,
@@ -650,6 +674,7 @@ internal fun SessionCombinedView(
             timelineState = timelineState,
             effectiveStartMs = effectiveStartMs,
             effectiveEndMs = effectiveEndMs,
+            exportPlaybackTimeline = exportPlaybackTimeline,
             onShowScreenshotModal = onShowScreenshotModal,
             onShowInspectUI = onShowInspectUI,
           )
@@ -876,6 +901,7 @@ private fun ColumnScope.VideoFramePanel(
   currentTimestamp: Long,
   effectiveStartMs: Long,
   effectiveEndMs: Long,
+  exportPlaybackTimeline: PlaybackTimeline?,
   activeDriverLog: TrailblazeLog.AgentDriverLog?,
   sessionId: String,
   imageLoader: ImageLoader,
@@ -931,13 +957,12 @@ private fun ColumnScope.VideoFramePanel(
 
     while (timelineState.isVideoPlaying) {
       val elapsed = (mark.elapsedNow().inWholeMilliseconds * speed).toLong()
-      val targetAbsMs = playStartAbsMs + elapsed
-      if (targetAbsMs >= videoEndAbsMs) {
-        timelineState.scrubTimestampMs = videoEndAbsMs
+      val tick = computePlaybackTick(elapsed, playStartAbsMs, videoEndAbsMs, exportPlaybackTimeline)
+      timelineState.scrubTimestampMs = tick.targetAbsMs
+      if (tick.reachedEnd) {
         timelineState.isVideoPlaying = false
         break
       }
-      timelineState.scrubTimestampMs = targetAbsMs
       delay(TimelineConstants.PLAYBACK_FRAME_INTERVAL_MS)
     }
   }
@@ -1006,6 +1031,11 @@ private fun ColumnScope.VideoFramePanel(
         )
       }
     }
+    // Export only: caption a fast-forwarded idle gap so the compressed animation doesn't
+    // silently imply two far-apart steps were adjacent (see issue #173 review).
+    exportPlaybackTimeline?.collapsedGapMsAt(currentTimestamp)?.let { gapMs ->
+      CompressedGapBadge(gapMs)
+    }
   }
 }
 
@@ -1024,6 +1054,7 @@ private fun ColumnScope.ScreenshotKeyframePanel(
   timelineState: SessionTimelineState,
   effectiveStartMs: Long,
   effectiveEndMs: Long,
+  exportPlaybackTimeline: PlaybackTimeline?,
   onShowScreenshotModal:
     ((imageModel: Any?, deviceWidth: Int, deviceHeight: Int, clickX: Int?, clickY: Int?, action: AgentDriverAction?) -> Unit)? =
     null,
@@ -1059,13 +1090,12 @@ private fun ColumnScope.ScreenshotKeyframePanel(
 
     while (timelineState.isVideoPlaying) {
       val elapsed = (mark.elapsedNow().inWholeMilliseconds * speed).toLong()
-      val targetAbsMs = playStartAbsMs + elapsed
-      if (targetAbsMs >= effectiveEndMs) {
-        timelineState.scrubTimestampMs = effectiveEndMs
+      val tick = computePlaybackTick(elapsed, playStartAbsMs, effectiveEndMs, exportPlaybackTimeline)
+      timelineState.scrubTimestampMs = tick.targetAbsMs
+      if (tick.reachedEnd) {
         timelineState.isVideoPlaying = false
         break
       }
-      timelineState.scrubTimestampMs = targetAbsMs
       delay(TimelineConstants.PLAYBACK_FRAME_INTERVAL_MS)
     }
   }
@@ -1155,6 +1185,38 @@ private fun ColumnScope.ScreenshotKeyframePanel(
         )
       }
     }
+    // Export only: caption a fast-forwarded idle gap so the compressed animation doesn't
+    // silently imply two far-apart steps were adjacent (see issue #173 review).
+    exportPlaybackTimeline?.collapsedGapMsAt(currentTimestamp)?.let { gapMs ->
+      CompressedGapBadge(gapMs)
+    }
+  }
+}
+
+/**
+ * Pill caption shown over the playback frame while export autoplay fast-forwards across a
+ * collapsed idle gap, e.g. "» 37m later". Keeps the standalone GIF/WebP/MP4 honest about the
+ * real time the compression skips — the duration that all three #173 reviewers said must not
+ * silently vanish — without spending it as playback. Export-only: in interactive viewing
+ * there's no [PlaybackTimeline], so this never renders there.
+ */
+@Composable
+private fun BoxScope.CompressedGapBadge(gapMs: Long) {
+  Box(
+    modifier = Modifier
+      .align(Alignment.TopCenter)
+      .padding(top = 8.dp)
+      .background(Color.Black.copy(alpha = 0.55f), RoundedCornerShape(12.dp))
+      .padding(horizontal = 10.dp, vertical = 4.dp),
+  ) {
+    Text(
+      // Prefix is ASCII ">>", not a ⏩ emoji or "»" — the bundled WASM Compose font renders
+      // neither (both came out as tofu in #173 end-to-end validation), but plain ASCII
+      // renders reliably and ">>" still reads as fast-forward/skip.
+      text = ">> ${formatCompactDuration(gapMs)} later",
+      style = MaterialTheme.typography.labelMedium,
+      color = Color.White,
+    )
   }
 }
 

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/tabs/session/SessionTimelineConstants.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/tabs/session/SessionTimelineConstants.kt
@@ -39,6 +39,22 @@ internal object TimelineConstants {
   // Playback
   const val PLAYBACK_FRAME_INTERVAL_MS = 50L
   const val END_OF_VIDEO_THRESHOLD_MS = 500L
+
+  /**
+   * Maximum dwell, in absolute session ms, that export autoplay spends on any single gap
+   * between recorded events. Gaps longer than this (idle time while a session was recorded
+   * interactively) are collapsed by [PlaybackTimeline] so export duration scales with step
+   * count rather than wall-clock — see issue #173. A 25-step session lands at roughly
+   * `25 * 4s = 100s` of compressed timeline, ~25s at the default 4x export speed, instead
+   * of mirroring a 100-minute recording. Only applied on the `?autoplay=1` export path;
+   * interactive playback keeps real (speed-scaled) timing.
+   *
+   * Note this is in *session* ms: the autoplay loop still divides elapsed by
+   * `playbackSpeed`, so the per-step *visible* dwell is `MAX_EXPORT_STEP_DWELL_MS /
+   * playbackSpeed` (~1s at the 4x default). Retune alongside the default speed in
+   * [SessionTimelineState] if either changes.
+   */
+  const val MAX_EXPORT_STEP_DWELL_MS = 4_000L
   const val NEARBY_LOGS_WINDOW_MS = 2000L
   const val SLIDESHOW_MIN_DELAY_MS = 200L
   const val SLIDESHOW_MAX_DELAY_MS = 3000L

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/utils/FormattingUtils.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/utils/FormattingUtils.kt
@@ -36,6 +36,27 @@ object FormattingUtils {
   }
 
   /**
+   * Coarse, human-readable duration for compact labels (e.g. the "» 37m later" badge the
+   * exported timeline shows over a collapsed idle gap). Rounds down to whole units:
+   * `"45s"`, `"37m"`, `"2h 5m"`, `"1h"` (minutes dropped on an exact hour). Unlike
+   * [formatDuration] (which renders seconds to 2dp and is meant for sub-minute step
+   * durations), this stays readable across minutes and hours.
+   */
+  fun formatCompactDuration(durationMs: Long): String {
+    val totalSeconds = kotlin.math.abs(durationMs) / 1000
+    val totalMinutes = totalSeconds / 60
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+    val seconds = totalSeconds % 60
+    return when {
+      hours > 0 && minutes > 0 -> "${hours}h ${minutes}m"
+      hours > 0 -> "${hours}h"
+      totalMinutes > 0 -> "${minutes}m"
+      else -> "${seconds}s"
+    }
+  }
+
+  /**
    * Formats integers with comma separators (e.g., 1234 → "1,234").
    * Used for displaying large numbers in a readable format.
    */

--- a/trailblaze-ui/src/jvmTest/kotlin/xyz/block/trailblaze/ui/tabs/session/PlaybackTimelineTest.kt
+++ b/trailblaze-ui/src/jvmTest/kotlin/xyz/block/trailblaze/ui/tabs/session/PlaybackTimelineTest.kt
@@ -1,0 +1,252 @@
+package xyz.block.trailblaze.ui.tabs.session
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for the idle-gap compression that keeps `--gif/--webp/--video` export
+ * duration proportional to step count rather than the session's real wall-clock (#173).
+ */
+class PlaybackTimelineTest {
+
+  @Test
+  fun `build returns null when there is nothing to compress`() {
+    assertNull(PlaybackTimeline.build(emptyList(), 1_000L))
+    assertNull(PlaybackTimeline.build(listOf(42L), 1_000L), "single anchor")
+    assertNull(PlaybackTimeline.build(listOf(1L, 1L, 1L), 1_000L), "all duplicates collapse to one")
+    assertNull(PlaybackTimeline.build(listOf(0L, 1_000L), 0L), "non-positive cap")
+  }
+
+  @Test
+  fun `gaps under the cap play one to one`() {
+    // Three anchors 1s apart, cap 4s — nothing is capped.
+    val tl = PlaybackTimeline.build(listOf(0L, 1_000L, 2_000L), 4_000L)!!
+    assertEquals(2_000L, tl.totalCompressedMs)
+    assertEquals(0L, tl.absoluteAt(0L))
+    assertEquals(1_000L, tl.absoluteAt(1_000L))
+    assertEquals(2_000L, tl.absoluteAt(2_000L))
+  }
+
+  @Test
+  fun `a long idle gap is collapsed to the cap`() {
+    // 0 -> 10ms of real activity, then a 100-minute idle gap, then end.
+    val tenMinutes = 10 * 60 * 1000L
+    val anchors = listOf(0L, 10L, tenMinutes)
+    val cap = 4_000L
+    val tl = PlaybackTimeline.build(anchors, cap)!!
+
+    // Compressed total = 10ms (first gap, under cap) + 4000ms (capped idle gap).
+    assertEquals(10L + cap, tl.totalCompressedMs)
+
+    // The collapsed gap still maps its endpoints to the real timestamps...
+    assertEquals(10L, tl.absoluteAt(10L))
+    assertEquals(tenMinutes, tl.absoluteAt(tl.totalCompressedMs))
+    // ...and the midpoint of the compressed gap interpolates to the midpoint of real time.
+    val mid = tl.absoluteAt(10L + cap / 2)
+    val expectedMid = (10L + tenMinutes) / 2
+    assertTrue(
+      kotlin.math.abs(mid - expectedMid) <= 2L,
+      "midpoint should interpolate to ~$expectedMid, was $mid",
+    )
+  }
+
+  @Test
+  fun `compressed duration scales with step count not wall-clock`() {
+    // 25 steps, each separated by an hour of idle time — the issue #173 shape.
+    val hour = 60 * 60 * 1000L
+    val anchors = (0 until 25).map { it * hour }
+    val cap = 4_000L
+    val tl = PlaybackTimeline.build(anchors, cap)!!
+
+    // 24 gaps, all far over the cap -> 24 * 4s, regardless of the ~24-hour real span.
+    assertEquals(24 * cap, tl.totalCompressedMs)
+    assertTrue(
+      tl.totalCompressedMs < 2 * 60 * 1000L,
+      "25-step session must compress to well under two minutes, was ${tl.totalCompressedMs}ms",
+    )
+  }
+
+  @Test
+  fun `out-of-range compressed offsets clamp to the endpoints`() {
+    val tl = PlaybackTimeline.build(listOf(100L, 600L), 4_000L)!!
+    assertEquals(100L, tl.absoluteAt(-50L))
+    assertEquals(600L, tl.absoluteAt(tl.totalCompressedMs + 9_999L))
+  }
+
+  @Test
+  fun `unsorted and duplicate anchors are normalized`() {
+    val tl = PlaybackTimeline.build(listOf(2_000L, 0L, 1_000L, 1_000L), 4_000L)!!
+    assertEquals(2_000L, tl.totalCompressedMs)
+    assertEquals(0L, tl.absoluteAt(0L))
+    assertEquals(2_000L, tl.absoluteAt(2_000L))
+  }
+
+  // ── compressedAt: inverse of absoluteAt ──────────────────────────────────
+
+  @Test
+  fun `compressedAt inverts absoluteAt across a collapsed gap`() {
+    val tenMinutes = 10 * 60 * 1000L
+    val tl = PlaybackTimeline.build(listOf(0L, 10L, tenMinutes), 4_000L)!!
+    // Endpoints.
+    assertEquals(0L, tl.compressedAt(tl.startAbsMs))
+    assertEquals(tl.totalCompressedMs, tl.compressedAt(tl.endAbsMs))
+    // Round-trip: compressed -> absolute -> compressed lands back where it started
+    // (within rounding) for several interior offsets.
+    for (c in listOf(0L, 5L, 10L, 10L + 1_000L, tl.totalCompressedMs - 1L)) {
+      val backC = tl.compressedAt(tl.absoluteAt(c))
+      assertTrue(kotlin.math.abs(backC - c) <= 2L, "round-trip $c -> $backC")
+    }
+  }
+
+  @Test
+  fun `compressedAt clamps outside the spanned range`() {
+    val tl = PlaybackTimeline.build(listOf(100L, 600L), 4_000L)!!
+    assertEquals(0L, tl.compressedAt(50L))
+    assertEquals(tl.totalCompressedMs, tl.compressedAt(9_999L))
+  }
+
+  // ── computePlaybackTick: shared autoplay step ────────────────────────────
+
+  @Test
+  fun `tick without a timeline advances 1 to 1 and snaps to endAbs`() {
+    // Below the end: advances from playStart by elapsed.
+    val t1 = computePlaybackTick(elapsedMs = 300L, playStartAbsMs = 1_000L, endAbsMs = 5_000L, timeline = null)
+    assertEquals(1_300L, t1.targetAbsMs)
+    assertFalse(t1.reachedEnd)
+    // At/over the end: snaps exactly to endAbs (not the overshoot) and reports end.
+    val t2 = computePlaybackTick(elapsedMs = 9_000L, playStartAbsMs = 1_000L, endAbsMs = 5_000L, timeline = null)
+    assertEquals(5_000L, t2.targetAbsMs)
+    assertTrue(t2.reachedEnd)
+  }
+
+  @Test
+  fun `tick with a timeline ends at the timeline endpoint, never the passed endAbs`() {
+    // Review #1: the end-snap must be the timeline's own endpoint, not the passed-in
+    // (uncovered) endAbs. This also pins the video-tail semantics (review #2): the video
+    // panel passes videoEndAbsMs = videoMetadata.endTimestampMs, which can extend past the
+    // last log event (effectiveEndMs = tl.endAbsMs). Compressed export deliberately stops at
+    // the last event and does NOT play a trailing event-less video tail — idle compression
+    // by design. Here the passed end (999_999) is well past tl.endAbsMs (600_000).
+    val tl = PlaybackTimeline.build(listOf(0L, 10L, 600_000L), 4_000L)!!
+    val videoEndAbsPastLastLog = 999_999L
+    val tick = computePlaybackTick(
+      elapsedMs = tl.totalCompressedMs + 1_000L,
+      playStartAbsMs = tl.startAbsMs,
+      endAbsMs = videoEndAbsPastLastLog,
+      timeline = tl,
+    )
+    assertTrue(tick.reachedEnd)
+    assertEquals(tl.endAbsMs, tick.targetAbsMs)
+    assertEquals(600_000L, tick.targetAbsMs)
+  }
+
+  @Test
+  fun `tick with a timeline snaps to its own endpoint even when the passed end is smaller`() {
+    // Reverse of the video-tail case: video ends BEFORE the last log, so the passed
+    // videoEndAbs (500_000) is less than tl.endAbsMs (600_000). Compression still follows
+    // the timeline and scrubs to its own endpoint; the frame cache clamps the sliver.
+    val tl = PlaybackTimeline.build(listOf(0L, 10L, 600_000L), 4_000L)!!
+    val videoEndAbsBeforeLastLog = 500_000L
+    val tick = computePlaybackTick(
+      elapsedMs = tl.totalCompressedMs + 1_000L,
+      playStartAbsMs = tl.startAbsMs,
+      endAbsMs = videoEndAbsBeforeLastLog,
+      timeline = tl,
+    )
+    assertTrue(tick.reachedEnd)
+    assertEquals(600_000L, tick.targetAbsMs)
+  }
+
+  @Test
+  fun `tick with a timeline advances onto the correct absolute frame mid-playback`() {
+    // A normal mid-run advance (not resume, not end): from session start, after some
+    // compressed elapsed that lands inside the second segment, the target must equal the
+    // timeline's own absolute mapping for that compressed offset.
+    val tl = PlaybackTimeline.build(listOf(0L, 1_000L, 3_000L, 600_000L), 4_000L)!!
+    val compressedElapsed = tl.totalCompressedMs - 100L // inside the final (collapsed) segment
+    val tick = computePlaybackTick(
+      elapsedMs = compressedElapsed,
+      playStartAbsMs = tl.startAbsMs, // export starts at session start -> compressedAt == 0
+      endAbsMs = 999_999L,
+      timeline = tl,
+    )
+    assertFalse(tick.reachedEnd)
+    assertEquals(tl.absoluteAt(compressedElapsed), tick.targetAbsMs)
+  }
+
+  @Test
+  fun `tick with a timeline resumes from the current position after a mid-run relaunch`() {
+    // review #2: a speed change relaunches the loop with elapsed reset to 0. Anchoring the
+    // compressed clock on the current scrub position must NOT jump playback back to start.
+    val tl = PlaybackTimeline.build(listOf(0L, 10L, 600_000L), 4_000L)!!
+    val midAbs = tl.absoluteAt(tl.totalCompressedMs / 2)
+    // Relaunch: elapsed starts at 0 again, playStart is the current (mid) position.
+    val tick = computePlaybackTick(elapsedMs = 0L, playStartAbsMs = midAbs, endAbsMs = 999_999L, timeline = tl)
+    assertFalse(tick.reachedEnd)
+    // Inside a collapsed gap 1 compressed-ms maps to ~150 absolute-ms, so compare in
+    // compressed space (the loop's clock), where the round-trip is near-exact. The point
+    // is that the offset is preserved — not reset to 0 — so playback doesn't restart.
+    assertTrue(
+      kotlin.math.abs(tl.compressedAt(tick.targetAbsMs) - tl.totalCompressedMs / 2) <= 2L,
+      "resume should preserve the compressed offset, target was ${tick.targetAbsMs}",
+    )
+    assertTrue(tick.targetAbsMs > tl.startAbsMs + 1_000L, "must not restart at session start")
+  }
+
+  // ── exportPlaybackAnchors: windowing rule ────────────────────────────────
+
+  @Test
+  fun `anchors always include the window bounds for an event-less session`() {
+    assertEquals(listOf(100L, 900L), exportPlaybackAnchors(emptyList(), startMs = 100L, endMs = 900L))
+  }
+
+  @Test
+  fun `anchors drop log timestamps outside the window`() {
+    val anchors = exportPlaybackAnchors(
+      logTimestampsMs = listOf(50L, 200L, 500L, 5_000L),
+      startMs = 100L,
+      endMs = 900L,
+    )
+    assertEquals(listOf(100L, 200L, 500L, 900L), anchors)
+  }
+
+  @Test
+  fun `anchors where every log shares one timestamp collapse to a single gap`() {
+    val anchors = exportPlaybackAnchors(listOf(400L, 400L, 400L), startMs = 100L, endMs = 900L)
+    // build() distinct()s these to {100, 400, 900} -> two gaps.
+    val tl = PlaybackTimeline.build(anchors, 4_000L)!!
+    assertEquals(100L, tl.startAbsMs)
+    assertEquals(900L, tl.endAbsMs)
+  }
+
+  // ── collapsedGapMsAt: surfacing fast-forwarded gaps ──────────────────────
+
+  @Test
+  fun `collapsedGapMsAt returns the real duration only inside a collapsed gap`() {
+    // First gap (0->2000) is under the 4s cap (plays 1:1); second (2000->600000) is collapsed.
+    val tl = PlaybackTimeline.build(listOf(0L, 2_000L, 600_000L), 4_000L)!!
+    // Inside the uncompressed gap -> null (nothing was skipped).
+    assertNull(tl.collapsedGapMsAt(1_000L))
+    // Inside the collapsed gap -> its real span (598_000ms), regardless of where in it.
+    assertEquals(598_000L, tl.collapsedGapMsAt(2_000L))
+    assertEquals(598_000L, tl.collapsedGapMsAt(300_000L))
+    assertEquals(598_000L, tl.collapsedGapMsAt(599_999L))
+  }
+
+  @Test
+  fun `collapsedGapMsAt is null outside the spanned range and at the final anchor`() {
+    val tl = PlaybackTimeline.build(listOf(0L, 600_000L), 4_000L)!!
+    assertNull(tl.collapsedGapMsAt(-1L))
+    assertNull(tl.collapsedGapMsAt(600_000L)) // end anchor: the gap is behind us
+    assertNull(tl.collapsedGapMsAt(700_000L))
+  }
+
+  @Test
+  fun `collapsedGapMsAt never fires when no gap exceeds the cap`() {
+    val tl = PlaybackTimeline.build(listOf(0L, 1_000L, 2_000L, 3_000L), 4_000L)!!
+    for (t in listOf(0L, 500L, 1_500L, 2_999L)) assertNull(tl.collapsedGapMsAt(t))
+  }
+}

--- a/trailblaze-ui/src/jvmTest/kotlin/xyz/block/trailblaze/ui/utils/FormattingUtilsTest.kt
+++ b/trailblaze-ui/src/jvmTest/kotlin/xyz/block/trailblaze/ui/utils/FormattingUtilsTest.kt
@@ -1,0 +1,31 @@
+package xyz.block.trailblaze.ui.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Coverage for [FormattingUtils.formatCompactDuration] — the coarse human format behind the
+ * "» Nm later" collapsed-gap badge in the exported timeline (#173).
+ */
+class FormattingUtilsTest {
+
+  @Test fun `sub-minute durations render as whole seconds`() {
+    assertEquals("0s", FormattingUtils.formatCompactDuration(0L))
+    assertEquals("5s", FormattingUtils.formatCompactDuration(5_000L))
+    assertEquals("40s", FormattingUtils.formatCompactDuration(40_900L)) // rounds down
+  }
+
+  @Test fun `minute-scale durations drop seconds`() {
+    assertEquals("1m", FormattingUtils.formatCompactDuration(60_000L))
+    assertEquals("37m", FormattingUtils.formatCompactDuration(37 * 60_000L + 30_000L))
+  }
+
+  @Test fun `hour-scale durations show hours and minutes`() {
+    assertEquals("1h", FormattingUtils.formatCompactDuration(60 * 60_000L)) // exact hour drops minutes
+    assertEquals("2h 5m", FormattingUtils.formatCompactDuration(2 * 60 * 60_000L + 5 * 60_000L))
+  }
+
+  @Test fun `negative durations are treated by magnitude`() {
+    assertEquals("37m", FormattingUtils.formatCompactDuration(-37 * 60_000L))
+  }
+}


### PR DESCRIPTION
Fixes #173.

## Problem

Animated timeline export (`trailblaze report --gif`/`--webp`/`--video`) drove the autoplay scrubber by `wallClockElapsed * playbackSpeed`, so animation length scaled with the session's **real wall-clock** — idle gaps included. A session recorded interactively over a long stretch (the issue's repro: ~25 meaningful steps spread across ~102 minutes) produced a 100+ minute animation that overran the capture window and aborted with **no artifact**:

```
Failed to capture report frames: Timeline playback did not signal completion within 600s …
```

Two further issues:
- `--video` ignored the `MAX_PLAYBACK_WAIT_MS` escape hatch that the `--gif` error explicitly advertised — it hit a hardcoded `600000ms` Playwright timeout instead.
- On overrun, all three paths hard-failed with no output rather than degrading.

## Fix

Matches the three suggestions in the issue:

1. **Cap per-step dwell (the core fix).** New `PlaybackTimeline` builds a piecewise-linear map from compressed playback time → absolute session time, collapsing any gap between recorded events longer than `MAX_EXPORT_STEP_DWELL_MS` (4s) down to that cap, while meaningful intra-step activity still plays 1:1. Both autoplay loops in `SessionCombinedView` use it, gated on the `?autoplay=1` export path so **interactive viewing is unchanged**. Export length now scales with step count, not wall-clock — a 25-step session animates in ~tens of seconds regardless of how long the recording took.
2. **One consistent, overridable timeout.** `PlaywrightReportCapture` resolves `MAX_PLAYBACK_WAIT_MS` once (env override, default 600000ms) and `ReportVideoExporter` now reads the same value instead of a hardcoded Playwright timeout — so the escape hatch works for `--video` too.
3. **Fail soft.** GIF/WebP capture writes the truncated frames with a warning instead of erroring; `--video` catches the Playwright `TimeoutError` and lets the existing `finally` finalize the partial MP4. (With the dwell cap in place this is rarely reached, but it's there as defense in depth.)

Documented the behavior + env var on the `report` command and regenerated `docs/CLI.md`.

## Tests

- New `PlaybackTimelineTest` (gap-collapse, 1:1 under cap, step-count scaling, clamping, normalization) and `PlaywrightReportCaptureTest` (timeout resolver fallback/override).
- Existing `Report*` + `CliCommandValidationTest` host suites and the full UI `jvmTest` suite pass.
- JVM and WASM (`-Ptrailblaze.wasm=true`) targets both compile.

Out of scope: the optional "surface duration in `session info`" nicety from the issue thread — not needed once playback no longer scales with wall-clock; can follow up if wanted.