### PR TITLE
Make the WASM report-template build work with Gradle's configuration cache

### DIFF
--- a/trailblaze-report/build.gradle.kts
+++ b/trailblaze-report/build.gradle.kts
@@ -73,9 +73,16 @@ val generateReportTemplate by tasks.registering(JavaExec::class) {
     // build yet leave `generateReportTemplate` UP-TO-DATE, embedding a stale WASM bundle in the
     // generated template. Declaring the output as an input makes Gradle re-run us whenever the
     // bundle changes (and correctly stay UP-TO-DATE when it doesn't).
+    //
+    // Register the webpack task's OUTPUT FILES (resolved lazily) rather than the task object: a
+    // `KotlinWebpack` task isn't serializable by the configuration cache, so passing the task
+    // provider straight to `inputs.files(...)` fails the build with `cannot serialize object of
+    // type 'org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack'`. Mapping to
+    // `outputs.files` stores only the file collection in the cache and keeps the implicit task
+    // dependency, which `dependsOn` also pins explicitly.
     val webpackTask = project(":trailblaze-ui").tasks.named("wasmJsBrowserProductionWebpack")
     dependsOn(webpackTask)
-    inputs.files(webpackTask)
+    inputs.files(webpackTask.map { it.outputs.files })
       .withPropertyName("wasmDist")
       .withPathSensitivity(PathSensitivity.RELATIVE)
   }


### PR DESCRIPTION
## What changed

The task that builds the blank WASM report template (`generateReportTemplate`)
now works when Gradle runs with the **configuration cache** enabled. Before
this change, a config-cache build failed while *storing* the cache with:

```
cannot serialize object of type
'org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpack',
a subtype of 'org.gradle.api.Task', as these are not supported with the
configuration cache.
```

If you build this repo without the configuration cache you'd never have hit
it; with it on, the report-template build was broken.

## Why

A recent change wired the webpack distribution (the embedded JS + WASM bundle)
as an *input* of `generateReportTemplate` so the task correctly re-runs when the
report UI changes. It did that by handing the webpack **task** itself to
`inputs.files(...)`. The configuration cache then tries to serialize that task,
and a `KotlinWebpack` task isn't serializable — so the build fails.

## The fix

Register the webpack task's **output files** (resolved lazily) instead of the
task object:

```kotlin
inputs.files(webpackTask.map { it.outputs.files })
```

This keeps the exact same up-to-date behavior — edit the report UI and the
template regenerates — but only the resolved file collection goes into the
configuration cache. `dependsOn(webpackTask)` still pins task ordering
explicitly.

## Test plan

- [x] `./gradlew :trailblaze-report:generateReportTemplate -Ptrailblaze.wasm=true`
      with the configuration cache enabled: cache **stored**, rerun **reuses**
      it and the task is `UP-TO-DATE`, template HTML produced.
- [x] `./gradlew :trailblaze-report:check -Ptrailblaze.wasm=true` passes with the
      configuration cache enabled.
