### PR TITLE
Set targetSdk=36 on trailblaze-android-ondevice-mcp to fix Play Protect block

### DIFF
--- a/trailblaze-android-ondevice-mcp/build.gradle.kts
+++ b/trailblaze-android-ondevice-mcp/build.gradle.kts
@@ -11,6 +11,7 @@ android {
   compileSdk = 36
   defaultConfig {
     minSdk = 26
+    targetSdk = 36
     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     testApplicationId = "xyz.block.trailblaze.runner"
   }


### PR DESCRIPTION
## Summary
- `trailblaze-android-ondevice-mcp/build.gradle.kts` never set `targetSdk`, so its generated androidTest APK (`xyz.block.trailblaze.runner`) ended up targeting a low API level
- Modern Android's Play Protect blocks installing apps that target old API levels with an "Unsafe app blocked... built for an older version of Android" dialog, which prevents the on-device runner from installing at all
- `trailblaze-android` already sets `targetSdk = 36`; this brings the on-device runner module in line with it

Fixes #182

## Test plan
- [x] `./gradlew :trailblaze-android-ondevice-mcp:assembleDebugAndroidTest` — BUILD SUCCESSFUL
- [x] `aapt dump badging` on the resulting APK confirms `targetSdkVersion:'36'` for `xyz.block.trailblaze.runner` (previously unset)