### PR TITLE
Fix Anthropic model resolution, missing on-device clients, direction enum casing

### DIFF
--- a/trailblaze-android-ondevice-mcp/build.gradle.kts
+++ b/trailblaze-android-ondevice-mcp/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.ktor.serialization.kotlinx.json)
   implementation(libs.ktor.server.content.negotiation)
+  implementation(libs.koog.prompt.executor.anthropic)
   implementation(libs.koog.prompt.executor.openai)
   implementation(libs.koog.prompt.executor.ollama)
   // Koog 1.0.0: LLM clients no longer accept a raw Ktor `HttpClient`; the androidTest source

--- a/trailblaze-android-ondevice-mcp/src/androidTest/java/xyz/block/trailblaze/AndroidStandaloneServerTest.kt
+++ b/trailblaze-android-ondevice-mcp/src/androidTest/java/xyz/block/trailblaze/AndroidStandaloneServerTest.kt
@@ -100,9 +100,7 @@ class AndroidStandaloneServerTest : BaseAndroidStandaloneServerTest() {
         apiKey = anthropicApiKey,
         settings = AnthropicClientSettings(
           modelVersionsMap = BuiltInLlmModelRegistry
-            .modelListForProvider(TrailblazeLlmProvider.ANTHROPIC)
-            ?.entries.orEmpty()
-            .associate { it.toKoogLlmModel() to it.modelId },
+            .koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC),
         ),
         httpClientFactory = httpClientFactory,
       )

--- a/trailblaze-android-ondevice-mcp/src/androidTest/java/xyz/block/trailblaze/AndroidStandaloneServerTest.kt
+++ b/trailblaze-android-ondevice-mcp/src/androidTest/java/xyz/block/trailblaze/AndroidStandaloneServerTest.kt
@@ -99,8 +99,11 @@ class AndroidStandaloneServerTest : BaseAndroidStandaloneServerTest() {
       llmClients[LLMProvider.Anthropic] = AnthropicLLMClient(
         apiKey = anthropicApiKey,
         settings = AnthropicClientSettings(
+          // Include the model this request resolved on the host — it may carry yaml overrides
+          // (or the built-in YAML may be unreadable on-device), so the built-in map alone can
+          // miss its LLModel key.
           modelVersionsMap = BuiltInLlmModelRegistry
-            .koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC),
+            .koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC, extraModels = listOf(trailblazeLlmModel)),
         ),
         httpClientFactory = httpClientFactory,
       )

--- a/trailblaze-android-ondevice-mcp/src/androidTest/java/xyz/block/trailblaze/AndroidStandaloneServerTest.kt
+++ b/trailblaze-android-ondevice-mcp/src/androidTest/java/xyz/block/trailblaze/AndroidStandaloneServerTest.kt
@@ -2,6 +2,8 @@ package xyz.block.trailblaze
 
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.clients.anthropic.AnthropicClientSettings
+import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.ollama.client.OllamaClient
 import ai.koog.prompt.llm.LLMProvider
@@ -16,6 +18,7 @@ import xyz.block.trailblaze.android.devices.TrailblazeAndroidOnDeviceClassifier
 import xyz.block.trailblaze.android.runner.rpc.OnDeviceRpcServer
 import xyz.block.trailblaze.devices.TrailblazeDeviceClassifier
 import xyz.block.trailblaze.llm.TrailblazeLlmProvider
+import xyz.block.trailblaze.llm.config.BuiltInLlmModelRegistry
 import xyz.block.trailblaze.llm.config.LlmAuthResolver
 import xyz.block.trailblaze.http.DefaultDynamicLlmClient
 import xyz.block.trailblaze.http.DynamicLlmClient
@@ -89,6 +92,18 @@ class AndroidStandaloneServerTest : BaseAndroidStandaloneServerTest() {
     InstrumentationArgUtil.getInstrumentationArg(LlmAuthResolver.resolve(TrailblazeLlmProvider.OPENAI))?.let { openAiApiKey ->
       llmClients[LLMProvider.OpenAI] = OpenAILLMClient(
         apiKey = openAiApiKey,
+        httpClientFactory = httpClientFactory,
+      )
+    }
+    InstrumentationArgUtil.getInstrumentationArg(LlmAuthResolver.resolve(TrailblazeLlmProvider.ANTHROPIC))?.let { anthropicApiKey ->
+      llmClients[LLMProvider.Anthropic] = AnthropicLLMClient(
+        apiKey = anthropicApiKey,
+        settings = AnthropicClientSettings(
+          modelVersionsMap = BuiltInLlmModelRegistry
+            .modelListForProvider(TrailblazeLlmProvider.ANTHROPIC)
+            ?.entries.orEmpty()
+            .associate { it.toKoogLlmModel() to it.modelId },
+        ),
         httpClientFactory = httpClientFactory,
       )
     }

--- a/trailblaze-android/build.gradle.kts
+++ b/trailblaze-android/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
   implementation(libs.okio)
   implementation(libs.slf4j.api)
   implementation(libs.koog.prompt.executor.clients)
+  implementation(libs.koog.prompt.executor.anthropic)
   implementation(libs.koog.prompt.executor.openai)
   implementation(libs.koog.prompt.executor.openrouter)
   implementation(libs.koog.prompt.executor.ollama)

--- a/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidLlmClientResolver.kt
+++ b/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidLlmClientResolver.kt
@@ -192,8 +192,11 @@ object AndroidLlmClientResolver {
           AnthropicLLMClient(
             apiKey = key,
             settings = AnthropicClientSettings(
+              // Include the runtime-resolved model: it may be a findOrFallback() construction
+              // (built-in YAML unreadable on-device → base map empty) or carry yaml overrides,
+              // either of which would miss the built-in map's LLModel keys.
               modelVersionsMap = BuiltInLlmModelRegistry
-                .koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC),
+                .koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC, extraModels = listOf(model)),
             ),
             httpClientFactory = httpClientFactory,
           ),

--- a/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidLlmClientResolver.kt
+++ b/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidLlmClientResolver.kt
@@ -193,9 +193,7 @@ object AndroidLlmClientResolver {
             apiKey = key,
             settings = AnthropicClientSettings(
               modelVersionsMap = BuiltInLlmModelRegistry
-                .modelListForProvider(TrailblazeLlmProvider.ANTHROPIC)
-                ?.entries.orEmpty()
-                .associate { it.toKoogLlmModel() to it.modelId },
+                .koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC),
             ),
             httpClientFactory = httpClientFactory,
           ),

--- a/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidLlmClientResolver.kt
+++ b/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidLlmClientResolver.kt
@@ -2,6 +2,8 @@ package xyz.block.trailblaze.android
 
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.clients.anthropic.AnthropicClientSettings
+import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAIClientSettings
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
 import ai.koog.prompt.executor.clients.openrouter.OpenRouterLLMClient
@@ -178,6 +180,23 @@ object AndroidLlmClientResolver {
               OpenAIClientSettings(
                 baseUrl = OpenAiInstrumentationArgUtil.getBaseUrlFromInstrumentationArg(),
               ),
+            httpClientFactory = httpClientFactory,
+          ),
+        )
+      }
+
+      // Anthropic
+      getToken(TrailblazeLlmProvider.ANTHROPIC)?.let { key ->
+        put(
+          LLMProvider.Anthropic,
+          AnthropicLLMClient(
+            apiKey = key,
+            settings = AnthropicClientSettings(
+              modelVersionsMap = BuiltInLlmModelRegistry
+                .modelListForProvider(TrailblazeLlmProvider.ANTHROPIC)
+                ?.entries.orEmpty()
+                .associate { it.toKoogLlmModel() to it.modelId },
+            ),
             httpClientFactory = httpClientFactory,
           ),
         )

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/maestro/TrailblazeScrollStartPosition.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/maestro/TrailblazeScrollStartPosition.kt
@@ -1,11 +1,15 @@
 package xyz.block.trailblaze.maestro
 
 import kotlinx.serialization.Serializable
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
-@Serializable
+@Serializable(with = TrailblazeScrollStartPosition.Serializer::class)
 enum class TrailblazeScrollStartPosition {
   CENTER,
   TOP,
   BOTTOM,
   ;
+
+  object Serializer :
+    CaseInsensitiveEnumSerializer<TrailblazeScrollStartPosition>(TrailblazeScrollStartPosition::class)
 }

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/ElementRetrieverTrailblazeTool.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/ElementRetrieverTrailblazeTool.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 import xyz.block.trailblaze.toolcalls.TrailblazeTool
 import xyz.block.trailblaze.toolcalls.TrailblazeToolClass
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
 /**
  * Command to retrieve a selector for an element based on the description.
@@ -52,10 +53,13 @@ data class ElementRetrieverTrailblazeTool(
   /**
    * Types of locators in order of preference.
    */
-  @Serializable
+  @Serializable(with = LocatorType.Serializer::class)
   enum class LocatorType {
     RESOURCE_ID,
     CONTENT_DESCRIPTION,
     TEXT,
+    ;
+
+    object Serializer : CaseInsensitiveEnumSerializer<LocatorType>(LocatorType::class)
   }
 }

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/LaunchAppTrailblazeTool.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/LaunchAppTrailblazeTool.kt
@@ -12,6 +12,7 @@ import xyz.block.trailblaze.toolcalls.TrailblazeToolClass
 import xyz.block.trailblaze.toolcalls.TrailblazeToolExecutionContext
 import xyz.block.trailblaze.toolcalls.TrailblazeToolResult
 import xyz.block.trailblaze.toolcalls.isSuccess
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
 @Serializable
 @TrailblazeToolClass("launchApp")
@@ -83,6 +84,7 @@ Available App Launch Modes:
     ),
   )
 
+  @Serializable(with = LaunchMode.Serializer::class)
   enum class LaunchMode {
     /**
      * Launch the app in a clean state, like when the app is initially installed.
@@ -100,6 +102,8 @@ Available App Launch Modes:
     FORCE_RESTART,
 
     ;
+
+    object Serializer : CaseInsensitiveEnumSerializer<LaunchMode>(LaunchMode::class)
 
     companion object {
       fun fromString(value: String?): LaunchMode = LaunchMode.entries.firstOrNull { it.name.equals(value, ignoreCase = true) } ?: REINSTALL

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/LenientDirectionSerializers.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/LenientDirectionSerializers.kt
@@ -1,0 +1,30 @@
+package xyz.block.trailblaze.toolcalls.commands
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import maestro.ScrollDirection
+import maestro.SwipeDirection
+
+object LenientScrollDirectionSerializer : KSerializer<ScrollDirection> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("maestro.ScrollDirection", PrimitiveKind.STRING)
+
+  override fun deserialize(decoder: Decoder): ScrollDirection =
+    ScrollDirection.valueOf(decoder.decodeString().trim().uppercase())
+
+  override fun serialize(encoder: Encoder, value: ScrollDirection) = encoder.encodeString(value.name)
+}
+
+object LenientSwipeDirectionSerializer : KSerializer<SwipeDirection> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("maestro.SwipeDirection", PrimitiveKind.STRING)
+
+  override fun deserialize(decoder: Decoder): SwipeDirection =
+    SwipeDirection.valueOf(decoder.decodeString().trim().uppercase())
+
+  override fun serialize(encoder: Encoder, value: SwipeDirection) = encoder.encodeString(value.name)
+}

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/LenientDirectionSerializers.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/LenientDirectionSerializers.kt
@@ -1,30 +1,13 @@
 package xyz.block.trailblaze.toolcalls.commands
 
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import maestro.ScrollDirection
 import maestro.SwipeDirection
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
-object LenientScrollDirectionSerializer : KSerializer<ScrollDirection> {
-  override val descriptor: SerialDescriptor =
-    PrimitiveSerialDescriptor("maestro.ScrollDirection", PrimitiveKind.STRING)
+// Maestro's direction enums are third-party, so the serializer can't be nested inside the
+// enum per CaseInsensitiveEnumSerializer's documented pattern — these standalone objects are
+// applied at the property site via @Serializable(with = ...) instead.
 
-  override fun deserialize(decoder: Decoder): ScrollDirection =
-    ScrollDirection.valueOf(decoder.decodeString().trim().uppercase())
+object LenientScrollDirectionSerializer : CaseInsensitiveEnumSerializer<ScrollDirection>(ScrollDirection::class)
 
-  override fun serialize(encoder: Encoder, value: ScrollDirection) = encoder.encodeString(value.name)
-}
-
-object LenientSwipeDirectionSerializer : KSerializer<SwipeDirection> {
-  override val descriptor: SerialDescriptor =
-    PrimitiveSerialDescriptor("maestro.SwipeDirection", PrimitiveKind.STRING)
-
-  override fun deserialize(decoder: Decoder): SwipeDirection =
-    SwipeDirection.valueOf(decoder.decodeString().trim().uppercase())
-
-  override fun serialize(encoder: Encoder, value: SwipeDirection) = encoder.encodeString(value.name)
-}
+object LenientSwipeDirectionSerializer : CaseInsensitiveEnumSerializer<SwipeDirection>(SwipeDirection::class)

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/ObjectiveStatusTrailblazeTool.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/ObjectiveStatusTrailblazeTool.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.tools.annotations.LLMDescription
 import kotlinx.serialization.Serializable
 import xyz.block.trailblaze.toolcalls.TrailblazeTool
 import xyz.block.trailblaze.toolcalls.TrailblazeToolClass
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
 @Serializable
 @TrailblazeToolClass("objectiveStatus")
@@ -24,8 +25,14 @@ data class ObjectiveStatusTrailblazeTool(
   val status: Status,
 ) : TrailblazeTool
 
+// The tool's own @LLMDescription instructs the model to return lowercase 'in_progress' /
+// 'completed' / 'failed', so this enum in particular must decode case-insensitively.
+@Serializable(with = Status.Serializer::class)
 enum class Status {
   IN_PROGRESS,
   COMPLETED,
   FAILED,
+  ;
+
+  object Serializer : CaseInsensitiveEnumSerializer<Status>(Status::class)
 }

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/ScrollUntilTextIsVisibleTrailblazeTool.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/ScrollUntilTextIsVisibleTrailblazeTool.kt
@@ -48,6 +48,7 @@ class ScrollUntilTextIsVisibleTrailblazeTool(
   @param:LLMDescription("A 0-based index to disambiguate multiple views with the same text. Default is '0'.")
   val index: Int = 0,
   @param:LLMDescription("Direction to scroll. Default is 'DOWN'.")
+  @Serializable(with = LenientScrollDirectionSerializer::class)
   val direction: ScrollDirection = ScrollDirection.DOWN,
   @param:LLMDescription("Percentage of element visible in viewport. Default is '100'.")
   val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE,

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/SwipeTrailblazeTool.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/SwipeTrailblazeTool.kt
@@ -31,6 +31,7 @@ To see more content BELOW (scroll down), use 'UP' (finger swipes upward).
 To see more content ABOVE (scroll up), use 'DOWN' (finger swipes downward).
 Default is 'DOWN'.""",
   )
+  @Serializable(with = LenientSwipeDirectionSerializer::class)
   val direction: SwipeDirection = SwipeDirection.DOWN,
   @param:LLMDescription(
     """

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/TextMatchMode.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/TextMatchMode.kt
@@ -1,15 +1,19 @@
 package xyz.block.trailblaze.toolcalls.commands
 
 import kotlinx.serialization.Serializable
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
 /**
  * How an assertVisible text check compares the captured [expectedText] against the live
  * element text at replay. [EXACT] is the default so trails without the field keep their
  * original strict-equality behavior.
  */
-@Serializable
+@Serializable(with = TextMatchMode.Serializer::class)
 enum class TextMatchMode {
   EXACT,
   PREFIX,
   REGEX,
+  ;
+
+  object Serializer : CaseInsensitiveEnumSerializer<TextMatchMode>(TextMatchMode::class)
 }

--- a/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/toolcalls/commands/CaseInsensitiveToolEnumsTest.kt
+++ b/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/toolcalls/commands/CaseInsensitiveToolEnumsTest.kt
@@ -1,0 +1,72 @@
+package xyz.block.trailblaze.toolcalls.commands
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import maestro.ScrollDirection
+import maestro.SwipeDirection
+import org.junit.Test
+import xyz.block.trailblaze.logs.client.TrailblazeJsonInstance
+import xyz.block.trailblaze.maestro.TrailblazeScrollStartPosition
+
+/**
+ * LLMs regularly emit enum values in lowercase regardless of the schema's casing (the tool
+ * descriptions themselves sometimes prompt lowercase — see objectiveStatus). Every LLM-facing
+ * enum tool parameter must decode case-insensitively via [CaseInsensitiveEnumSerializer];
+ * these decode through the real tool serializers so the annotation wiring is covered.
+ */
+class CaseInsensitiveToolEnumsTest {
+
+  @Test
+  fun `scrollUntilTextIsVisible decodes lowercase direction and scrollStartPosition`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      ScrollUntilTextIsVisibleTrailblazeTool.serializer(),
+      """{"text":"Settings","direction":"up","scrollStartPosition":"bottom"}""",
+    )
+    assertThat(tool.direction).isEqualTo(ScrollDirection.UP)
+    assertThat(tool.scrollStartPosition).isEqualTo(TrailblazeScrollStartPosition.BOTTOM)
+  }
+
+  @Test
+  fun `swipe decodes lowercase direction`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      SwipeTrailblazeTool.serializer(),
+      """{"direction":"down"}""",
+    )
+    assertThat(tool.direction).isEqualTo(SwipeDirection.DOWN)
+  }
+
+  @Test
+  fun `objectiveStatus decodes the lowercase status its own description prompts for`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      ObjectiveStatusTrailblazeTool.serializer(),
+      """{"explanation":"done","status":"in_progress"}""",
+    )
+    assertThat(tool.status).isEqualTo(Status.IN_PROGRESS)
+  }
+
+  @Test
+  fun `launchApp decodes lowercase launchMode`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      LaunchAppTrailblazeTool.serializer(),
+      """{"appId":"com.example.app","launchMode":"force_restart"}""",
+    )
+    assertThat(tool.launchMode).isEqualTo(LaunchAppTrailblazeTool.LaunchMode.FORCE_RESTART)
+  }
+
+  @Test
+  fun `elementRetriever decodes lowercase locatorType`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      ElementRetrieverTrailblazeTool.serializer(),
+      """{"identifier":"the button","locatorType":"resource_id","value":"btn"}""",
+    )
+    assertThat(tool.locatorType)
+      .isEqualTo(ElementRetrieverTrailblazeTool.LocatorType.RESOURCE_ID)
+  }
+
+  @Test
+  fun `textMatchMode decodes lowercase`() {
+    assertThat(
+      TrailblazeJsonInstance.decodeFromString(TextMatchMode.serializer(), "\"prefix\""),
+    ).isEqualTo(TextMatchMode.PREFIX)
+  }
+}

--- a/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/toolcalls/commands/LenientDirectionSerializersTest.kt
+++ b/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/toolcalls/commands/LenientDirectionSerializersTest.kt
@@ -1,11 +1,16 @@
 package xyz.block.trailblaze.toolcalls.commands
 
+import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.messageContains
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import maestro.ScrollDirection
 import maestro.SwipeDirection
 import org.junit.Test
+import xyz.block.trailblaze.logs.client.TrailblazeJsonInstance
 
 class LenientDirectionSerializersTest {
 
@@ -28,5 +33,36 @@ class LenientDirectionSerializersTest {
     assertThat(
       Json.encodeToString(LenientScrollDirectionSerializer, ScrollDirection.LEFT),
     ).isEqualTo("\"LEFT\"")
+  }
+
+  // Invalid values must fail with SerializationException, NOT IllegalArgumentException —
+  // BaseTrailblazeAgent.resolveDynamicTool deliberately catches only IllegalStateException
+  // and SerializationException; anything else propagates and kills the run.
+  @Test
+  fun `invalid direction throws SerializationException listing valid values`() {
+    assertFailure {
+      Json.decodeFromString(LenientScrollDirectionSerializer, "\"forward\"")
+    }.isInstanceOf(SerializationException::class)
+      .messageContains("UP")
+  }
+
+  // Decodes through the tool's own serializer so the @Serializable(with = ...) annotation
+  // wiring on the direction property is exercised, not just the serializer object.
+  @Test
+  fun `swipe tool decodes lowercase direction via property annotation`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      SwipeTrailblazeTool.serializer(),
+      """{"direction":"down"}""",
+    )
+    assertThat(tool.direction).isEqualTo(SwipeDirection.DOWN)
+  }
+
+  @Test
+  fun `scroll tool decodes lowercase direction via property annotation`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      ScrollUntilTextIsVisibleTrailblazeTool.serializer(),
+      """{"text":"Settings","direction":"up"}""",
+    )
+    assertThat(tool.direction).isEqualTo(ScrollDirection.UP)
   }
 }

--- a/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/toolcalls/commands/LenientDirectionSerializersTest.kt
+++ b/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/toolcalls/commands/LenientDirectionSerializersTest.kt
@@ -1,0 +1,32 @@
+package xyz.block.trailblaze.toolcalls.commands
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlinx.serialization.json.Json
+import maestro.ScrollDirection
+import maestro.SwipeDirection
+import org.junit.Test
+
+class LenientDirectionSerializersTest {
+
+  @Test
+  fun `scroll direction decodes lowercase`() {
+    assertThat(
+      Json.decodeFromString(LenientScrollDirectionSerializer, "\"down\""),
+    ).isEqualTo(ScrollDirection.DOWN)
+  }
+
+  @Test
+  fun `swipe direction decodes mixed case with whitespace`() {
+    assertThat(
+      Json.decodeFromString(LenientSwipeDirectionSerializer, "\" Up \""),
+    ).isEqualTo(SwipeDirection.UP)
+  }
+
+  @Test
+  fun `encodes canonical enum name`() {
+    assertThat(
+      Json.encodeToString(LenientScrollDirectionSerializer, ScrollDirection.LEFT),
+    ).isEqualTo("\"LEFT\"")
+  }
+}

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/host/rules/TrailblazeHostDynamicLlmTokenProvider.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/host/rules/TrailblazeHostDynamicLlmTokenProvider.kt
@@ -105,9 +105,7 @@ object TrailblazeHostDynamicLlmTokenProvider : TrailblazeDynamicLlmTokenProvider
           apiKey = apiKey,
           settings = AnthropicClientSettings(
             modelVersionsMap = BuiltInLlmModelRegistry
-              .modelListForProvider(TrailblazeLlmProvider.ANTHROPIC)
-              ?.entries.orEmpty()
-              .associate { it.toKoogLlmModel() to it.modelId },
+              .koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC),
           ),
           httpClientFactory = httpClientFactory,
         )

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/host/rules/TrailblazeHostDynamicLlmTokenProvider.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/host/rules/TrailblazeHostDynamicLlmTokenProvider.kt
@@ -14,6 +14,7 @@ import xyz.block.trailblaze.llm.LlmProviderEnvVarUtil
 import xyz.block.trailblaze.llm.TrailblazeLlmProvider
 import xyz.block.trailblaze.llm.config.BuiltInLlmModelRegistry
 import xyz.block.trailblaze.llm.config.LlmConfigLoader
+import xyz.block.trailblaze.llm.config.LlmConfigResolver
 import xyz.block.trailblaze.llm.config.LlmProviderType
 import xyz.block.trailblaze.llm.providers.TrailblazeDynamicLlmTokenProvider
 import xyz.block.trailblaze.mcp.utils.JvmLLMProvidersUtil
@@ -27,6 +28,18 @@ import xyz.block.trailblaze.mcp.utils.JvmLLMProvidersUtil
 object TrailblazeHostDynamicLlmTokenProvider : TrailblazeDynamicLlmTokenProvider {
 
   private val loadedConfig by lazy { LlmConfigLoader.load() }
+
+  /**
+   * Anthropic models as the user's `trailblaze.yaml` resolves them. Overridden fields
+   * (`context_length`, `max_output_tokens`, `vision`) and custom model ids produce LLModel
+   * forms that differ from the built-in registry entries, so the client's modelVersionsMap
+   * must include these too or koog rejects them as "Unsupported model".
+   */
+  private val resolvedAnthropicModels by lazy {
+    LlmConfigResolver.resolve(loadedConfig).modelLists
+      .filter { it.provider.id == TrailblazeLlmProvider.ANTHROPIC.id }
+      .flatMap { it.entries }
+  }
 
   val ollamaBaseUrl: String? by lazy {
     loadedConfig.providers["ollama"]?.baseUrl
@@ -104,8 +117,10 @@ object TrailblazeHostDynamicLlmTokenProvider : TrailblazeDynamicLlmTokenProvider
         TrailblazeLlmProvider.ANTHROPIC -> AnthropicLLMClient(
           apiKey = apiKey,
           settings = AnthropicClientSettings(
-            modelVersionsMap = BuiltInLlmModelRegistry
-              .koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC),
+            modelVersionsMap = BuiltInLlmModelRegistry.koogModelVersionsMap(
+              TrailblazeLlmProvider.ANTHROPIC,
+              extraModels = resolvedAnthropicModels,
+            ),
           ),
           httpClientFactory = httpClientFactory,
         )

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/host/rules/TrailblazeHostDynamicLlmTokenProvider.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/host/rules/TrailblazeHostDynamicLlmTokenProvider.kt
@@ -2,6 +2,7 @@ package xyz.block.trailblaze.host.rules
 
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.executor.clients.LLMClient
+import ai.koog.prompt.executor.clients.anthropic.AnthropicClientSettings
 import ai.koog.prompt.executor.clients.anthropic.AnthropicLLMClient
 import ai.koog.prompt.executor.clients.google.GoogleLLMClient
 import ai.koog.prompt.executor.clients.openai.OpenAILLMClient
@@ -11,6 +12,7 @@ import io.ktor.client.HttpClient
 import xyz.block.trailblaze.host.llm.OpenAICompatibleLlmClientFactory
 import xyz.block.trailblaze.llm.LlmProviderEnvVarUtil
 import xyz.block.trailblaze.llm.TrailblazeLlmProvider
+import xyz.block.trailblaze.llm.config.BuiltInLlmModelRegistry
 import xyz.block.trailblaze.llm.config.LlmConfigLoader
 import xyz.block.trailblaze.llm.config.LlmProviderType
 import xyz.block.trailblaze.llm.providers.TrailblazeDynamicLlmTokenProvider
@@ -101,6 +103,12 @@ object TrailblazeHostDynamicLlmTokenProvider : TrailblazeDynamicLlmTokenProvider
       when (trailblazeLlmProvider) {
         TrailblazeLlmProvider.ANTHROPIC -> AnthropicLLMClient(
           apiKey = apiKey,
+          settings = AnthropicClientSettings(
+            modelVersionsMap = BuiltInLlmModelRegistry
+              .modelListForProvider(TrailblazeLlmProvider.ANTHROPIC)
+              ?.entries.orEmpty()
+              .associate { it.toKoogLlmModel() to it.modelId },
+          ),
           httpClientFactory = httpClientFactory,
         )
 

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/llm/config/BuiltInLlmModelRegistry.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/llm/config/BuiltInLlmModelRegistry.kt
@@ -131,10 +131,24 @@ object BuiltInLlmModelRegistry {
    * (currently only `AnthropicLLMClient`) resolve the request's [LLModel] in this map by
    * data-class equality and throw "Unsupported model" on a miss, so any model that can
    * reach the client at runtime must have an entry here.
+   *
+   * [extraModels] covers models whose [LLModel] form differs from the built-in entry (or has
+   * no built-in entry at all): user-yaml overrides of `context_length`/`max_output_tokens`/
+   * `vision` change [LLModel] equality, custom model ids aren't in the built-in list, and on
+   * runtimes where the built-in YAML isn't readable the base map is empty. Custom ids are a
+   * documented contract (docs/llm_configuration.md "Custom model specs"): users add a
+   * newly-released model via yaml without waiting for a trailblaze release that catalogs it,
+   * so an unknown model must not be rejected as long as the provider exists. Callers that
+   * know the runtime-resolved model(s) should pass them; extras win on key collisions.
+   * Filtered to [provider] so callers can pass a model without checking its provider first.
    */
-  fun koogModelVersionsMap(provider: TrailblazeLlmProvider): Map<LLModel, String> =
-    modelListForProvider(provider)?.entries.orEmpty()
-      .associate { it.toKoogLlmModel() to it.modelId }
+  fun koogModelVersionsMap(
+    provider: TrailblazeLlmProvider,
+    extraModels: List<TrailblazeLlmModel> = emptyList(),
+  ): Map<LLModel, String> = (
+    modelListForProvider(provider)?.entries.orEmpty() +
+      extraModels.filter { it.trailblazeLlmProvider.id == provider.id }
+    ).associate { it.toKoogLlmModel() to it.modelId }
 
   /**
    * Returns the default model ID for the given provider, or null if not set.

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/llm/config/BuiltInLlmModelRegistry.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/llm/config/BuiltInLlmModelRegistry.kt
@@ -1,6 +1,7 @@
 package xyz.block.trailblaze.llm.config
 
 import ai.koog.prompt.llm.LLMCapability
+import ai.koog.prompt.llm.LLModel
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlConfiguration
 import xyz.block.trailblaze.llm.TrailblazeLlmModel
@@ -123,6 +124,17 @@ object BuiltInLlmModelRegistry {
    */
   fun modelListForProvider(provider: TrailblazeLlmProvider): TrailblazeLlmModelList? =
     getOrLoadProvider(provider.id)?.modelList
+
+  /**
+   * Koog `modelVersionsMap` for the given provider's built-in models — maps each model's
+   * [LLModel] form to the API model name. Koog clients that take a `modelVersionsMap`
+   * (currently only `AnthropicLLMClient`) resolve the request's [LLModel] in this map by
+   * data-class equality and throw "Unsupported model" on a miss, so any model that can
+   * reach the client at runtime must have an entry here.
+   */
+  fun koogModelVersionsMap(provider: TrailblazeLlmProvider): Map<LLModel, String> =
+    modelListForProvider(provider)?.entries.orEmpty()
+      .associate { it.toKoogLlmModel() to it.modelId }
 
   /**
    * Returns the default model ID for the given provider, or null if not set.

--- a/trailblaze-models/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/yaml/serializers/CaseInsensitiveEnumSerializer.kt
+++ b/trailblaze-models/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/yaml/serializers/CaseInsensitiveEnumSerializer.kt
@@ -21,7 +21,8 @@ import kotlinx.serialization.encoding.Encoder
  * }
  * ```
  *
- * Serializes back to the canonical uppercase name; accepts any casing on deserialization.
+ * Serializes back to the canonical uppercase name; accepts any casing and surrounding
+ * whitespace on deserialization.
  * Throws [SerializationException] with the list of valid values if the input doesn't match.
  */
 @Suppress("UNCHECKED_CAST")
@@ -37,7 +38,7 @@ abstract class CaseInsensitiveEnumSerializer<T : Enum<T>>(
   override fun serialize(encoder: Encoder, value: T) = encoder.encodeString(value.name)
 
   override fun deserialize(decoder: Decoder): T {
-    val raw = decoder.decodeString().uppercase()
+    val raw = decoder.decodeString().trim().uppercase()
     return values.firstOrNull { it.name == raw }
       ?: throw SerializationException(
         "Unknown ${descriptor.serialName} value: '$raw'. " +

--- a/trailblaze-models/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/llm/config/BuiltInLlmModelRegistryKoogMapTest.kt
+++ b/trailblaze-models/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/llm/config/BuiltInLlmModelRegistryKoogMapTest.kt
@@ -1,0 +1,66 @@
+package xyz.block.trailblaze.llm.config
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEmpty
+import kotlin.test.Test
+import xyz.block.trailblaze.llm.TrailblazeLlmModel
+import xyz.block.trailblaze.llm.TrailblazeLlmProvider
+
+/**
+ * Guards the koog `modelVersionsMap` contract: `AnthropicLLMClient` resolves the request's
+ * `LLModel` in the map by data-class equality and throws "Unsupported model" on a miss, so
+ * the map must cover both built-in models and runtime-resolved models whose LLModel form
+ * differs from the built-in entry (yaml overrides, custom ids, fallback constructions).
+ */
+class BuiltInLlmModelRegistryKoogMapTest {
+
+  @Test
+  fun `built-in anthropic models resolve by LLModel equality`() {
+    val map = BuiltInLlmModelRegistry.koogModelVersionsMap(TrailblazeLlmProvider.ANTHROPIC)
+    assertThat(map).isNotEmpty()
+    val builtIn = BuiltInLlmModelRegistry
+      .modelListForProvider(TrailblazeLlmProvider.ANTHROPIC)!!.entries.first()
+    assertThat(map[builtIn.toKoogLlmModel()]).isEqualTo(builtIn.modelId)
+  }
+
+  @Test
+  fun `extra model with yaml-style overrides resolves alongside built-ins`() {
+    // A user-yaml override of context_length yields an LLModel that is NOT equal to the
+    // built-in entry — without extraModels this lookup is the "Unsupported model" crash.
+    val overridden = BuiltInLlmModelRegistry
+      .modelListForProvider(TrailblazeLlmProvider.ANTHROPIC)!!.entries.first()
+      .copy(contextLength = 42_000L)
+    val map = BuiltInLlmModelRegistry.koogModelVersionsMap(
+      TrailblazeLlmProvider.ANTHROPIC,
+      extraModels = listOf(overridden),
+    )
+    assertThat(map[overridden.toKoogLlmModel()]).isEqualTo(overridden.modelId)
+  }
+
+  @Test
+  fun `extra model not in the built-in catalog resolves`() {
+    val custom = TrailblazeLlmModel.fallback(
+      provider = TrailblazeLlmProvider.ANTHROPIC,
+      modelId = "claude-brand-new-model",
+    )
+    val map = BuiltInLlmModelRegistry.koogModelVersionsMap(
+      TrailblazeLlmProvider.ANTHROPIC,
+      extraModels = listOf(custom),
+    )
+    assertThat(map[custom.toKoogLlmModel()]).isEqualTo("claude-brand-new-model")
+  }
+
+  @Test
+  fun `extra models for other providers are filtered out`() {
+    val openAiModel = TrailblazeLlmModel.fallback(
+      provider = TrailblazeLlmProvider.OPENAI,
+      modelId = "gpt-something",
+    )
+    val map = BuiltInLlmModelRegistry.koogModelVersionsMap(
+      TrailblazeLlmProvider.ANTHROPIC,
+      extraModels = listOf(openAiModel),
+    )
+    assertThat(map[openAiModel.toKoogLlmModel()]).isEqualTo(null)
+  }
+}

--- a/trailblaze-playwright/src/main/java/xyz/block/trailblaze/playwright/tools/PlaywrightNativeNavigateTool.kt
+++ b/trailblaze-playwright/src/main/java/xyz/block/trailblaze/playwright/tools/PlaywrightNativeNavigateTool.kt
@@ -9,6 +9,7 @@ import xyz.block.trailblaze.toolcalls.TrailblazeToolClass
 import xyz.block.trailblaze.toolcalls.TrailblazeToolExecutionContext
 import xyz.block.trailblaze.toolcalls.TrailblazeToolResult
 import xyz.block.trailblaze.util.Console
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
 @Serializable
 @TrailblazeToolClass("web_navigate")
@@ -33,11 +34,14 @@ class PlaywrightNativeNavigateTool(
   override val reasoning: String? = null,
 ) : PlaywrightExecutableTool, ReasoningTrailblazeTool {
 
-  @Serializable
+  @Serializable(with = NavigationAction.Serializer::class)
   enum class NavigationAction {
     GOTO,
     BACK,
     FORWARD,
+    ;
+
+    object Serializer : CaseInsensitiveEnumSerializer<NavigationAction>(NavigationAction::class)
   }
 
   override suspend fun executeWithPlaywright(

--- a/trailblaze-playwright/src/main/java/xyz/block/trailblaze/playwright/tools/PlaywrightNativeScrollTool.kt
+++ b/trailblaze-playwright/src/main/java/xyz/block/trailblaze/playwright/tools/PlaywrightNativeScrollTool.kt
@@ -9,6 +9,7 @@ import xyz.block.trailblaze.toolcalls.TrailblazeToolClass
 import xyz.block.trailblaze.toolcalls.TrailblazeToolExecutionContext
 import xyz.block.trailblaze.toolcalls.TrailblazeToolResult
 import xyz.block.trailblaze.util.Console
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
 @Serializable
 @TrailblazeToolClass("web_scroll")
@@ -39,12 +40,15 @@ class PlaywrightNativeScrollTool(
   override fun withNodeSelector(selector: TrailblazeNodeSelector): PlaywrightExecutableTool =
     PlaywrightNativeScrollTool(direction = direction, amount = amount, ref = null, reasoning = reasoning, nodeSelector = selector)
 
-  @Serializable
+  @Serializable(with = ScrollDirection.Serializer::class)
   enum class ScrollDirection {
     UP,
     DOWN,
     LEFT,
     RIGHT,
+    ;
+
+    object Serializer : CaseInsensitiveEnumSerializer<ScrollDirection>(ScrollDirection::class)
   }
 
   override suspend fun executeWithPlaywright(

--- a/trailblaze-playwright/src/main/java/xyz/block/trailblaze/playwright/tools/PlaywrightNativeVerifyValueTool.kt
+++ b/trailblaze-playwright/src/main/java/xyz/block/trailblaze/playwright/tools/PlaywrightNativeVerifyValueTool.kt
@@ -10,6 +10,7 @@ import xyz.block.trailblaze.toolcalls.TrailblazeToolClass
 import xyz.block.trailblaze.toolcalls.TrailblazeToolExecutionContext
 import xyz.block.trailblaze.toolcalls.TrailblazeToolResult
 import xyz.block.trailblaze.util.Console
+import xyz.block.trailblaze.yaml.serializers.CaseInsensitiveEnumSerializer
 
 @Serializable
 @TrailblazeToolClass("web_verifyValue", isVerification = true)
@@ -45,11 +46,14 @@ class PlaywrightNativeVerifyValueTool(
   override fun withNodeSelector(selector: TrailblazeNodeSelector): PlaywrightExecutableTool =
     PlaywrightNativeVerifyValueTool(ref = null, type = type, expected = expected, attribute = attribute, reasoning = reasoning, nodeSelector = selector)
 
-  @Serializable
+  @Serializable(with = VerifyValueType.Serializer::class)
   enum class VerifyValueType {
     TEXT,
     VALUE,
     ATTRIBUTE,
+    ;
+
+    object Serializer : CaseInsensitiveEnumSerializer<VerifyValueType>(VerifyValueType::class)
   }
 
   override suspend fun executeWithPlaywright(

--- a/trailblaze-playwright/src/test/kotlin/xyz/block/trailblaze/playwright/tools/PlaywrightToolEnumCasingTest.kt
+++ b/trailblaze-playwright/src/test/kotlin/xyz/block/trailblaze/playwright/tools/PlaywrightToolEnumCasingTest.kt
@@ -1,0 +1,41 @@
+package xyz.block.trailblaze.playwright.tools
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.Test
+import xyz.block.trailblaze.logs.client.TrailblazeJsonInstance
+
+/**
+ * LLM-facing enum tool parameters must decode case-insensitively — models regularly emit
+ * lowercase values regardless of the schema's casing. Decodes through the real tool
+ * serializers so the @Serializable(with = ...) wiring is covered.
+ */
+class PlaywrightToolEnumCasingTest {
+
+  @Test
+  fun `web_scroll decodes lowercase direction`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      PlaywrightNativeScrollTool.serializer(),
+      """{"direction":"down"}""",
+    )
+    assertThat(tool.direction).isEqualTo(PlaywrightNativeScrollTool.ScrollDirection.DOWN)
+  }
+
+  @Test
+  fun `web_verifyValue decodes lowercase type`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      PlaywrightNativeVerifyValueTool.serializer(),
+      """{"expected":"hello","type":"attribute"}""",
+    )
+    assertThat(tool.type).isEqualTo(PlaywrightNativeVerifyValueTool.VerifyValueType.ATTRIBUTE)
+  }
+
+  @Test
+  fun `web_navigate decodes lowercase action`() {
+    val tool = TrailblazeJsonInstance.decodeFromString(
+      PlaywrightNativeNavigateTool.serializer(),
+      """{"action":"goto","url":"https://example.com"}""",
+    )
+    assertThat(tool.action).isEqualTo(PlaywrightNativeNavigateTool.NavigationAction.GOTO)
+  }
+}


### PR DESCRIPTION
anthropic-direct fails before any tool runs. fixes:

- `AnthropicLLMClient` resolves api model names through `modelVersionsMap`, keyed by `LLModel` equality. models built from the yaml catalog never equal koog's built-ins (capability lists differ), so every anthropic run throws `Unsupported model`. construct the client with a map derived from `BuiltInLlmModelRegistry` instead.
- the on-device resolvers (`AndroidLlmClientResolver`, `AndroidStandaloneServerTest`) build clients for openai/openrouter/ollama but not anthropic, so asserts fail with `Unsupported provider` even when the token is forwarded. registered anthropic on both.
- direction enums reject lowercase llm output (`ScrollDirection does not contain element with name 'down'`). added case-insensitive serializers for the two direction fields, with tests.

repro: `trailblaze run <trail> -d android --llm anthropic/claude-sonnet-4-6` with `ANTHROPIC_API_KEY` set, on v2026.06.15 through v2026.07.02.2.

`:trailblaze-common:jvmTest` green, `:trailblaze-desktop:releaseArtifacts` builds.
