### PR TITLE
TrailRunner target icons: add optional `icon:` field + convention resolver (foundation for #200)

### DIFF
--- a/trailblaze-models/api/android/trailblaze-models.api
+++ b/trailblaze-models/api/android/trailblaze-models.api
@@ -4601,19 +4601,21 @@ public final class xyz/block/trailblaze/api/waypoint/WaypointVariant$Companion {
 
 public final class xyz/block/trailblaze/config/AppTargetYamlConfig {
 	public static final field Companion Lxyz/block/trailblaze/config/AppTargetYamlConfig$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/util/Map;
-	public final fun component4 ()Z
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)Lxyz/block/trailblaze/config/AppTargetYamlConfig;
-	public static synthetic fun copy$default (Lxyz/block/trailblaze/config/AppTargetYamlConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lxyz/block/trailblaze/config/AppTargetYamlConfig;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)Lxyz/block/trailblaze/config/AppTargetYamlConfig;
+	public static synthetic fun copy$default (Lxyz/block/trailblaze/config/AppTargetYamlConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lxyz/block/trailblaze/config/AppTargetYamlConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getHasCustomIosDriver ()Z
+	public final fun getIcon ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getPlatforms ()Ljava/util/Map;
 	public final fun getSystemPrompt ()Ljava/lang/String;
@@ -4836,6 +4838,16 @@ public final synthetic class xyz/block/trailblaze/config/ShortcutMetadata$$seria
 
 public final class xyz/block/trailblaze/config/ShortcutMetadata$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class xyz/block/trailblaze/config/TargetIconConvention {
+	public static final field ICONS_DIR Ljava/lang/String;
+	public static final field INSTANCE Lxyz/block/trailblaze/config/TargetIconConvention;
+	public final fun androidIconPath (Ljava/lang/String;)Ljava/lang/String;
+	public final fun hostFromUrl (Ljava/lang/String;)Ljava/lang/String;
+	public final fun resolveIconPath (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun resolveIconPath$default (Lxyz/block/trailblaze/config/TargetIconConvention;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun webIconPath (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class xyz/block/trailblaze/config/ToolSetYamlConfig {
@@ -5489,19 +5501,21 @@ public final class xyz/block/trailblaze/config/project/TrailmapScriptedToolFileK
 
 public final class xyz/block/trailblaze/config/project/TrailmapTargetConfig {
 	public static final field Companion Lxyz/block/trailblaze/config/project/TrailmapTargetConfig$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/util/Map;
-	public final fun component4 ()Z
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;
-	public static synthetic fun copy$default (Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;
+	public static synthetic fun copy$default (Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getHasCustomIosDriver ()Z
+	public final fun getIcon ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getPlatforms ()Ljava/util/Map;
 	public final fun getSystemPromptFile ()Ljava/lang/String;

--- a/trailblaze-models/api/jvm/trailblaze-models.api
+++ b/trailblaze-models/api/jvm/trailblaze-models.api
@@ -4611,19 +4611,21 @@ public final class xyz/block/trailblaze/codegen/SerialDescriptorTsCodegen {
 
 public final class xyz/block/trailblaze/config/AppTargetYamlConfig {
 	public static final field Companion Lxyz/block/trailblaze/config/AppTargetYamlConfig$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/util/Map;
-	public final fun component4 ()Z
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)Lxyz/block/trailblaze/config/AppTargetYamlConfig;
-	public static synthetic fun copy$default (Lxyz/block/trailblaze/config/AppTargetYamlConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lxyz/block/trailblaze/config/AppTargetYamlConfig;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)Lxyz/block/trailblaze/config/AppTargetYamlConfig;
+	public static synthetic fun copy$default (Lxyz/block/trailblaze/config/AppTargetYamlConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lxyz/block/trailblaze/config/AppTargetYamlConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getHasCustomIosDriver ()Z
+	public final fun getIcon ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getPlatforms ()Ljava/util/Map;
 	public final fun getSystemPrompt ()Ljava/lang/String;
@@ -4846,6 +4848,16 @@ public final synthetic class xyz/block/trailblaze/config/ShortcutMetadata$$seria
 
 public final class xyz/block/trailblaze/config/ShortcutMetadata$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class xyz/block/trailblaze/config/TargetIconConvention {
+	public static final field ICONS_DIR Ljava/lang/String;
+	public static final field INSTANCE Lxyz/block/trailblaze/config/TargetIconConvention;
+	public final fun androidIconPath (Ljava/lang/String;)Ljava/lang/String;
+	public final fun hostFromUrl (Ljava/lang/String;)Ljava/lang/String;
+	public final fun resolveIconPath (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun resolveIconPath$default (Lxyz/block/trailblaze/config/TargetIconConvention;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
+	public final fun webIconPath (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class xyz/block/trailblaze/config/ToolSetYamlConfig {
@@ -5499,19 +5511,21 @@ public final class xyz/block/trailblaze/config/project/TrailmapScriptedToolFileK
 
 public final class xyz/block/trailblaze/config/project/TrailmapTargetConfig {
 	public static final field Companion Lxyz/block/trailblaze/config/project/TrailmapTargetConfig$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/util/Map;
-	public final fun component4 ()Z
-	public final fun component5 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;
-	public static synthetic fun copy$default (Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;)Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;
+	public static synthetic fun copy$default (Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ZLjava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lxyz/block/trailblaze/config/project/TrailmapTargetConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getHasCustomIosDriver ()Z
+	public final fun getIcon ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getPlatforms ()Ljava/util/Map;
 	public final fun getSystemPromptFile ()Ljava/lang/String;

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/config/AppTargetYamlConfig.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/config/AppTargetYamlConfig.kt
@@ -56,6 +56,18 @@ import xyz.block.trailblaze.logs.client.temp.YamlJsonBridge
 data class AppTargetYamlConfig(
   val id: String,
   @SerialName("display_name") val displayName: String,
+  /**
+   * Optional workspace-relative path to an icon rendered beside this target in the TrailRunner
+   * UI (Android launcher icon / web favicon). When null, the UI may fall back to a filename
+   * convention under the shared icons folder — see [TargetIconConvention]. An explicit value
+   * here overrides that convention.
+   *
+   * Authored on the trailmap `target:` block
+   * ([TrailmapTargetConfig.icon][xyz.block.trailblaze.config.project.TrailmapTargetConfig.icon])
+   * and threaded onto this resolved config by
+   * [TrailmapTargetConfig.toAppTargetYamlConfig][xyz.block.trailblaze.config.project.TrailmapTargetConfig.toAppTargetYamlConfig].
+   */
+  val icon: String? = null,
   val platforms: Map<String, PlatformConfig>? = null,
   @SerialName("has_custom_ios_driver") val hasCustomIosDriver: Boolean = false,
   /**

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/config/TargetIconConvention.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/config/TargetIconConvention.kt
@@ -1,0 +1,74 @@
+package xyz.block.trailblaze.config
+
+/**
+ * Filename convention + resolution helper for per-target icons shown in the TrailRunner UI.
+ *
+ * The convention lets a workspace fill the target list's icons by simply dropping files into the
+ * shared icons folder ([ICONS_DIR]) — no per-target authoring required:
+ *
+ *  - **Android target** → `assets/icons/android_<app_id>.png`
+ *    (e.g. `assets/icons/android_com.example.app.png`)
+ *  - **Web target** → `assets/icons/favicon_<host>.png`
+ *    (e.g. `assets/icons/favicon_example.com.png`)
+ *
+ * These filenames match exactly what the extraction step produces (Android launcher icon via
+ * `aapt`, web favicon via a favicon service), so populating the folder is enough to light up the
+ * first-run empty state.
+ *
+ * An explicit [AppTargetYamlConfig.icon] always wins over the convention — see [resolveIconPath].
+ *
+ * Pure and dependency-free so it can be shared between the runtime and the TrailRunner UI.
+ */
+object TargetIconConvention {
+  /** Workspace-relative directory the convention resolves against. */
+  const val ICONS_DIR: String = "assets/icons"
+
+  /** Convention path for an Android target's launcher icon, keyed by its application id. */
+  fun androidIconPath(appId: String): String = "$ICONS_DIR/android_$appId.png"
+
+  /** Convention path for a web target's favicon, keyed by its host (no scheme, no path). */
+  fun webIconPath(host: String): String = "$ICONS_DIR/favicon_$host.png"
+
+  /**
+   * Extracts the bare host from a start/base URL for use with [webIconPath].
+   *
+   * Strips an optional scheme (`https://`, `http://`, or scheme-relative `//`), then trims at the
+   * first `/`, `?`, or `#`, and drops any `user@` and `:port` suffix. Returns null when no host can
+   * be derived (blank input, or a value with no host component). Deliberately lightweight — it
+   * avoids a URL/URI dependency so this stays usable in commonMain and on the web UI side.
+   */
+  fun hostFromUrl(url: String?): String? {
+    if (url.isNullOrBlank()) return null
+    var s = url.trim()
+    val schemeSep = s.indexOf("://")
+    s = when {
+      schemeSep >= 0 -> s.substring(schemeSep + 3)
+      s.startsWith("//") -> s.substring(2)
+      else -> s
+    }
+    // Cut off path / query / fragment.
+    val end = s.indexOfFirst { it == '/' || it == '?' || it == '#' }
+    if (end >= 0) s = s.substring(0, end)
+    // Drop userinfo (user@host) then port (host:port).
+    s = s.substringAfterLast('@')
+    s = s.substringBefore(':')
+    return s.ifBlank { null }
+  }
+
+  /**
+   * Resolves the icon path for a target: the explicit [explicitIcon] if set, otherwise the Android
+   * convention (when [appId] is non-null), otherwise the web convention derived from [startUrl].
+   * Returns null when nothing resolves. The convention paths are relative to the workspace root; the
+   * caller is responsible for confirming the file actually exists on disk.
+   */
+  fun resolveIconPath(
+    explicitIcon: String?,
+    appId: String? = null,
+    startUrl: String? = null,
+  ): String? {
+    if (!explicitIcon.isNullOrBlank()) return explicitIcon
+    if (appId != null) return androidIconPath(appId)
+    val host = hostFromUrl(startUrl) ?: return null
+    return webIconPath(host)
+  }
+}

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/config/project/TrailblazeTrailmapManifest.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/config/project/TrailblazeTrailmapManifest.kt
@@ -216,6 +216,15 @@ data class TrailblazeTrailmapManifest(
 data class TrailmapTargetConfig(
   @SerialName("id") val id: String? = null,
   @SerialName("display_name") val displayName: String,
+  /**
+   * Optional workspace-relative path to an icon shown beside this target in the TrailRunner UI
+   * (Android launcher icon / web favicon). Threaded onto the generated [AppTargetYamlConfig.icon]
+   * by [toAppTargetYamlConfig]. When absent, the UI may fall back to the filename convention in
+   * [xyz.block.trailblaze.config.TargetIconConvention] (`android_<app_id>.png` /
+   * `favicon_<host>.png` under the shared icons folder), so simply populating that folder fills the
+   * first-run target list without per-target authoring. An explicit value overrides the convention.
+   */
+  @SerialName("icon") val icon: String? = null,
   @SerialName("platforms") val platforms: Map<String, PlatformConfig>? = null,
   @SerialName("has_custom_ios_driver") val hasCustomIosDriver: Boolean = false,
   /**
@@ -247,6 +256,7 @@ data class TrailmapTargetConfig(
     AppTargetYamlConfig(
       id = id ?: defaultId,
       displayName = displayName,
+      icon = icon,
       platforms = platforms,
       hasCustomIosDriver = hasCustomIosDriver,
       systemPrompt = resolvedSystemPrompt,

--- a/trailblaze-models/src/jvmTest/kotlin/xyz/block/trailblaze/config/TargetIconConventionTest.kt
+++ b/trailblaze-models/src/jvmTest/kotlin/xyz/block/trailblaze/config/TargetIconConventionTest.kt
@@ -1,0 +1,74 @@
+package xyz.block.trailblaze.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** Unit coverage for the pure [TargetIconConvention] filename + resolution helper. */
+class TargetIconConventionTest {
+
+  @Test
+  fun androidConventionPath() {
+    assertEquals(
+      "assets/icons/android_com.example.app.png",
+      TargetIconConvention.androidIconPath("com.example.app"),
+    )
+  }
+
+  @Test
+  fun webConventionPath() {
+    assertEquals(
+      "assets/icons/favicon_example.com.png",
+      TargetIconConvention.webIconPath("example.com"),
+    )
+  }
+
+  @Test
+  fun hostFromUrlStripsSchemePathPortAndUserinfo() {
+    assertEquals("example.com", TargetIconConvention.hostFromUrl("https://example.com/travel/flights"))
+    assertEquals("example.com", TargetIconConvention.hostFromUrl("http://example.com"))
+    assertEquals("example.com", TargetIconConvention.hostFromUrl("//example.com/path"))
+    assertEquals("example.com", TargetIconConvention.hostFromUrl("example.com"))
+    assertEquals("example.com", TargetIconConvention.hostFromUrl("https://user@example.com:8080/x?y#z"))
+  }
+
+  @Test
+  fun hostFromUrlReturnsNullForBlank() {
+    assertNull(TargetIconConvention.hostFromUrl(null))
+    assertNull(TargetIconConvention.hostFromUrl("   "))
+  }
+
+  @Test
+  fun explicitIconWinsOverConvention() {
+    assertEquals(
+      "assets/icons/custom.png",
+      TargetIconConvention.resolveIconPath(
+        explicitIcon = "assets/icons/custom.png",
+        appId = "com.example.app",
+        startUrl = "https://example.com",
+      ),
+    )
+  }
+
+  @Test
+  fun resolvePrefersAndroidThenWebThenNull() {
+    assertEquals(
+      "assets/icons/android_com.example.app.png",
+      TargetIconConvention.resolveIconPath(explicitIcon = null, appId = "com.example.app"),
+    )
+    assertEquals(
+      "assets/icons/favicon_example.com.png",
+      TargetIconConvention.resolveIconPath(explicitIcon = null, startUrl = "https://example.com/x"),
+    )
+    assertNull(TargetIconConvention.resolveIconPath(explicitIcon = null))
+  }
+
+  @Test
+  fun iconThreadsFromTrailmapTargetToResolvedConfig() {
+    val resolved = xyz.block.trailblaze.config.project.TrailmapTargetConfig(
+      displayName = "Example App",
+      icon = "assets/icons/android_com.example.app.png",
+    ).toAppTargetYamlConfig(defaultId = "example", resolvedTools = emptyList())
+    assertEquals("assets/icons/android_com.example.app.png", resolved.icon)
+  }
+}


### PR DESCRIPTION
Foundation for #200 — surfacing app icons (Android) / favicons (web) next to each TrailRunner target to fix the empty no-targets first-run experience.

This PR lands the **data-model + resolver slice**; the TrailRunner UI rendering is the explicit follow-up.

## What's here
- Optional `icon:` field on `TrailmapTargetConfig` (authored) and `AppTargetYamlConfig` (resolved manifest), threaded through `toAppTargetYamlConfig`. The bundled-config generator already passes unknown target fields through, so an explicit `icon:` carries end-to-end into `targets/<id>.yaml` with no build-logic change.
- New pure `TargetIconConvention` helper — convention paths (`android_<app_id>.png` / `favicon_<host>.png`) + `hostFromUrl` + `resolveIconPath` with explicit-override precedence — plus a passing `TargetIconConventionTest`. This gives the zero-config path: drop icons in the folder and targets light up with no per-target YAML.
- Regenerated `:trailblaze-models` apiDump baselines (jvm + android) for the new public surface.

## Verification
`:trailblaze-models:compileKotlinJvm` and `:compileTestKotlinJvm` build clean (`--no-daemon`, only pre-existing warnings); the new unit test passes.

## Out of scope / follow-up
The TrailRunner UI rendering (Compose/web) that actually draws the resolved icon next to each target on `:52525`. See #200 for the full design — icon extraction via `aapt` (incl. adaptive-icon compositing) for Android and Google-s2 / DuckDuckGo for web favicons, plus the empty-first-run motivation.

Refs #200.
