### PR TITLE
Fix stale WASM bundle in generated report template

### DIFF
--- a/trailblaze-report/build.gradle.kts
+++ b/trailblaze-report/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 plugins {
@@ -66,7 +67,17 @@ val generateReportTemplate by tasks.registering(JavaExec::class) {
   description = "Generates a blank report template HTML with embedded WASM UI (requires -Ptrailblaze.wasm=true)"
   group = "report"
   if (reportWasmEnabled.get()) {
-    dependsOn(":trailblaze-ui:wasmJsBrowserProductionWebpack")
+    // Register the webpack distribution (the embedded JS + WASM bundle) as an INPUT, not just a
+    // `dependsOn`. A bare `dependsOn` orders the tasks but does NOT tie this task's up-to-date
+    // state to the bundle's contents — so editing the Compose report UI would re-run the webpack
+    // build yet leave `generateReportTemplate` UP-TO-DATE, embedding a stale WASM bundle in the
+    // generated template. Declaring the output as an input makes Gradle re-run us whenever the
+    // bundle changes (and correctly stay UP-TO-DATE when it doesn't).
+    val webpackTask = project(":trailblaze-ui").tasks.named("wasmJsBrowserProductionWebpack")
+    dependsOn(webpackTask)
+    inputs.files(webpackTask)
+      .withPropertyName("wasmDist")
+      .withPathSensitivity(PathSensitivity.RELATIVE)
   }
   classpath = sourceSets["main"].runtimeClasspath
   mainClass.set("xyz.block.trailblaze.report.ReportMainKt")


### PR DESCRIPTION
## Problem

`:trailblaze-report:generateReportTemplate` (in `trailblaze-report/build.gradle.kts`) declared its **output** (`trailblaze_report.html`) but not its **inputs**. It had a bare `dependsOn(":trailblaze-ui:wasmJsBrowserProductionWebpack")`, which orders the two tasks but does **not** tie the template task's up-to-date state to the webpack bundle's contents.

As a result, editing the Compose report UI (e.g. files under `trailblaze-ui/src/commonMain/.../tabs/session/`) re-ran `compileKotlinWasmJs` and `wasmJsBrowserProductionWebpack`, but `generateReportTemplate` stayed `UP-TO-DATE` and kept embedding the **stale** WASM bundle in `trailblaze-report/build/report-template/trailblaze_report.html`. So `trailblaze report --gif/--webp/--video` (and the desktop report) rendered old UI until the template output was manually deleted or a clean build was run.

This was discovered while validating #178 (issue #173): badge-text changes in the WASM UI silently didn't appear in the exported GIF until the template HTML was deleted to force regeneration. The fix is independent of #178.

## Fix

Register the webpack distribution (the embedded JS + WASM bundle) as a proper task **input** via `inputs.files(webpackTask)` with `RELATIVE` path sensitivity, keeping the implicit dependency. Passing the `TaskProvider` to `inputs.files(...)` wires in the webpack task's declared outputs (the dist dir at `trailblaze-ui/build/kotlin-webpack/wasmJs/productionExecutable` — exactly what `WasmReport.generateRaw` embeds).

## Verification

Full WASM builds (`-Ptrailblaze.wasm=true`):

| Step | `generateReportTemplate` outcome | `trailblaze_report.html` hash |
|------|----------------------------------|-------------------------------|
| Baseline build | EXECUTED | `e26ba2e…` |
| No-op re-run | **UP-TO-DATE** | unchanged |
| After editing a report-UI string | **EXECUTED** (previously stayed UP-TO-DATE — the bug) | `5ce675b…` (changed) |
| No-op re-run after edit | **UP-TO-DATE** | — |

Confirms the task now re-runs when the bundle changes and correctly stays up-to-date when it doesn't (no always-rerun churn).

> Note: the template HTML embeds the JS/WASM bundles gzip+base64-encoded, so an edited UI string is not grep-able as plaintext in the output. Verification used task outcome (UP-TO-DATE vs EXECUTED) plus output-file hash change, which directly proves the new bundle was re-embedded.

### Out of scope
`WasmReport.generateRaw` also reads `trailblaze-ui/src/wasmJsMain/resources/index.html` directly (not via the webpack dist), so edits to that template file are still not tracked by up-to-date checking. The reported bug was specifically the WASM bundle; happy to add an `inputs.file(...)` for that index.html in a follow-up if wanted.