### PR TITLE
Wire scripted-tool analyzer enrichment into waypoint CLI load paths

### DIFF
--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointCommandShared.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointCommandShared.kt
@@ -7,9 +7,11 @@ import xyz.block.trailblaze.config.project.LoadedTrailblazeProjectConfig
 import xyz.block.trailblaze.config.project.TrailblazeProjectConfig
 import xyz.block.trailblaze.config.project.TrailblazeProjectConfigException
 import xyz.block.trailblaze.config.project.TrailblazeProjectConfigLoader
+import xyz.block.trailblaze.config.project.TrailblazeResolvedConfig
 import xyz.block.trailblaze.config.project.TrailblazeTrailmapManifestLoader
 import xyz.block.trailblaze.config.project.TrailblazeWorkspaceConfigResolver
 import xyz.block.trailblaze.llm.config.TrailblazeConfigPaths
+import xyz.block.trailblaze.scripting.AnalyzerScriptedToolEnrichment
 import xyz.block.trailblaze.util.Console
 import xyz.block.trailblaze.waypoint.SessionLogScreenState
 import xyz.block.trailblaze.waypoint.WaypointLoader
@@ -327,11 +329,13 @@ private fun trailmapManifestAppIds(
     .orEmpty()
 }
 
-private fun loadResolvedConfig(fromPath: java.nio.file.Path) =
-  TrailblazeWorkspaceConfigResolver.resolve(fromPath).configFile?.let { configFile ->
+private fun loadResolvedConfig(fromPath: java.nio.file.Path): TrailblazeResolvedConfig? {
+  val scriptedToolEnrichment = AnalyzerScriptedToolEnrichment.resolveFromEnvironment()
+  return TrailblazeWorkspaceConfigResolver.resolve(fromPath).configFile?.let { configFile ->
     TrailblazeProjectConfigLoader.loadResolvedRuntime(
       configFile = configFile,
       includeClasspathTrailmaps = true,
+      scriptedToolEnrichment = scriptedToolEnrichment,
     )
   } ?: TrailblazeProjectConfigLoader.resolveRuntime(
     loaded = LoadedTrailblazeProjectConfig(
@@ -339,7 +343,9 @@ private fun loadResolvedConfig(fromPath: java.nio.file.Path) =
       sourceFile = File(".").absoluteFile,
     ),
     includeClasspathTrailmaps = true,
+    scriptedToolEnrichment = scriptedToolEnrichment,
   )
+}
 
 /** Renders a [WaypointMatchResult] into a multi-line, human-friendly string. */
 internal fun formatResult(r: WaypointMatchResult): String = buildString {

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointDiscovery.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/cli/WaypointDiscovery.kt
@@ -9,6 +9,7 @@ import xyz.block.trailblaze.config.project.TrailblazeProjectConfig
 import xyz.block.trailblaze.config.project.TrailblazeProjectConfigException
 import xyz.block.trailblaze.config.project.TrailblazeProjectConfigLoader
 import xyz.block.trailblaze.config.project.TrailblazeWorkspaceConfigResolver
+import xyz.block.trailblaze.scripting.AnalyzerScriptedToolEnrichment
 import xyz.block.trailblaze.util.Console
 import xyz.block.trailblaze.waypoint.WaypointLoader
 
@@ -132,6 +133,7 @@ object WaypointDiscovery {
       val resolved = TrailblazeProjectConfigLoader.loadResolvedRuntime(
         configFile = configFile,
         includeClasspathTrailmaps = true,
+        scriptedToolEnrichment = AnalyzerScriptedToolEnrichment.resolveFromEnvironment(),
       )
       resolved?.waypoints
     } catch (e: TrailblazeProjectConfigException) {
@@ -166,6 +168,7 @@ object WaypointDiscovery {
           sourceFile = File(".").absoluteFile,
         ),
         includeClasspathTrailmaps = true,
+        scriptedToolEnrichment = AnalyzerScriptedToolEnrichment.resolveFromEnvironment(),
       ).waypoints
     } catch (e: TrailblazeProjectConfigException) {
       // Typed loader error from a malformed classpath trailmap manifest. Logged at error

--- a/trailblaze-host/src/test/java/xyz/block/trailblaze/cli/WaypointDiscoveryTest.kt
+++ b/trailblaze-host/src/test/java/xyz/block/trailblaze/cli/WaypointDiscoveryTest.kt
@@ -7,7 +7,10 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.Assume.assumeTrue
 import xyz.block.trailblaze.api.waypoint.WaypointDefinition
+import xyz.block.trailblaze.scripting.AnalyzerScriptedToolEnrichment
+import xyz.block.trailblaze.scripting.MetaOnlyDescriptorTestFixture
 
 /**
  * Tests for [WaypointDiscovery] — the helper that combines workspace trailmap waypoints,
@@ -275,6 +278,33 @@ class WaypointDiscoveryTest {
   }
 
   @Test
+  fun `scripted-tool workspace trailmap waypoints surface once analyzer enrichment is wired in`() {
+    // Regression test for issue #196: `WaypointDiscovery`'s two trailmap-load call sites
+    // used to call TrailblazeProjectConfigLoader without `scriptedToolEnrichment`, so any
+    // workspace trailmap carrying a `.ts` scripted-tool descriptor threw during resolution
+    // and its waypoints were silently dropped (even though `trailblaze check`/`run` resolved
+    // the same trailmap fine via `AnalyzerScriptedToolEnrichment.resolveFromEnvironment()`).
+    val enrichment = AnalyzerScriptedToolEnrichment.resolveFromEnvironment()
+    assumeTrue(MetaOnlyDescriptorTestFixture.ANALYZER_UNAVAILABLE_SKIP_MESSAGE, enrichment != null)
+
+    val classpathRoot = newTempDir()
+    val workspaceRoot = newTempDir()
+    addWorkspaceScriptedToolTrailmap(workspaceRoot, trailmapId = "myapp")
+    val emptyRoot = File(workspaceRoot, "trails-not-here")
+
+    val result = withClasspathRoot(classpathRoot) {
+      WaypointDiscovery.discover(root = emptyRoot, fromPath = workspaceRoot.toPath())
+    }
+
+    assertEquals(listOf("myapp/ready"), result.definitions.map(WaypointDefinition::id))
+    assertTrue(
+      !result.trailmapLoadFailed,
+      "a workspace trailmap with a scripted (.ts) tool should resolve cleanly, not be " +
+        "dropped for lack of wired-in analyzer enrichment",
+    )
+  }
+
+  @Test
   fun `empty classpath and empty root yields empty result`() {
     val classpathRoot = newTempDir()
     val workspaceRoot = newTempDir()
@@ -349,6 +379,57 @@ class WaypointDiscoveryTest {
     val trailmapsBlock = (existingTrailmaps + listOf("  - trailmaps/$trailmapId/trailmap.yaml"))
       .joinToString("\n")
     workspaceConfig.writeText("trailmaps:\n$trailmapsBlock\n")
+  }
+
+  /**
+   * Drops a workspace trailmap at `<workspaceRoot>/trails/config/trailmaps/<trailmapId>/`
+   * carrying one meta-only scripted (`.ts`) tool plus one waypoint, and wires it into
+   * `trailblaze.yaml`. Mirrors [MetaOnlyDescriptorTestFixture]'s authoring shape but adds a
+   * `waypoints:` entry, since that fixture (shared with [CompileCommandTest]) has no need
+   * for waypoints of its own.
+   */
+  private fun addWorkspaceScriptedToolTrailmap(workspaceRoot: File, trailmapId: String) {
+    val configDir = File(workspaceRoot, "trails/config").apply { mkdirs() }
+    val trailmapDir = File(configDir, "trailmaps/$trailmapId").apply { mkdirs() }
+    File(trailmapDir, "trailmap.yaml").writeText(
+      """
+      id: $trailmapId
+      target:
+        display_name: $trailmapId
+        tools:
+          - sampleTool
+      waypoints:
+        - waypoints/ready.waypoint.yaml
+      """.trimIndent(),
+    )
+    val toolsDir = File(trailmapDir, "tools").apply { mkdirs() }
+    File(toolsDir, "sampleTool.yaml").writeText(
+      """
+      script: ./sampleTool.ts
+      _meta:
+        trailblaze/requiresContext: true
+      """.trimIndent(),
+    )
+    File(toolsDir, "sampleTool.ts").writeText(
+      """
+      import { trailblaze } from "@trailblaze/scripting";
+
+      export interface SampleArgs {
+        who: string;
+      }
+
+      export const sampleTool = trailblaze.tool<SampleArgs>(async (input) => {
+        return `hello, ${'$'}{input.who}`;
+      });
+      """.trimIndent(),
+    )
+    val waypointDir = File(trailmapDir, "waypoints").apply { mkdirs() }
+    File(waypointDir, "ready.waypoint.yaml").writeText(
+      "id: \"$trailmapId/ready\"\ndescription: \"Ready.\"",
+    )
+    File(configDir, "trailblaze.yaml").writeText(
+      "trailmaps:\n  - trailmaps/$trailmapId/trailmap.yaml\n",
+    )
   }
 
   private fun newTempDir(): File =


### PR DESCRIPTION
## Summary

Fixes #196. Every `trailblaze waypoint` subcommand (`list`, `locate`, `validate`, `suggest-selector`, `graph`, `capture-example`, ...) silently dropped all waypoints from any workspace trailmap containing a scripted (`.ts`) tool. The trailmap threw during resolution with a "requires analyzer enrichment ... No `ScriptedToolEnrichment` was wired" warning, and its waypoints never loaded — even though `trailblaze check`/`run` resolve the same trailmap fine.

`CompileCommand` and `TrailblazeHostYamlRunner` build the analyzer-backed enrichment via `AnalyzerScriptedToolEnrichment.resolveFromEnvironment()` and pass it into the project-config loader, but the four `waypoint` CLI load sites didn't:

- `WaypointDiscovery.tryLoadWorkspaceWaypoints`
- `WaypointDiscovery.tryLoadClasspathOnlyWaypoints`
- `WaypointCommandShared.loadResolvedConfig` (both branches)

This PR passes the same `AnalyzerScriptedToolEnrichment.resolveFromEnvironment()` at those four call sites.

## Test plan

- [x] Added a regression test in `WaypointDiscoveryTest` that builds a workspace trailmap with a real scripted `.ts` tool plus a waypoint, and asserts the waypoint now surfaces via `WaypointDiscovery.discover` (gated behind the analyzer being available, mirroring the existing `CompileCommandTest` pattern).
- [x] `./gradlew :trailblaze-host:test --tests "xyz.block.trailblaze.cli.*"` passes locally, including the new test running against the real analyzer (not skipped).