### PR TITLE
Fix daemon SIGSEGV from cross-thread QuickJS access on async host callbacks

### DIFF
--- a/trailblaze-quickjs-tools/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/quickjs/tools/QuickJsToolHost.kt
+++ b/trailblaze-quickjs-tools/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/quickjs/tools/QuickJsToolHost.kt
@@ -3,10 +3,12 @@ package xyz.block.trailblaze.quickjs.tools
 import com.dokar.quickjs.QuickJs
 import com.dokar.quickjs.binding.asyncFunction
 import com.dokar.quickjs.binding.function
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.util.concurrent.Executors
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -26,6 +28,16 @@ class QuickJsToolHost internal constructor(
    * assertion needs to read state outside the normal listTools/callTool surface.
    */
   internal val quickJs: QuickJs,
+  /**
+   * The single owning thread for [quickJs]. QuickJS-NG (via quickjs-kt) is NOT thread-safe:
+   * `evaluate` runs the native call on the *calling* thread while async host functions resume
+   * on `CoroutineScope(jobDispatcher)`. If those differ, the async resume re-enters the engine
+   * (and JNI) from the wrong thread and the JVM segfaults (`SIGSEGV` in `jni_CallObjectMethod`).
+   * So the engine is created, evaluated, resumed, and closed entirely on this one-thread
+   * dispatcher (used as the engine's `jobDispatcher` AND wrapped around every `quickJs.*` call).
+   * Owned by this host; closed in [shutdown].
+   */
+  private val engineDispatcher: ExecutorCoroutineDispatcher,
 ) {
 
   /**
@@ -43,31 +55,40 @@ class QuickJsToolHost internal constructor(
   internal val evalMutex: Mutex = Mutex()
 
   /**
+   * Guards [shutdown] so a second call is a no-op instead of dispatching onto an
+   * already-[ExecutorCoroutineDispatcher.close]d [engineDispatcher], which rejects new tasks
+   * with a `CancellationException` rather than the idempotent no-op callers expect.
+   */
+  private val isShutdown = java.util.concurrent.atomic.AtomicBoolean(false)
+
+  /**
    * List the tools the bundle registered. Reads `globalThis.__trailblazeTools` and serializes
    * per-tool spec to a [RegisteredToolSpec]. Returns an empty list when the bundle didn't
    * register anything (legitimate — the bundle might be a no-op fixture).
    */
   suspend fun listTools(): List<RegisteredToolSpec> = evalMutex.withLock {
-    val specsJson = quickJs.evaluate<String>(
-      // Reads the registry, projects each entry to `{name, spec}`, JSON-stringifies. The
-      // `|| {}` fallback means an empty registry returns `[]` rather than crashing on `Object.keys(undefined)`.
-      """
-      JSON.stringify(
-        Object.entries(globalThis.__trailblazeTools || {}).map(([name, t]) => ({
-          name,
-          spec: t.spec || {}
-        }))
+    withContext(engineDispatcher) {
+      val specsJson = quickJs.evaluate<String>(
+        // Reads the registry, projects each entry to `{name, spec}`, JSON-stringifies. The
+        // `|| {}` fallback means an empty registry returns `[]` rather than crashing on `Object.keys(undefined)`.
+        """
+        JSON.stringify(
+          Object.entries(globalThis.__trailblazeTools || {}).map(([name, t]) => ({
+            name,
+            spec: t.spec || {}
+          }))
+        )
+        """.trimIndent(),
+        "list-tools.js",
+        false,
       )
-      """.trimIndent(),
-      "list-tools.js",
-      false,
-    )
-    val parsed = JSON.parseToJsonElement(specsJson) as kotlinx.serialization.json.JsonArray
-    parsed.map { entry ->
-      val obj = entry.jsonObject
-      val name = (obj["name"] as kotlinx.serialization.json.JsonPrimitive).content
-      val spec = obj["spec"]?.jsonObject ?: JsonObject(emptyMap())
-      RegisteredToolSpec(name = name, spec = spec)
+      val parsed = JSON.parseToJsonElement(specsJson) as kotlinx.serialization.json.JsonArray
+      parsed.map { entry ->
+        val obj = entry.jsonObject
+        val name = (obj["name"] as kotlinx.serialization.json.JsonPrimitive).content
+        val spec = obj["spec"]?.jsonObject ?: JsonObject(emptyMap())
+        RegisteredToolSpec(name = name, spec = spec)
+      }
     }
   }
 
@@ -82,6 +103,7 @@ class QuickJsToolHost internal constructor(
    */
   suspend fun callTool(name: String, args: JsonObject, ctx: JsonObject? = null): JsonObject =
     evalMutex.withLock {
+      withContext(engineDispatcher) {
       // Encode args/ctx as JS string literals + `JSON.parse(...)` inside the module rather than
       // splicing the raw JSON output into the generated source. JSON encodes the U+2028
       // (line separator) and U+2029 (paragraph separator) code points as themselves — valid
@@ -258,20 +280,31 @@ class QuickJsToolHost internal constructor(
         false,
       )
       JSON.parseToJsonElement(resultJson).jsonObject
+      }
     }
 
   /**
-   * Free the QuickJS engine. Idempotent; safe to call multiple times. Runs the native free
-   * under `Dispatchers.IO` because tearing down a bundle with lots of retained JS allocations
-   * can block.
+   * Free the QuickJS engine. Idempotent; safe to call multiple times. The native free runs on
+   * [engineDispatcher] (the engine's owning thread — freeing it from any other thread is the same
+   * cross-thread hazard as evaluating from one), then the dedicated thread is released.
    */
   suspend fun shutdown() {
-    withContext(Dispatchers.IO) {
+    if (!isShutdown.compareAndSet(false, true)) return
+    withContext(engineDispatcher) {
       runCatching { quickJs.close() }
     }
+    engineDispatcher.close()
   }
 
   companion object {
+
+    /**
+     * Monotonic id for engine threads. Each [connect] mints its own single-thread dispatcher, so
+     * in a multi-tenant daemon (many devices/agents/bundles at once) every engine runs on its own
+     * uniquely-named thread — a thread dump or `hs_err` crash log then names exactly which engine
+     * it was, instead of N identical `quickjs-tool-engine` threads.
+     */
+    private val engineThreadSeq = java.util.concurrent.atomic.AtomicLong(0)
 
     /**
      * Stand up a fresh QuickJS engine, install the optional host binding, evaluate the bundle.
@@ -303,8 +336,18 @@ class QuickJsToolHost internal constructor(
       engineExtension: QuickJsEngineExtension? = null,
       logSink: (String) -> Unit = DEFAULT_LOG_SINK,
     ): QuickJsToolHost {
-      val quickJs = QuickJs.create(Dispatchers.Default)
+      // One dedicated daemon thread owns this engine for its entire lifecycle. It is BOTH the
+      // engine's `jobDispatcher` (so async host-function resumes run here) AND the thread every
+      // `quickJs.*` call below is confined to via `withContext`. Using a multi-threaded pool like
+      // `Dispatchers.Default` lets `evaluate` (caller thread) and the async resume (a pool worker)
+      // land on different threads, which re-enters the single-threaded native engine cross-thread
+      // and segfaults the JVM (`SIGSEGV` in `jni_CallObjectMethod`).
+      val engineDispatcher: ExecutorCoroutineDispatcher = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "quickjs-tool-engine-${engineThreadSeq.incrementAndGet()}").apply { isDaemon = true }
+      }.asCoroutineDispatcher()
+      val quickJs = withContext(engineDispatcher) { QuickJs.create(engineDispatcher) }
       try {
+        withContext(engineDispatcher) {
         if (hostBinding != null) {
           // Async binding so JS can `await __trailblazeCall(name, argsJson)`. Returns the
           // result-JSON string the SDK shim will JSON.parse on the JS side.
@@ -360,9 +403,11 @@ class QuickJsToolHost internal constructor(
         // Evaluate the author bundle. Population of globalThis.__trailblazeTools happens
         // here as a side effect.
         quickJs.evaluate<Any?>(bundleJs, bundleFilename, false)
-        return QuickJsToolHost(quickJs)
+        }
+        return QuickJsToolHost(quickJs, engineDispatcher)
       } catch (t: Throwable) {
-        runCatching { quickJs.close() }
+        withContext(engineDispatcher) { runCatching { quickJs.close() } }
+        engineDispatcher.close()
         throw t
       }
     }

--- a/trailblaze-quickjs-tools/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/quickjs/tools/QuickJsToolHost.kt
+++ b/trailblaze-quickjs-tools/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/quickjs/tools/QuickJsToolHost.kt
@@ -104,182 +104,182 @@ class QuickJsToolHost internal constructor(
   suspend fun callTool(name: String, args: JsonObject, ctx: JsonObject? = null): JsonObject =
     evalMutex.withLock {
       withContext(engineDispatcher) {
-      // Encode args/ctx as JS string literals + `JSON.parse(...)` inside the module rather than
-      // splicing the raw JSON output into the generated source. JSON encodes the U+2028
-      // (line separator) and U+2029 (paragraph separator) code points as themselves — valid
-      // JSON, but in classic JS source they are line terminators that break a multi-line
-      // string-spliced expression at parse time. Embedding via a JS string literal turns the
-      // bytes into characters QuickJS reads through the string-literal grammar (which treats
-      // them as ordinary characters), and `JSON.parse` reconstructs the object on the JS side.
-      val argsLiteral = jsString(JSON.encodeToString(JsonObject.serializer(), args))
-      val ctxLiteral = if (ctx != null) {
-        // Same string-literal-then-parse trick. Wrapping in `JSON.parse(<literal>)` produces
-        // an Object the handler sees as `ctx`.
-        "JSON.parse(${jsString(JSON.encodeToString(JsonObject.serializer(), ctx))})"
-      } else {
-        "undefined"
-      }
-      // Module-mode evaluation supports top-level await in QuickJS-NG; script-mode does not, and
-      // quickjs-kt's `evaluate<T>` doesn't unwrap returned Promises (returns the literal Promise
-      // object stringified). The dispatch path therefore uses module mode + writes the result to a
-      // global, then a separate script-mode read picks the result up. The [evalMutex] above
-      // makes the "evaluate then read" pair atomic so concurrent callers can't clobber each
-      // other's `__trailblazeLastResult`.
-      // The `try { JSON.stringify } catch` on the JS side guarantees the string we read back
-      // is always parseable JSON — handlers that return non-serializable values (functions,
-      // BigInts, circular structures) get a structured `{ isError: true, ... }` envelope
-      // instead of crashing the Kotlin parse step. Without this, `JSON.stringify` on a bad
-      // value emits `undefined`, the read-back returns the literal string `"undefined"`, and
-      // `JSON.parseToJsonElement` throws an opaque `JsonDecodingException` from a layer with
-      // no author context.
-      val dispatchExpr = """
-        const __registry = globalThis.__trailblazeTools || {};
-        const tool = __registry[${jsString(name)}];
-        if (!tool) {
-          // Include the registered tool names in the error so the author sees which tools
-          // actually loaded — typo, mismatched `name:` field in the descriptor, or a bundle
-          // that registered nothing at all are the three things this catches. The bundler
-          // should have ensured at least one registration; emit a more pointed hint when
-          // the registry is empty.
-          const __known = Object.keys(__registry);
-          const __hint = __known.length === 0
-            ? ' (no tools are registered on this host — the bundle may have loaded but its synthesized wrapper failed to populate `globalThis.__trailblazeTools`. Verify your scripted-tool source exports the function under the same `name:` declared in its YAML descriptor.)'
-            : ' (registered tools: ' + __known.sort().join(', ') + ')';
-          throw new Error('Tool not registered: ' + ${jsString(name)} + __hint);
-        }
-        const __args = JSON.parse(${argsLiteral});
-        const __ctx = ${ctxLiteral};
-        // Inject framework-provided resolver methods on `ctx.target`. Methods can't
-        // survive the JSON-serialization round-trip (host → JS engine), so we attach
-        // them here on the JS side after deserialization. The methods read from the
-        // same `target` data the framework already populates (appId, appIds[],
-        // and the future resolvedBaseUrl / baseUrls[] fields when the manifest schema
-        // for `target.platforms.web.base_urls:` lands). Forward-compatible: when the
-        // framework starts emitting baseUrls data, `resolveBaseUrl` automatically
-        // picks it up without any author-side change.
-        if (__ctx && __ctx.target) {
-          __ctx.target.resolveAppId = function(options) {
-            const opts = options || {};
-            const fromTarget = this.appId || (this.appIds && this.appIds[0]);
-            if (typeof fromTarget === 'string' && fromTarget.length > 0) return fromTarget;
-            if (typeof opts.defaultAppId === 'string') {
-              const trimmed = opts.defaultAppId.trim();
-              if (trimmed.length > 0) return trimmed;
-            }
-            return undefined;
-          };
-          __ctx.target.resolveBaseUrl = function(options) {
-            const opts = options || {};
-            const fromTarget = this.resolvedBaseUrl || (this.baseUrls && this.baseUrls[0]);
-            if (typeof fromTarget === 'string' && fromTarget.length > 0) return fromTarget;
-            if (typeof opts.defaultBaseUrl === 'string') {
-              const trimmed = opts.defaultBaseUrl.trim();
-              if (trimmed.length > 0) return trimmed;
-            }
-            return undefined;
-          };
-        }
-        // Wrap the handler call in a JS-side try/catch so a JS-side throw surfaces through
-        // the same `isError: true` envelope path that `toTrailblazeToolResult` already maps
-        // to `ExceptionThrown.errorMessage`. Without this catch, the throw escapes QuickJS as
-        // a Kotlin throwable whose `.message` carries the JS error message but loses
-        // `Error.stack` (the bundle filename + line/col QuickJS-NG fills in) — the author
-        // debugging from session logs sees "boom" with no breadcrumb to the source line.
-        // Surfacing the stack here keeps the existing Kotlin-side catch a fallback for
-        // anything QuickJS still routes through the throwable path (engine crashes,
-        // unhandled rejections that escape this scope, etc.).
-        let __dispatchResult;
-        let __dispatchError;
-        // Track caught-ness with an explicit boolean rather than `if (__dispatchError)`.
-        // Falsy throws (`throw 0`, `throw ''`, `throw false`, `throw null`, `throw undefined`)
-        // are legal in JS and must still surface as `isError: true` envelopes — a truthiness
-        // check would misclassify them as successes and silently swallow the failure.
-        let __dispatchCaught = false;
-        try {
-          __dispatchResult = await tool.handler(__args, __ctx);
-        } catch (e) {
-          __dispatchError = e;
-          __dispatchCaught = true;
-        }
-        if (__dispatchCaught) {
-          // `e.name` ('Error', 'TypeError', 'RangeError', …) prefixes the message so the
-          // class of failure is visible at a glance. `e.stack` is QuickJS-NG's filled-in
-          // stack with the bundle filename and line/col of every frame; missing on
-          // primitive throws (`throw "string"`, `throw 42`) which don't carry stack info,
-          // in which case we just fall back to the stringified value.
-          const __e = __dispatchError;
-          // `__isErrorObj` and `__name` both read properties off the thrown value. Each access
-          // can independently throw — `Object.defineProperty(o, 'name', { get() { throw … } })`
-          // and proxy `has` traps are both legal — so a hostile throw could re-introduce the
-          // lost-envelope failure mode this catch exists to prevent. The defensive wrappers
-          // around `String(__e)` and `__e.stack` aren't enough on their own; the property
-          // accesses ahead of them need the same treatment. `hasOwnProperty.call(...)` is used
-          // instead of `'message' in __e` so a proxy `has` trap can't intercept the check.
-          let __isErrorObj = false;
-          try {
-            __isErrorObj = __e !== null && __e !== undefined && typeof __e === 'object' &&
-              Object.prototype.hasOwnProperty.call(__e, 'message');
-          } catch (__hasOwnError) {
-            // Even `hasOwnProperty` can be tripped up by a poisoned prototype — fall back to
-            // the safer object-presence check and treat the throw as a primitive.
-            __isErrorObj = false;
-          }
-          let __name = 'Error';
-          if (__isErrorObj) {
-            try {
-              const __n = __e.name;
-              if (typeof __n === 'string' && __n.length > 0) __name = __n;
-            } catch (__nameError) {
-              // Accessor-defined `name` that throws — keep the default `'Error'` prefix.
-            }
-          }
-          // Defensive stringify: `String(obj)` itself can throw for some objects (null prototype
-          // + missing toString/valueOf, throwing accessor on toString, etc.). If it does, we'd
-          // re-introduce the very Kotlin-side-throw + lost-envelope failure mode this catch
-          // exists to prevent — flagged by automated review. Fall back to a static placeholder
-          // so the error envelope still ships rather than crashing the dispatch.
-          let __msg;
-          try {
-            __msg = __isErrorObj ? __e.message : String(__e);
-          } catch (__stringifyError) {
-            __msg = '<unstringifiable thrown value>';
-          }
-          if (__msg === undefined || __msg === null) {
-            __msg = String(__msg);
-          }
-          let __stack = '';
-          if (__isErrorObj) {
-            try {
-              if (typeof __e.stack === 'string' && __e.stack.length > 0) {
-                __stack = '\n' + __e.stack;
-              }
-            } catch (__stackError) {
-              // Accessor-defined `stack` that throws — same defense as above. Drop the stack
-              // rather than crashing; the message is still informative on its own.
-            }
-          }
-          globalThis.__trailblazeLastResult = JSON.stringify({
-            isError: true,
-            content: [{ type: 'text', text: __name + ': ' + __msg + __stack }]
-          });
+        // Encode args/ctx as JS string literals + `JSON.parse(...)` inside the module rather than
+        // splicing the raw JSON output into the generated source. JSON encodes the U+2028
+        // (line separator) and U+2029 (paragraph separator) code points as themselves — valid
+        // JSON, but in classic JS source they are line terminators that break a multi-line
+        // string-spliced expression at parse time. Embedding via a JS string literal turns the
+        // bytes into characters QuickJS reads through the string-literal grammar (which treats
+        // them as ordinary characters), and `JSON.parse` reconstructs the object on the JS side.
+        val argsLiteral = jsString(JSON.encodeToString(JsonObject.serializer(), args))
+        val ctxLiteral = if (ctx != null) {
+          // Same string-literal-then-parse trick. Wrapping in `JSON.parse(<literal>)` produces
+          // an Object the handler sees as `ctx`.
+          "JSON.parse(${jsString(JSON.encodeToString(JsonObject.serializer(), ctx))})"
         } else {
+          "undefined"
+        }
+        // Module-mode evaluation supports top-level await in QuickJS-NG; script-mode does not, and
+        // quickjs-kt's `evaluate<T>` doesn't unwrap returned Promises (returns the literal Promise
+        // object stringified). The dispatch path therefore uses module mode + writes the result to a
+        // global, then a separate script-mode read picks the result up. The [evalMutex] above
+        // makes the "evaluate then read" pair atomic so concurrent callers can't clobber each
+        // other's `__trailblazeLastResult`.
+        // The `try { JSON.stringify } catch` on the JS side guarantees the string we read back
+        // is always parseable JSON — handlers that return non-serializable values (functions,
+        // BigInts, circular structures) get a structured `{ isError: true, ... }` envelope
+        // instead of crashing the Kotlin parse step. Without this, `JSON.stringify` on a bad
+        // value emits `undefined`, the read-back returns the literal string `"undefined"`, and
+        // `JSON.parseToJsonElement` throws an opaque `JsonDecodingException` from a layer with
+        // no author context.
+        val dispatchExpr = """
+          const __registry = globalThis.__trailblazeTools || {};
+          const tool = __registry[${jsString(name)}];
+          if (!tool) {
+            // Include the registered tool names in the error so the author sees which tools
+            // actually loaded — typo, mismatched `name:` field in the descriptor, or a bundle
+            // that registered nothing at all are the three things this catches. The bundler
+            // should have ensured at least one registration; emit a more pointed hint when
+            // the registry is empty.
+            const __known = Object.keys(__registry);
+            const __hint = __known.length === 0
+              ? ' (no tools are registered on this host — the bundle may have loaded but its synthesized wrapper failed to populate `globalThis.__trailblazeTools`. Verify your scripted-tool source exports the function under the same `name:` declared in its YAML descriptor.)'
+              : ' (registered tools: ' + __known.sort().join(', ') + ')';
+            throw new Error('Tool not registered: ' + ${jsString(name)} + __hint);
+          }
+          const __args = JSON.parse(${argsLiteral});
+          const __ctx = ${ctxLiteral};
+          // Inject framework-provided resolver methods on `ctx.target`. Methods can't
+          // survive the JSON-serialization round-trip (host → JS engine), so we attach
+          // them here on the JS side after deserialization. The methods read from the
+          // same `target` data the framework already populates (appId, appIds[],
+          // and the future resolvedBaseUrl / baseUrls[] fields when the manifest schema
+          // for `target.platforms.web.base_urls:` lands). Forward-compatible: when the
+          // framework starts emitting baseUrls data, `resolveBaseUrl` automatically
+          // picks it up without any author-side change.
+          if (__ctx && __ctx.target) {
+            __ctx.target.resolveAppId = function(options) {
+              const opts = options || {};
+              const fromTarget = this.appId || (this.appIds && this.appIds[0]);
+              if (typeof fromTarget === 'string' && fromTarget.length > 0) return fromTarget;
+              if (typeof opts.defaultAppId === 'string') {
+                const trimmed = opts.defaultAppId.trim();
+                if (trimmed.length > 0) return trimmed;
+              }
+              return undefined;
+            };
+            __ctx.target.resolveBaseUrl = function(options) {
+              const opts = options || {};
+              const fromTarget = this.resolvedBaseUrl || (this.baseUrls && this.baseUrls[0]);
+              if (typeof fromTarget === 'string' && fromTarget.length > 0) return fromTarget;
+              if (typeof opts.defaultBaseUrl === 'string') {
+                const trimmed = opts.defaultBaseUrl.trim();
+                if (trimmed.length > 0) return trimmed;
+              }
+              return undefined;
+            };
+          }
+          // Wrap the handler call in a JS-side try/catch so a JS-side throw surfaces through
+          // the same `isError: true` envelope path that `toTrailblazeToolResult` already maps
+          // to `ExceptionThrown.errorMessage`. Without this catch, the throw escapes QuickJS as
+          // a Kotlin throwable whose `.message` carries the JS error message but loses
+          // `Error.stack` (the bundle filename + line/col QuickJS-NG fills in) — the author
+          // debugging from session logs sees "boom" with no breadcrumb to the source line.
+          // Surfacing the stack here keeps the existing Kotlin-side catch a fallback for
+          // anything QuickJS still routes through the throwable path (engine crashes,
+          // unhandled rejections that escape this scope, etc.).
+          let __dispatchResult;
+          let __dispatchError;
+          // Track caught-ness with an explicit boolean rather than `if (__dispatchError)`.
+          // Falsy throws (`throw 0`, `throw ''`, `throw false`, `throw null`, `throw undefined`)
+          // are legal in JS and must still surface as `isError: true` envelopes — a truthiness
+          // check would misclassify them as successes and silently swallow the failure.
+          let __dispatchCaught = false;
           try {
-            globalThis.__trailblazeLastResult = JSON.stringify(__dispatchResult == null ? {} : __dispatchResult);
+            __dispatchResult = await tool.handler(__args, __ctx);
           } catch (e) {
+            __dispatchError = e;
+            __dispatchCaught = true;
+          }
+          if (__dispatchCaught) {
+            // `e.name` ('Error', 'TypeError', 'RangeError', …) prefixes the message so the
+            // class of failure is visible at a glance. `e.stack` is QuickJS-NG's filled-in
+            // stack with the bundle filename and line/col of every frame; missing on
+            // primitive throws (`throw "string"`, `throw 42`) which don't carry stack info,
+            // in which case we just fall back to the stringified value.
+            const __e = __dispatchError;
+            // `__isErrorObj` and `__name` both read properties off the thrown value. Each access
+            // can independently throw — `Object.defineProperty(o, 'name', { get() { throw … } })`
+            // and proxy `has` traps are both legal — so a hostile throw could re-introduce the
+            // lost-envelope failure mode this catch exists to prevent. The defensive wrappers
+            // around `String(__e)` and `__e.stack` aren't enough on their own; the property
+            // accesses ahead of them need the same treatment. `hasOwnProperty.call(...)` is used
+            // instead of `'message' in __e` so a proxy `has` trap can't intercept the check.
+            let __isErrorObj = false;
+            try {
+              __isErrorObj = __e !== null && __e !== undefined && typeof __e === 'object' &&
+                Object.prototype.hasOwnProperty.call(__e, 'message');
+            } catch (__hasOwnError) {
+              // Even `hasOwnProperty` can be tripped up by a poisoned prototype — fall back to
+              // the safer object-presence check and treat the throw as a primitive.
+              __isErrorObj = false;
+            }
+            let __name = 'Error';
+            if (__isErrorObj) {
+              try {
+                const __n = __e.name;
+                if (typeof __n === 'string' && __n.length > 0) __name = __n;
+              } catch (__nameError) {
+                // Accessor-defined `name` that throws — keep the default `'Error'` prefix.
+              }
+            }
+            // Defensive stringify: `String(obj)` itself can throw for some objects (null prototype
+            // + missing toString/valueOf, throwing accessor on toString, etc.). If it does, we'd
+            // re-introduce the very Kotlin-side-throw + lost-envelope failure mode this catch
+            // exists to prevent — flagged by automated review. Fall back to a static placeholder
+            // so the error envelope still ships rather than crashing the dispatch.
+            let __msg;
+            try {
+              __msg = __isErrorObj ? __e.message : String(__e);
+            } catch (__stringifyError) {
+              __msg = '<unstringifiable thrown value>';
+            }
+            if (__msg === undefined || __msg === null) {
+              __msg = String(__msg);
+            }
+            let __stack = '';
+            if (__isErrorObj) {
+              try {
+                if (typeof __e.stack === 'string' && __e.stack.length > 0) {
+                  __stack = '\n' + __e.stack;
+                }
+              } catch (__stackError) {
+                // Accessor-defined `stack` that throws — same defense as above. Drop the stack
+                // rather than crashing; the message is still informative on its own.
+              }
+            }
             globalThis.__trailblazeLastResult = JSON.stringify({
               isError: true,
-              content: [{ type: 'text', text: 'Tool ' + ${jsString(name)} + ' returned a non-JSON-serializable value: ' + (e && e.message || String(e)) }]
+              content: [{ type: 'text', text: __name + ': ' + __msg + __stack }]
             });
+          } else {
+            try {
+              globalThis.__trailblazeLastResult = JSON.stringify(__dispatchResult == null ? {} : __dispatchResult);
+            } catch (e) {
+              globalThis.__trailblazeLastResult = JSON.stringify({
+                isError: true,
+                content: [{ type: 'text', text: 'Tool ' + ${jsString(name)} + ' returned a non-JSON-serializable value: ' + (e && e.message || String(e)) }]
+              });
+            }
           }
-        }
-      """.trimIndent()
-      quickJs.evaluate<Any?>(dispatchExpr, "call-tool-$name.js", true)
-      val resultJson = quickJs.evaluate<String>(
-        "globalThis.__trailblazeLastResult",
-        "read-result.js",
-        false,
-      )
-      JSON.parseToJsonElement(resultJson).jsonObject
+        """.trimIndent()
+        quickJs.evaluate<Any?>(dispatchExpr, "call-tool-$name.js", true)
+        val resultJson = quickJs.evaluate<String>(
+          "globalThis.__trailblazeLastResult",
+          "read-result.js",
+          false,
+        )
+        JSON.parseToJsonElement(resultJson).jsonObject
       }
     }
 
@@ -287,13 +287,24 @@ class QuickJsToolHost internal constructor(
    * Free the QuickJS engine. Idempotent; safe to call multiple times. The native free runs on
    * [engineDispatcher] (the engine's owning thread — freeing it from any other thread is the same
    * cross-thread hazard as evaluating from one), then the dedicated thread is released.
+   *
+   * Takes [evalMutex] for the whole close, not just a courtesy — without it, `shutdown()` could
+   * close `quickJs` and `engineDispatcher` while a `callTool`/`listTools` is mid-dispatch (e.g.
+   * suspended inside an async host callback). kotlinx.coroutines' `ExecutorCoroutineDispatcher`
+   * falls back to `Dispatchers.IO` when a dispatch is rejected by an already-`close()`d executor,
+   * so that in-flight call would resume on an arbitrary IO thread against an engine this thread
+   * just freed — the exact cross-thread hazard this whole class exists to eliminate. Holding
+   * [evalMutex] here guarantees `shutdown()` either runs before any call starts or waits for the
+   * current one to finish first.
    */
   suspend fun shutdown() {
     if (!isShutdown.compareAndSet(false, true)) return
-    withContext(engineDispatcher) {
-      runCatching { quickJs.close() }
+    evalMutex.withLock {
+      withContext(engineDispatcher) {
+        runCatching { quickJs.close() }
+      }
+      runCatching { engineDispatcher.close() }
     }
-    engineDispatcher.close()
   }
 
   companion object {
@@ -345,69 +356,85 @@ class QuickJsToolHost internal constructor(
       val engineDispatcher: ExecutorCoroutineDispatcher = Executors.newSingleThreadExecutor { r ->
         Thread(r, "quickjs-tool-engine-${engineThreadSeq.incrementAndGet()}").apply { isDaemon = true }
       }.asCoroutineDispatcher()
-      val quickJs = withContext(engineDispatcher) { QuickJs.create(engineDispatcher) }
       try {
-        withContext(engineDispatcher) {
-        if (hostBinding != null) {
-          // Async binding so JS can `await __trailblazeCall(name, argsJson)`. Returns the
-          // result-JSON string the SDK shim will JSON.parse on the JS side.
-          quickJs.asyncFunction(HOST_CALL_BINDING) { args ->
-            val name = args.getOrNull(0) as? String
-              ?: error("$HOST_CALL_BINDING called without a tool name string")
-            val argsJson = args.getOrNull(1) as? String
-              ?: error("$HOST_CALL_BINDING called without an argsJson string")
-            hostBinding.callFromBundle(name, argsJson)
+        return withContext(engineDispatcher) {
+          // `QuickJs.create` itself runs on engineDispatcher and lives inside this try/catch —
+          // not just the setup below it. A creation failure (native init/OOM) still needs to
+          // reach the outer catch so engineDispatcher gets closed; hoisting `create` above this
+          // try (as an earlier version of this function did) leaks the dedicated thread on that
+          // failure, since nothing downstream would ever call engineDispatcher.close().
+          val quickJs = QuickJs.create(engineDispatcher)
+          try {
+            if (hostBinding != null) {
+              // Async binding so JS can `await __trailblazeCall(name, argsJson)`. Returns the
+              // result-JSON string the SDK shim will JSON.parse on the JS side.
+              quickJs.asyncFunction(HOST_CALL_BINDING) { args ->
+                val name = args.getOrNull(0) as? String
+                  ?: error("$HOST_CALL_BINDING called without a tool name string")
+                val argsJson = args.getOrNull(1) as? String
+                  ?: error("$HOST_CALL_BINDING called without an argsJson string")
+                hostBinding.callFromBundle(name, argsJson)
+              }
+            }
+            // `console.log`/`error`/`warn`/`info` shim — author code from any Node-flavored
+            // source expects `console` to exist. Bundles that hit `console.foo(...)` route
+            // through the [logSink] parameter so callers control destination (logcat, daemon
+            // log, test capture). Default sink uses `println` to stderr so a developer running
+            // a host-embedded engine sees their own log lines without wiring anything; on-device
+            // callers can pass a sink that forwards to logcat. Mirrors the field-style format
+            // `BundleRuntimePrelude.CONSOLE_BINDING` uses in the legacy bundle module so the
+            // two modules' logs grep the same.
+            quickJs.function("__trailblazeLog") { args ->
+              val level = (args.getOrNull(0) as? String)?.takeIf { it.isNotEmpty() } ?: "log"
+              val message = args.getOrNull(1) as? String ?: ""
+              val sanitized = message.replace("\n", "\\n").replace("\r", "\\r")
+              logSink("[trailblaze-tools] level=$level msg=$sanitized")
+              null
+            }
+            // Console shim: each method joins its variadic args to a single string so the
+            // Kotlin-side binding receives (level, message) and not a fan-out of N positional
+            // args. Joiner mirrors the convention used by the legacy bundle module's prelude.
+            quickJs.evaluate<Any?>(
+              """
+              (function () {
+                function fmt(args) { return Array.prototype.map.call(args, function (a) {
+                  return typeof a === 'string' ? a : (function () { try { return JSON.stringify(a); } catch (e) { return String(a); } })();
+                }).join(' '); }
+                globalThis.console = globalThis.console || {
+                  log:   function () { __trailblazeLog('log',   fmt(arguments)); },
+                  error: function () { __trailblazeLog('error', fmt(arguments)); },
+                  warn:  function () { __trailblazeLog('warn',  fmt(arguments)); },
+                  info:  function () { __trailblazeLog('info',  fmt(arguments)); },
+                };
+              })();
+              """.trimIndent(),
+              "console-shim.js",
+              false,
+            )
+            // Optional engine extension (e.g. an OkHttp-backed `fetch`). Installed after the
+            // console shim and BEFORE the author bundle so a tool handler can reference whatever
+            // globals it binds. Kept as a caller-supplied hook so this module stays free of the
+            // extension's transitive deps (OkHttp etc.) — the on-device APK only pays for it if a
+            // caller actually opts in.
+            engineExtension?.install(quickJs)
+            // Evaluate the author bundle. Population of globalThis.__trailblazeTools happens
+            // here as a side effect.
+            quickJs.evaluate<Any?>(bundleJs, bundleFilename, false)
+            QuickJsToolHost(quickJs, engineDispatcher)
+          } catch (t: Throwable) {
+            // Runs on engineDispatcher (still inside the outer withContext) — freeing the
+            // native engine from any other thread is the same cross-thread hazard `evaluate`
+            // has, so this can't be hoisted out to the outer catch below.
+            runCatching { quickJs.close() }
+            throw t
           }
         }
-        // `console.log`/`error`/`warn`/`info` shim — author code from any Node-flavored
-        // source expects `console` to exist. Bundles that hit `console.foo(...)` route
-        // through the [logSink] parameter so callers control destination (logcat, daemon
-        // log, test capture). Default sink uses `println` to stderr so a developer running
-        // a host-embedded engine sees their own log lines without wiring anything; on-device
-        // callers can pass a sink that forwards to logcat. Mirrors the field-style format
-        // `BundleRuntimePrelude.CONSOLE_BINDING` uses in the legacy bundle module so the
-        // two modules' logs grep the same.
-        quickJs.function("__trailblazeLog") { args ->
-          val level = (args.getOrNull(0) as? String)?.takeIf { it.isNotEmpty() } ?: "log"
-          val message = args.getOrNull(1) as? String ?: ""
-          val sanitized = message.replace("\n", "\\n").replace("\r", "\\r")
-          logSink("[trailblaze-tools] level=$level msg=$sanitized")
-          null
-        }
-        // Console shim: each method joins its variadic args to a single string so the
-        // Kotlin-side binding receives (level, message) and not a fan-out of N positional
-        // args. Joiner mirrors the convention used by the legacy bundle module's prelude.
-        quickJs.evaluate<Any?>(
-          """
-          (function () {
-            function fmt(args) { return Array.prototype.map.call(args, function (a) {
-              return typeof a === 'string' ? a : (function () { try { return JSON.stringify(a); } catch (e) { return String(a); } })();
-            }).join(' '); }
-            globalThis.console = globalThis.console || {
-              log:   function () { __trailblazeLog('log',   fmt(arguments)); },
-              error: function () { __trailblazeLog('error', fmt(arguments)); },
-              warn:  function () { __trailblazeLog('warn',  fmt(arguments)); },
-              info:  function () { __trailblazeLog('info',  fmt(arguments)); },
-            };
-          })();
-          """.trimIndent(),
-          "console-shim.js",
-          false,
-        )
-        // Optional engine extension (e.g. an OkHttp-backed `fetch`). Installed after the
-        // console shim and BEFORE the author bundle so a tool handler can reference whatever
-        // globals it binds. Kept as a caller-supplied hook so this module stays free of the
-        // extension's transitive deps (OkHttp etc.) — the on-device APK only pays for it if a
-        // caller actually opts in.
-        engineExtension?.install(quickJs)
-        // Evaluate the author bundle. Population of globalThis.__trailblazeTools happens
-        // here as a side effect.
-        quickJs.evaluate<Any?>(bundleJs, bundleFilename, false)
-        }
-        return QuickJsToolHost(quickJs, engineDispatcher)
       } catch (t: Throwable) {
-        withContext(engineDispatcher) { runCatching { quickJs.close() } }
-        engineDispatcher.close()
+        // Runs on the caller's original dispatcher (we've already left `withContext`). Closing
+        // the executor is plain bookkeeping (`ExecutorService.shutdown()`), not a native call,
+        // so it doesn't need engineDispatcher confinement — and covers every failure above,
+        // including `QuickJs.create` itself throwing before `quickJs` ever existed to close.
+        runCatching { engineDispatcher.close() }
         throw t
       }
     }

--- a/trailblaze-quickjs-tools/src/jvmTest/kotlin/xyz/block/trailblaze/quickjs/tools/QuickJsToolHostTest.kt
+++ b/trailblaze-quickjs-tools/src/jvmTest/kotlin/xyz/block/trailblaze/quickjs/tools/QuickJsToolHostTest.kt
@@ -7,10 +7,13 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.fail
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -446,6 +449,28 @@ class QuickJsToolHostTest {
   }
 
   @Test
+  fun `connect closes its dedicated engine thread when it fails, not just the engine`() = runBlocking {
+    // `connect()` mints a dedicated single-thread `engineDispatcher` before the engine even
+    // exists, so closing `quickJs` alone on failure isn't enough — regression coverage for a
+    // bug where `QuickJs.create` (and, by extension, the whole per-engine setup) ran outside
+    // the try/catch that closes `engineDispatcher`, leaking the dedicated daemon thread on any
+    // connect() failure (a real risk for a long-running daemon that retries failed connects).
+    val before = Thread.getAllStackTraces().keys.count { it.name.startsWith("quickjs-tool-engine-") }
+    runCatching {
+      QuickJsToolHost.connect("this is not valid JavaScript ((", bundleFilename = "broken.js")
+    }
+    // Executor shutdown terminates its worker thread asynchronously; poll briefly rather than
+    // asserting immediately, which would flake on a slow CI runner.
+    val settled = withTimeoutOrNull(2_000) {
+      while (Thread.getAllStackTraces().keys.count { it.name.startsWith("quickjs-tool-engine-") } > before) {
+        delay(20)
+      }
+      true
+    }
+    assertTrue(settled == true, "connect() must not leak its dedicated engine thread when it fails")
+  }
+
+  @Test
   fun `callTool surfaces handler throws as isError envelope with name message and JS stack`() = runBlocking {
     // Pin the JS stack-preservation contract. A handler throw is caught on the JS side and
     // surfaced through the same `isError: true` envelope as a handler-returned error, but
@@ -767,6 +792,58 @@ class QuickJsToolHostTest {
     if (secondShutdown.isFailure) {
       fail("shutdown is not idempotent: second call threw ${secondShutdown.exceptionOrNull()}")
     }
+  }
+
+  @Test
+  fun `shutdown waits for an in-flight callTool instead of racing it`() = runBlocking {
+    // Regression test for the cross-thread hazard `engineDispatcher` confinement exists to
+    // prevent, reintroduced via a different door: `shutdown()` used to close `quickJs` and
+    // `engineDispatcher` without taking `evalMutex`, so it could run concurrently with a
+    // `callTool` that was suspended mid-dispatch (e.g. inside an async host callback, exactly
+    // the `await ctx.tools.*` shape from the original bug report). kotlinx.coroutines'
+    // `ExecutorCoroutineDispatcher` falls back to `Dispatchers.IO` when a task is submitted to
+    // an already-`close()`d executor, so the stranded `callTool` would resume on an arbitrary
+    // IO thread against an engine `shutdown()` just freed. `shutdown()` now takes `evalMutex`
+    // for its whole close, so it must block until the in-flight call finishes.
+    val handlerStarted = CompletableDeferred<Unit>()
+    val releaseHandler = CompletableDeferred<Unit>()
+    val binding = HostBinding { _, _ ->
+      handlerStarted.complete(Unit)
+      releaseHandler.await()
+      """{"content":[]}"""
+    }
+    val host = connect(
+      """
+      const tools = (globalThis.__trailblazeTools = globalThis.__trailblazeTools || {});
+      tools["slow"] = {
+        name: "slow",
+        spec: {},
+        handler: async () => {
+          await globalThis.__trailblazeCall("inner", "{}");
+          return { content: [] };
+        },
+      };
+      """.trimIndent(),
+      hostBinding = binding,
+    )
+
+    val callToolResult = async { host.callTool("slow", JsonObject(emptyMap())) }
+    handlerStarted.await()
+
+    // Issued while `callTool` is suspended inside the async host callback, still holding
+    // `evalMutex`. It must block rather than closing the engine out from under that call.
+    val shutdownJob = async { host.shutdown() }
+    val shutdownFinishedEarly = withTimeoutOrNull(200) { shutdownJob.await() } != null
+    assertTrue(!shutdownFinishedEarly, "shutdown() must not complete while a callTool is still in flight")
+
+    releaseHandler.complete(Unit)
+    val result = withTimeoutOrNull(5_000) { callToolResult.await() }
+    assertNotNull(result, "callTool should complete normally once its handler is released")
+    assertEquals(0, (result["content"] as JsonArray).size)
+
+    // Now that the in-flight call is done, shutdown proceeds and completes cleanly.
+    withTimeoutOrNull(5_000) { shutdownJob.await() }
+      ?: fail("shutdown() should have completed once the in-flight callTool released evalMutex")
   }
 
   @Test

--- a/trailblaze-scripting/src/main/kotlin/xyz/block/trailblaze/scripting/TrailblazeScriptEngine.kt
+++ b/trailblaze-scripting/src/main/kotlin/xyz/block/trailblaze/scripting/TrailblazeScriptEngine.kt
@@ -3,8 +3,11 @@ package xyz.block.trailblaze.scripting
 import com.dokar.quickjs.QuickJs
 import com.dokar.quickjs.QuickJsException
 import com.dokar.quickjs.binding.function
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 
@@ -22,6 +25,12 @@ import kotlinx.serialization.json.JsonObject
  * `DelegatingTrailblazeTool.toExecutableTrailblazeTools` is not suspending.
  */
 object TrailblazeScriptEngine {
+
+  /**
+   * Monotonic id so each per-call engine thread is uniquely named — a thread dump / crash log in a
+   * multi-tenant daemon then names exactly which script evaluation it was.
+   */
+  private val scriptEngineThreadSeq = AtomicLong(0)
 
   /**
    * Synchronous bridge that resolves a tool name + JSON params into an executed
@@ -77,29 +86,44 @@ object TrailblazeScriptEngine {
       appendLine(source)
       appendLine("})()")
     }
-    val quickJs = QuickJs.create(Dispatchers.Default)
+    // Dedicated single owning thread for this engine (see QuickJsToolHost for the full rationale):
+    // quickjs-kt's engine is single-threaded and resumes Promise/async jobs on its jobDispatcher, so
+    // a multi-threaded dispatcher can resume on a different thread and segfault the JVM (SIGSEGV in
+    // jni_CallObjectMethod). Confine create/evaluate/close to one thread. Per-call, matching this
+    // method's per-call engine lifecycle; concurrent (multi-tenant) calls each get their own engine
+    // + thread rather than sharing one.
+    val engineDispatcher = Executors.newSingleThreadExecutor { r ->
+      Thread(r, "quickjs-script-engine-${scriptEngineThreadSeq.incrementAndGet()}").apply { isDaemon = true }
+    }.asCoroutineDispatcher()
     try {
-      if (dispatcher != null) {
-        quickJs.function("__trailblazeExecuteRaw") { args ->
-          val toolName = args[0] as String
-          val paramsJson = args[1] as String
-          dispatcher.dispatch(toolName, paramsJson)
+      withContext(engineDispatcher) {
+        val quickJs = QuickJs.create(engineDispatcher)
+        try {
+          if (dispatcher != null) {
+            quickJs.function("__trailblazeExecuteRaw") { args ->
+              val toolName = args[0] as String
+              val paramsJson = args[1] as String
+              dispatcher.dispatch(toolName, paramsJson)
+            }
+          }
+          // No wall-clock timeout: quickjs-kt 1.0.5 exposes no interrupt handler, so a
+          // `while(true){}` in JS never yields to the coroutine and withTimeout can't fire.
+          // Real timeout discipline lands in a follow-up (interrupt handler + budget).
+          quickJs.evaluate<String>(wrapped)
+        } catch (e: QuickJsException) {
+          // quickjs-kt raises QuickJsException for every engine-side failure — syntax errors,
+          // runtime throws, and type-mismatches (including "script did not return a String").
+          throw ScriptEvaluationException(
+            "JavaScript evaluation failed: ${e.message}",
+            cause = e,
+            source = source,
+          )
+        } finally {
+          quickJs.close()
         }
       }
-      // No wall-clock timeout: quickjs-kt 1.0.5 exposes no interrupt handler, so a
-      // `while(true){}` in JS never yields to the coroutine and withTimeout can't fire.
-      // Real timeout discipline lands in a follow-up (interrupt handler + budget).
-      quickJs.evaluate<String>(wrapped)
-    } catch (e: QuickJsException) {
-      // quickjs-kt raises QuickJsException for every engine-side failure — syntax errors,
-      // runtime throws, and type-mismatches (including "script did not return a String").
-      throw ScriptEvaluationException(
-        "JavaScript evaluation failed: ${e.message}",
-        cause = e,
-        source = source,
-      )
     } finally {
-      quickJs.close()
+      engineDispatcher.close()
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #194.

`QuickJsToolHost.connect()` and `TrailblazeScriptEngine.evaluate()` created their QuickJS engine with `Dispatchers.Default`, a multi-threaded pool. QuickJS-NG (via quickjs-kt) is single-threaded internally: `evaluate()` runs the native call on the *calling* thread, while async host-function resumes run via `CoroutineScope(jobDispatcher).launch`. When an async resume landed on a different `Dispatchers.Default` worker than the thread that created/evaluated the engine, the resume re-entered the native engine (and JNI) from the wrong thread, crashing the JVM with a native `SIGSEGV` in `jni_CallObjectMethod` — taking down the whole daemon, not just the offending run.

This surfaced on-device when a scripted `.ts` tool's handler `await`ed a host tool call (e.g. `await ctx.tools.android_adbShell(...)`), but the root cause is thread confinement, not device-specific — it's timing-dependent on whether the async resume happens to land back on the creating thread.

## Fix

Confine each QuickJS engine's entire lifecycle — create, every `evaluate`, the async resume, and close — to one dedicated single-thread `ExecutorCoroutineDispatcher`, minted per engine (per `connect()` / per `evaluate()` call) and used both as the engine's `jobDispatcher` and as the dispatcher every `quickJs.*` call is wrapped in. Per-engine (not a shared global) so a multi-tenant daemon still runs N concurrent engines (multiple devices/agents/bundles) fully in parallel — each just gets its own owning thread. Threads are uniquely named (`quickjs-tool-engine-<n>` / `quickjs-script-engine-<n>`) so a future crash log or thread dump identifies the exact engine.

Applied to both call sites that create a QuickJS engine:
- `QuickJsToolHost.kt` — the actual crash site (installs an `asyncFunction` host binding for `trailblaze.call(...)`)
- `TrailblazeScriptEngine.kt` — same underlying hazard; lower risk in practice since this path runs synchronously under `runBlocking`, fixed for consistency

Also found and fixed a regression while testing: `QuickJsToolHost.shutdown()` is documented and tested as idempotent, but closing the new per-engine dispatcher at the end of `shutdown()` made a second call throw (`CancellationException: The task was rejected` from dispatching onto an already-closed executor). Added an `AtomicBoolean` guard so repeat `shutdown()` calls remain a safe no-op.

## Test plan

- [x] `:trailblaze-quickjs-tools:jvmTest` passes, including the existing test that exercises an async host callback via `await globalThis.__trailblazeCall(...)` (the exact crash path) and the shutdown-idempotency tests
- [x] `:trailblaze-scripting:test` passes
- [x] `:trailblaze-host:test` and `:trailblaze-scripting-fetch:jvmTest` pass (downstream consumers of both engines)
- [x] Confirmed no other call sites construct `QuickJsToolHost` directly or create a `QuickJs` engine with a shared dispatcher