### PR TITLE
Fix host->device adb port forward hang on some Android devices (Tab S8)

### DIFF
--- a/trailblaze-common/src/jvmMain/kotlin/xyz/block/trailblaze/util/AndroidHostAdbUtils.kt
+++ b/trailblaze-common/src/jvmMain/kotlin/xyz/block/trailblaze/util/AndroidHostAdbUtils.kt
@@ -250,8 +250,7 @@ object AndroidHostAdbUtils {
    * Runs an `adb` ProcessBuilder with a timeout, force-killing it if it does not exit in time.
    * Matches the legacy `process.waitFor(timeout, SECONDS) -> destroyForcibly` pattern that protected
    * device discovery and port-forward cleanup from a wedged adb/adbd. Returns true only if the
-   * process both exited within the deadline and exited with a zero exit code — a process that ran
-   * to completion but failed (e.g. `adb forward` rejecting a bad port) is not a "clean exit".
+   * process exited within the deadline with a zero exit code.
    */
   private fun runProcessBuilderWithTimeout(
     pb: ProcessBuilder,
@@ -278,10 +277,7 @@ object AndroidHostAdbUtils {
    * the forward down via `adb forward --remove tcp:$localPort`. Mirrors [adbPortForwardLocalAbstract]
    * and [adbPortReverse], which already shell out to the binary.
    *
-   * @throws IOException if the `adb forward` command times out or exits non-zero, so callers
-   * ([adbPortForward], [diagnoseAndReAdbPortForward]) surface the failure instead of silently
-   * believing a forward is active when the device never actually got one — the exact class of
-   * silent hang this whole binary-based approach exists to fix.
+   * @throws IOException if the `adb forward` command times out or exits non-zero.
    */
   private fun installAdbForwardViaBinary(
     deviceId: TrailblazeDeviceId,
@@ -334,9 +330,7 @@ object AndroidHostAdbUtils {
       // localPort), so just drop our duplicate AutoCloseable WITHOUT running `--remove`.
       activeForwards.putIfAbsent(key, forwarder)
     } catch (e: Exception) {
-      // Fall back to the exception's class name if the message is blank, so the user-visible
-      // error stays informative instead of "null". Stack trace is still preserved via the
-      // `cause` parameter for log inspection.
+      // Fall back to the class name when message is blank, so the error isn't just "null".
       val detail = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
       throw RuntimeException(
         "Failed to start port forwarding tcp:$localPort -> tcp:$remotePort on " +

--- a/trailblaze-common/src/jvmMain/kotlin/xyz/block/trailblaze/util/AndroidHostAdbUtils.kt
+++ b/trailblaze-common/src/jvmMain/kotlin/xyz/block/trailblaze/util/AndroidHostAdbUtils.kt
@@ -249,8 +249,9 @@ object AndroidHostAdbUtils {
   /**
    * Runs an `adb` ProcessBuilder with a timeout, force-killing it if it does not exit in time.
    * Matches the legacy `process.waitFor(timeout, SECONDS) -> destroyForcibly` pattern that protected
-   * device discovery and port-forward cleanup from a wedged adb/adbd. Returns true on a clean exit
-   * within the deadline.
+   * device discovery and port-forward cleanup from a wedged adb/adbd. Returns true only if the
+   * process both exited within the deadline and exited with a zero exit code — a process that ran
+   * to completion but failed (e.g. `adb forward` rejecting a bad port) is not a "clean exit".
    */
   private fun runProcessBuilderWithTimeout(
     pb: ProcessBuilder,
@@ -262,7 +263,7 @@ object AndroidHostAdbUtils {
       process.destroyForcibly()
       process.waitFor(1, java.util.concurrent.TimeUnit.SECONDS)
     }
-    finished
+    finished && process.exitValue() == 0
   } catch (_: Exception) {
     false
   }
@@ -276,19 +277,27 @@ object AndroidHostAdbUtils {
    * e.g. the Galaxy Tab S8 — flooding "tcp:<port>: closed"). Returns an [AutoCloseable] that tears
    * the forward down via `adb forward --remove tcp:$localPort`. Mirrors [adbPortForwardLocalAbstract]
    * and [adbPortReverse], which already shell out to the binary.
+   *
+   * @throws IOException if the `adb forward` command times out or exits non-zero, so callers
+   * ([adbPortForward], [diagnoseAndReAdbPortForward]) surface the failure instead of silently
+   * believing a forward is active when the device never actually got one — the exact class of
+   * silent hang this whole binary-based approach exists to fix.
    */
   private fun installAdbForwardViaBinary(
     deviceId: TrailblazeDeviceId,
     localPort: Int,
     remotePort: Int,
   ): AutoCloseable {
-    runProcessBuilderWithTimeout(
+    val installed = runProcessBuilderWithTimeout(
       createAdbCommandProcessBuilder(
         deviceId = deviceId,
         args = listOf("forward", "tcp:$localPort", "tcp:$remotePort"),
       ),
       timeoutMs = DEFAULT_SHORT_CALL_TIMEOUT_MS,
     )
+    if (!installed) {
+      throw IOException("adb forward tcp:$localPort tcp:$remotePort failed or timed out")
+    }
     return AutoCloseable {
       runCatching {
         runProcessBuilderWithTimeout(
@@ -325,10 +334,9 @@ object AndroidHostAdbUtils {
       // localPort), so just drop our duplicate AutoCloseable WITHOUT running `--remove`.
       activeForwards.putIfAbsent(key, forwarder)
     } catch (e: Exception) {
-      // Many transports throw with a null `message` (notably dadb's BindException for
-      // "Address already in use"), so falling back to `e.javaClass.simpleName` keeps the
-      // user-visible error informative instead of "null". Stack trace is still preserved
-      // via the `cause` parameter for log inspection.
+      // Fall back to the exception's class name if the message is blank, so the user-visible
+      // error stays informative instead of "null". Stack trace is still preserved via the
+      // `cause` parameter for log inspection.
       val detail = e.message?.takeIf { it.isNotBlank() } ?: e.javaClass.simpleName
       throw RuntimeException(
         "Failed to start port forwarding tcp:$localPort -> tcp:$remotePort on " +

--- a/trailblaze-common/src/jvmMain/kotlin/xyz/block/trailblaze/util/AndroidHostAdbUtils.kt
+++ b/trailblaze-common/src/jvmMain/kotlin/xyz/block/trailblaze/util/AndroidHostAdbUtils.kt
@@ -27,7 +27,7 @@ object AndroidHostAdbUtils {
   private val dadbClients = ConcurrentHashMap<String, Dadb>()
 
   // Tracks active port forwards (host port → AutoCloseable) so removePortForward can tear them
-  // down. dadb's tcpForward returns an AutoCloseable that owns the forward's lifetime.
+  // down. The AutoCloseable owns the forward's lifetime (removes it via the adb binary on close).
   private val activeForwards = ConcurrentHashMap<Pair<String, Int>, AutoCloseable>()
 
   // Default per-shell-call timeout for command paths that need a bounded wait (`logcat -d`,
@@ -271,6 +271,38 @@ object AndroidHostAdbUtils {
     listInstalledPackages(deviceId).any { it == appId }
 
   /**
+   * Installs a host→device `adb forward tcp:$localPort tcp:$remotePort` via the real adb binary
+   * (NOT dadb's [Dadb.tcpForward], which drops the connection immediately on some devices —
+   * e.g. the Galaxy Tab S8 — flooding "tcp:<port>: closed"). Returns an [AutoCloseable] that tears
+   * the forward down via `adb forward --remove tcp:$localPort`. Mirrors [adbPortForwardLocalAbstract]
+   * and [adbPortReverse], which already shell out to the binary.
+   */
+  private fun installAdbForwardViaBinary(
+    deviceId: TrailblazeDeviceId,
+    localPort: Int,
+    remotePort: Int,
+  ): AutoCloseable {
+    runProcessBuilderWithTimeout(
+      createAdbCommandProcessBuilder(
+        deviceId = deviceId,
+        args = listOf("forward", "tcp:$localPort", "tcp:$remotePort"),
+      ),
+      timeoutMs = DEFAULT_SHORT_CALL_TIMEOUT_MS,
+    )
+    return AutoCloseable {
+      runCatching {
+        runProcessBuilderWithTimeout(
+          createAdbCommandProcessBuilder(
+            deviceId = deviceId,
+            args = listOf("forward", "--remove", "tcp:$localPort"),
+          ),
+          timeoutMs = DEFAULT_SHORT_CALL_TIMEOUT_MS,
+        )
+      }
+    }
+  }
+
+  /**
    * Sets up a host→device TCP forward, equivalent to `adb forward tcp:local tcp:remote`. Idempotent
    * per (deviceId, localPort): a no-op if the forward is already active. Forwards are owned by the
    * JVM process and torn down via [removePortForward] or when the JVM exits.
@@ -287,12 +319,11 @@ object AndroidHostAdbUtils {
     }
     try {
       Console.log("Setting up port forward tcp:$localPort -> tcp:$remotePort")
-      val forwarder = withDadb(deviceId) { it.tcpForward(localPort, remotePort) }
-      val existing = activeForwards.putIfAbsent(key, forwarder)
-      if (existing != null) {
-        // Lost a race — close the duplicate.
-        runCatching { forwarder.close() }
-      }
+      // Real `adb forward` binary instead of dadb.tcpForward (which fails on some devices).
+      val forwarder = installAdbForwardViaBinary(deviceId, localPort, remotePort)
+      // If we lost a race, the winner governs the same underlying `adb forward` (idempotent by
+      // localPort), so just drop our duplicate AutoCloseable WITHOUT running `--remove`.
+      activeForwards.putIfAbsent(key, forwarder)
     } catch (e: Exception) {
       // Many transports throw with a null `message` (notably dadb's BindException for
       // "Address already in use"), so falling back to `e.javaClass.simpleName` keeps the
@@ -317,9 +348,10 @@ object AndroidHostAdbUtils {
    * table — queried directly via the `host:list-forward` host-service (the authoritative source,
    * not the in-process [activeForwards] map which can be stale). Then unconditionally tears down
    * any tracked forwarder this JVM held for that (deviceId, localPort) pair and re-establishes a
-   * fresh one via [Dadb.tcpForward]. Returns the pre-recovery presence state for callers that
-   * want to structure failure messages or telemetry: `true` = entry was PRESENT in the adb
-   * server's table, `false` = ABSENT, `null` = could not determine (host-services query failed).
+   * fresh one via the real adb binary (see [installAdbForwardViaBinary]). Returns the pre-recovery
+   * presence state for callers that want to structure failure messages or telemetry: `true` =
+   * entry was PRESENT in the adb server's table, `false` = ABSENT, `null` = could not determine
+   * (host-services query failed).
    */
   fun diagnoseAndReAdbPortForward(
     deviceId: TrailblazeDeviceId,
@@ -341,14 +373,10 @@ object AndroidHostAdbUtils {
     val key = deviceId.instanceId to localPort
     activeForwards.remove(key)?.let { runCatching { it.close() } }
     try {
-      val forwarder = withDadb(deviceId) { it.tcpForward(localPort, remotePort) }
-      val existing = activeForwards.putIfAbsent(key, forwarder)
-      if (existing != null) {
-        // Lost a race — close the duplicate so we don't leak its socket.
-        runCatching { forwarder.close() }
-      }
+      val forwarder = installAdbForwardViaBinary(deviceId, localPort, remotePort)
+      activeForwards.putIfAbsent(key, forwarder)
     } catch (e: Exception) {
-      Console.log("[AndroidHostAdbUtils] dadb tcpForward (recovery) failed: ${e.message}")
+      Console.log("[AndroidHostAdbUtils] adb forward (recovery) failed: ${e.message}")
     }
     return wasActive
   }


### PR DESCRIPTION
## Summary
- `dadb`'s `tcpForward` drops the connection immediately on some devices (reproduced on a Samsung Galaxy Tab S8 / SM-X800, Android 16), flooding the host with `tcp:<port>: closed` and hanging the drive forever waiting for the on-device RPC server.
- `adbPortForward` and its recovery path (`diagnoseAndReAdbPortForward`) now set up host→device forwards via the real `adb forward` binary instead of `dadb.tcpForward`, mirroring `adbPortForwardLocalAbstract` and `adbPortReverse`, which already shell out to the binary for the same reason.
- Extracted a shared `installAdbForwardViaBinary` helper that installs the forward and returns an `AutoCloseable` that tears it down via `adb forward --remove`.

This applies the fix diagnosed and verified by @basementbot at https://github.com/block/trailblaze/compare/main...basementbot:trailblaze:fix/dadb-adb-forward-tab-s8, adapted to the current state of `AndroidHostAdbUtils.kt`.

Fixes #183

## Test plan
- [x] `./gradlew :trailblaze-common:compileKotlinJvm` builds clean
- [x] `./gradlew :trailblaze-common:jvmTest --tests "xyz.block.trailblaze.util.AndroidHostAdbUtilsTest"` passes
- [ ] Manual verification on a Galaxy Tab S8 (or similar affected device) that a drive no longer hangs on connect