### PR TITLE
Fix Android 35 UiAutomation runner recovery

### DIFF
--- a/trailblaze-android-ondevice-mcp/src/test/java/xyz/block/trailblaze/mcp/handlers/RunYamlRequestHandlerTest.kt
+++ b/trailblaze-android-ondevice-mcp/src/test/java/xyz/block/trailblaze/mcp/handlers/RunYamlRequestHandlerTest.kt
@@ -347,6 +347,12 @@ class RunYamlRequestHandlerTest {
       "instrumentation is in a ${UiAutomationHandleErrors.NON_RECOVERABLE_STATE_PHRASE} — kill the " +
       "test APK process and re-launch. Original error: UiAutomation not connected"
 
+  private val reflectionBlockedWedgeMessage =
+    "UiAutomation is not connected and the cached handle could not be cleared via reflection " +
+      "(both Instrumentation.disconnectUiAutomation() and the mUiAutomation field are " +
+      "inaccessible — Android internal API may have changed). Recover by restarting the " +
+      "Trailblaze on-device server. Original error: UiAutomation not connected"
+
   /**
    * Shape #4 — on-device source tag: when the launched job's failure carries the non-recoverable
    * UiAutomation wedge signature, the awaitCompletion=true response is tagged
@@ -364,6 +370,19 @@ class RunYamlRequestHandlerTest {
     assertTrue(result is RpcResult.Success, "Expected RpcResult.Success, got $result")
     assertEquals(false, result.data.success)
     assertTrue(result.data.nonRecoverableWedge, "Expected the wedge tag to be set")
+  }
+
+  @Test
+  fun `blocked reflective recovery tags the response nonRecoverableWedge true`() = runTest {
+    val handler = createHandler(
+      runTrailblazeYaml = { _, _, _ -> throw IllegalStateException(reflectionBlockedWedgeMessage) },
+    )
+
+    val result = handler.handle(testRequest.copy(awaitCompletion = true))
+
+    assertTrue(result is RpcResult.Success, "Expected RpcResult.Success, got $result")
+    assertEquals(false, result.data.success)
+    assertTrue(result.data.nonRecoverableWedge, "Blocked reflective recovery must arm the runner restart")
   }
 
   /** Negative control: an ordinary failure must leave `nonRecoverableWedge = false`. */

--- a/trailblaze-common/src/androidMain/kotlin/xyz/block/trailblaze/InstrumentationUtil.kt
+++ b/trailblaze-common/src/androidMain/kotlin/xyz/block/trailblaze/InstrumentationUtil.kt
@@ -128,9 +128,9 @@ object InstrumentationUtil {
    *
    * Recovery: on the first hit we clear the cached handle via reflection on [Instrumentation]'s
    * private `mUiAutomation` field, force a fresh `getUiAutomation(FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)`
-   * (which constructs a new handle and calls `connect()`), and retry once. If the retry also fails — most likely the
-   * underlying system service is genuinely gone — we re-throw with a wrapped message that points
-   * the operator at the actual recovery (restart the on-device server / test APK).
+   * (which constructs a new handle and calls `connect()`), and retry once. If Android blocks
+   * clearing the cache, or the retry also fails, we propagate a terminal signature that causes
+   * the host to restart the on-device server before its next trail.
    *
    * Reflection is the only path here because the platform doesn't expose a public way to drop
    * the cached handle. The field name is stable across all Android versions Trailblaze targets;
@@ -155,8 +155,9 @@ object InstrumentationUtil {
       val cleared = clearInstrumentationUiAutomationCache()
       if (!cleared) {
         throw IllegalStateException(
-          "UiAutomation is not connected and the cached handle could not be cleared via " +
-            "reflection (both Instrumentation.disconnectUiAutomation() and the mUiAutomation " +
+          "UiAutomation is not connected and the " +
+            "${UiAutomationHandleErrors.NON_RECOVERABLE_CACHE_CLEAR_FAILED_PHRASE} " +
+            "(both Instrumentation.disconnectUiAutomation() and the mUiAutomation " +
             "field are inaccessible — Android internal API may have changed). " +
             "Recover by restarting the Trailblaze on-device server (kill + re-launch the test " +
             "APK process). Original error: $msg",

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/util/UiAutomationHandleErrors.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/util/UiAutomationHandleErrors.kt
@@ -24,12 +24,13 @@ package xyz.block.trailblaze.util
  */
 object UiAutomationHandleErrors {
 
-  // Distinctive phrases from the NON-recoverable message that `InstrumentationUtil`'s
-  // `runWithStaleUiAutomationRecovery` throws after its in-process retry also fails. They are the
-  // source of truth for both that throw site and [isNonRecoverableStaleHandleSignature], so the
-  // matcher can't drift from the emitted text. Neither phrase appears in a recoverable signature.
+  // Distinctive phrases from the terminal errors `InstrumentationUtil` throws when it cannot
+  // clear the cached handle or its in-process reconnect retry fails. Keeping the emitted text
+  // and host-side classifier in sync lets both failures trigger the existing runner restart.
   const val NON_RECOVERABLE_RETRY_FAILED_PHRASE = "UiAutomation reconnect retry also failed"
   const val NON_RECOVERABLE_STATE_PHRASE = "non-recoverable state"
+  const val NON_RECOVERABLE_CACHE_CLEAR_FAILED_PHRASE =
+    "cached handle could not be cleared via reflection"
 
   // Matches both the platform's own "UiAutomation not connected!" error and our
   // [silentShellWedgeMessage], which starts with it on purpose so one check covers both.
@@ -46,17 +47,20 @@ object UiAutomationHandleErrors {
       "no output after '$command' — every shell command is silently returning nothing."
 
   /**
-   * @return true if [message] is the terminal NON-recoverable signature that surfaces only after
-   *   the in-process [isStaleHandleSignature] retry has already failed (see
-   *   `InstrumentationUtil.runWithStaleUiAutomationRecovery`). This is what reaches the on-disk
-   *   `SessionStatus.Ended.Failed.exceptionMessage`, so the host harness keys its server-relaunch
-   *   decision on it. Both distinctive phrases must be present, so an ordinary recoverable
-   *   signature (already absorbed in-process) or an unrelated failure does not match.
+   * @return true if [message] indicates that in-process UiAutomation recovery is impossible:
+   *   either Android blocked clearing the cached handle, or reconnecting after the cache reset
+   *   also failed. Both errors require the host to restart the on-device instrumentation.
+   *   Ordinary recoverable stale handles and unrelated reflection failures do not match.
    */
   fun isNonRecoverableStaleHandleSignature(message: String?): Boolean {
     val msg = message.orEmpty()
-    return msg.contains(NON_RECOVERABLE_RETRY_FAILED_PHRASE, ignoreCase = true) &&
+    val reconnectRetryFailed =
+      msg.contains(NON_RECOVERABLE_RETRY_FAILED_PHRASE, ignoreCase = true) &&
       msg.contains(NON_RECOVERABLE_STATE_PHRASE, ignoreCase = true)
+    val reflectiveRecoveryBlocked =
+      msg.contains("UiAutomation", ignoreCase = true) &&
+        msg.contains(NON_RECOVERABLE_CACHE_CLEAR_FAILED_PHRASE, ignoreCase = true)
+    return reconnectRetryFailed || reflectiveRecoveryBlocked
   }
 
   /**

--- a/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/util/UiAutomationHandleErrorsTest.kt
+++ b/trailblaze-common/src/jvmAndAndroidTest/kotlin/xyz/block/trailblaze/util/UiAutomationHandleErrorsTest.kt
@@ -64,6 +64,27 @@ class UiAutomationHandleErrorsTest {
   }
 
   @Test
+  fun `recognizes Android 35 rejecting reflective stale-handle recovery`() {
+    assertTrue(
+      UiAutomationHandleErrors.isNonRecoverableStaleHandleSignature(
+        "UiAutomation is not connected and the cached handle could not be cleared via " +
+          "reflection (both Instrumentation.disconnectUiAutomation() and the mUiAutomation " +
+          "field are inaccessible — Android internal API may have changed). Recover by " +
+          "restarting the Trailblaze on-device server. Original error: UiAutomation not connected",
+      ),
+    )
+  }
+
+  @Test
+  fun `does not classify unrelated reflective recovery failures as a UiAutomation wedge`() {
+    assertFalse(
+      UiAutomationHandleErrors.isNonRecoverableStaleHandleSignature(
+        "A cached handle could not be cleared via reflection",
+      ),
+    )
+  }
+
+  @Test
   fun `silent-shell wedge message is a recoverable signature but not the non-recoverable one`() {
     // Recoverable → retry runs first; the non-recoverable signature is reserved for retry failure.
     val message = UiAutomationHandleErrors.silentShellWedgeMessage("pm clear com.example.app")

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/host/yaml/DesktopYamlRunner.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/host/yaml/DesktopYamlRunner.kt
@@ -90,8 +90,8 @@ class DesktopYamlRunner(
      * single matching tool log proves the server was in the kill-and-relaunch-only state,
      * regardless of how the session later ended (a different last-step failure, an LLM
      * call-budget exhaustion, even a nominal success if the remaining steps never touched the
-     * device). Still keyed to the exact two-phrase signature, so the strictness rationale of the
-     * status overload — never arm on ordinary failures — is preserved.
+     * device). Still keyed to terminal UiAutomation recovery failures, so the strictness
+     * rationale of the status overload — never arm on ordinary failures — is preserved.
      */
     internal fun shouldRelaunchOnDeviceServer(logs: List<TrailblazeLog>): Boolean {
       if (shouldRelaunchOnDeviceServer(logs.getSessionStatus())) return true

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeImpl.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeImpl.kt
@@ -142,6 +142,25 @@ class TrailblazeMcpBridgeImpl(
     @Volatile var progressMessage: String = "Checking Playwright drivers..."
   }
 
+  /** Keeps a terminal runner failure armed until that device has actually been restarted. */
+  internal class OnDeviceRunnerRecovery(
+    private val onWedged: (TrailblazeDeviceId) -> Unit = {},
+  ) {
+    private val wedgedDeviceIds: MutableSet<TrailblazeDeviceId> = ConcurrentHashMap.newKeySet()
+
+    fun arm(deviceId: TrailblazeDeviceId) {
+      if (wedgedDeviceIds.add(deviceId)) {
+        onWedged(deviceId)
+      }
+    }
+
+    fun requiresRestart(deviceId: TrailblazeDeviceId): Boolean = deviceId in wedgedDeviceIds
+
+    fun markRecovered(deviceId: TrailblazeDeviceId) {
+      wedgedDeviceIds.remove(deviceId)
+    }
+  }
+
   private val webInitJobs = ConcurrentHashMap<String, WebInitState>()
 
   /** Persists failure messages after the init thread exits, so the MCP client sees them on the next poll. */
@@ -171,6 +190,16 @@ class TrailblazeMcpBridgeImpl(
    */
   private val persistentDevices = ConcurrentHashMap<String, TrailblazeConnectedDevice>()
 
+  private val onDeviceRunnerRecovery = OnDeviceRunnerRecovery { deviceId ->
+    val key = deviceId.instanceId
+    cachedScreenStates.remove(key)
+    onDeviceAgentReady.remove(key)
+    Console.info(
+      "[MCP Bridge] Non-recoverable UiAutomation wedge armed for $key; " +
+        "the on-device runner will be force-restarted before its next MCP action.",
+    )
+  }
+
   /**
    * One host-to-runner RPC client per Android device. The bridge lives in the daemon, so this
    * keeps its WebSocket open across separate CLI `snapshot`, `tool`, and `step` requests instead
@@ -182,6 +211,7 @@ class TrailblazeMcpBridgeImpl(
       sendProgressMessage = {
         Console.log("[MCP Bridge] [rpc ${deviceId.instanceId}] $it")
       },
+      onNonRecoverableWedge = { onDeviceRunnerRecovery.arm(deviceId) },
     )
   }
 
@@ -868,7 +898,16 @@ class TrailblazeMcpBridgeImpl(
           }
         }
 
-        doConnectAndEnable(forceRestart = false)
+        val recoverFromPriorWedge = onDeviceRunnerRecovery.requiresRestart(trailblazeDeviceId)
+        if (recoverFromPriorWedge) {
+          Console.info(
+            "[MCP Bridge] Recovering from a non-recoverable UiAutomation wedge on $key; " +
+              "force-restarting the on-device runner before the next MCP action.",
+          )
+          onDeviceRpcClients.evict(trailblazeDeviceId)
+        }
+
+        doConnectAndEnable(forceRestart = recoverFromPriorWedge)
         try {
           // Fail-fast first probe: a healthy clean start serves in ~26s (install + launch), so 40s
           // detects a zombie quickly and leaves room for the full restart+reprobe under the MCP timeout.
@@ -882,6 +921,9 @@ class TrailblazeMcpBridgeImpl(
         }
 
         onDeviceAgentReady.add(key)
+        if (recoverFromPriorWedge) {
+          onDeviceRunnerRecovery.markRecovered(trailblazeDeviceId)
+        }
         Console.log("[MCP Bridge] On-device agent ready for $key")
       } catch (e: Exception) {
         Console.log("[MCP Bridge] On-device agent setup failed for $key: ${e.message}")
@@ -1652,6 +1694,14 @@ class TrailblazeMcpBridgeImpl(
     blocking: Boolean = false,
     traceId: TraceId? = null,
   ): String {
+    val driverType = getConfiguredDriverType(trailblazeDeviceId.trailblazeDevicePlatform)
+    if (onDeviceRunnerRecovery.requiresRestart(trailblazeDeviceId)) {
+      ensureOnDeviceAgentRunning(trailblazeDeviceId, driverType)
+      check(!onDeviceRunnerRecovery.requiresRestart(trailblazeDeviceId)) {
+        "On-device runner recovery failed for ${trailblazeDeviceId.instanceId}; " +
+          "the runner will be restarted before the next MCP action."
+      }
+    }
     val rpcClient = onDeviceRpcClients.get(trailblazeDeviceId)
 
     return run {
@@ -1661,7 +1711,6 @@ class TrailblazeMcpBridgeImpl(
         sessionIdPrefix = "yaml",
       )
 
-      val driverType = getConfiguredDriverType(trailblazeDeviceId.trailblazeDevicePlatform)
       // Honor "Capture Network Traffic" on the host-driven Android RPC path. The MCP bridge
       // doesn't go through BasePlaywrightNativeTest's `ensureWebNetworkCaptureStarted()`, so we
       // wire an analog here. The actual capture lives in an external module behind
@@ -1775,6 +1824,7 @@ class TrailblazeMcpBridgeImpl(
               )
             }
             false -> {
+              rpcClient.noteIfNonRecoverableWedge(response)
               val message = response.errorMessage?.takeUnless { it.isBlank() }
                 ?: "unknown on-device error"
               Console.log("[executeToolViaRpc] On-device execution failed: $message")

--- a/trailblaze-host/src/test/java/xyz/block/trailblaze/host/yaml/DesktopYamlRunnerWedgeDecisionTest.kt
+++ b/trailblaze-host/src/test/java/xyz/block/trailblaze/host/yaml/DesktopYamlRunnerWedgeDecisionTest.kt
@@ -36,11 +36,26 @@ class DesktopYamlRunnerWedgeDecisionTest {
       "test APK process and re-launch the Trailblaze on-device server to recover. Original error: " +
       "UiAutomation not connected"
 
+  private val reflectionBlockedWedgeMessage =
+    "UiAutomation is not connected and the cached handle could not be cleared via reflection " +
+      "(both Instrumentation.disconnectUiAutomation() and the mUiAutomation field are " +
+      "inaccessible — Android internal API may have changed). Recover by restarting the " +
+      "Trailblaze on-device server. Original error: UiAutomation not connected"
+
   @Test
   fun `relaunches on the non-recoverable UiAutomation wedge`() {
     assertTrue(
       DesktopYamlRunner.shouldRelaunchOnDeviceServer(
         SessionStatus.Ended.Failed(durationMs = 12_000, exceptionMessage = nonRecoverableWedgeMessage),
+      ),
+    )
+  }
+
+  @Test
+  fun `relaunches when Android blocks reflective UiAutomation recovery`() {
+    assertTrue(
+      DesktopYamlRunner.shouldRelaunchOnDeviceServer(
+        SessionStatus.Ended.Failed(durationMs = 12_000, exceptionMessage = reflectionBlockedWedgeMessage),
       ),
     )
   }
@@ -161,6 +176,16 @@ class DesktopYamlRunnerWedgeDecisionTest {
         ),
       ),
     )
+    assertTrue(DesktopYamlRunner.shouldRelaunchOnDeviceServer(logs))
+  }
+
+  @Test
+  fun `log scan relaunches when Android blocks reflective recovery during a successful trail`() {
+    val logs = listOf(
+      toolLog(successful = false, exceptionMessage = reflectionBlockedWedgeMessage),
+      statusLog(SessionStatus.Ended.Succeeded(durationMs = 42_000)),
+    )
+
     assertTrue(DesktopYamlRunner.shouldRelaunchOnDeviceServer(logs))
   }
 

--- a/trailblaze-host/src/test/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeRecoveryTest.kt
+++ b/trailblaze-host/src/test/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeRecoveryTest.kt
@@ -1,0 +1,187 @@
+package xyz.block.trailblaze.mcp
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.builtins.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import xyz.block.trailblaze.devices.TrailblazeDeviceId
+import xyz.block.trailblaze.devices.TrailblazeDevicePlatform
+import xyz.block.trailblaze.host.MockRpcServer
+import xyz.block.trailblaze.host.OnDeviceRpcClientPool
+import xyz.block.trailblaze.llm.RunYamlResponse
+import xyz.block.trailblaze.logs.client.TrailblazeJsonInstance
+import xyz.block.trailblaze.logs.model.SessionId
+import xyz.block.trailblaze.mcp.android.ondevice.rpc.GetScreenStateRequest
+import xyz.block.trailblaze.mcp.android.ondevice.rpc.OnDeviceRpcClient
+import xyz.block.trailblaze.mcp.android.ondevice.rpc.RpcResult
+import xyz.block.trailblaze.util.UiAutomationHandleErrors
+
+class TrailblazeMcpBridgeRecoveryTest {
+
+  private val affectedDevice = TrailblazeDeviceId(
+    instanceId = "test-direct-mcp-wedged-device",
+    trailblazeDevicePlatform = TrailblazeDevicePlatform.ANDROID,
+  )
+
+  private val unaffectedDevice = TrailblazeDeviceId(
+    instanceId = "test-direct-mcp-healthy-device",
+    trailblazeDevicePlatform = TrailblazeDevicePlatform.ANDROID,
+  )
+
+  private val legacyWedgeMessage =
+    "${UiAutomationHandleErrors.NON_RECOVERABLE_RETRY_FAILED_PHRASE}. The on-device server's " +
+      "instrumentation is in a ${UiAutomationHandleErrors.NON_RECOVERABLE_STATE_PHRASE} — " +
+      "restart the Trailblaze on-device server."
+
+  private val reflectionBlockedWedgeMessage =
+    "UiAutomation is not connected and the " +
+      "${UiAutomationHandleErrors.NON_RECOVERABLE_CACHE_CLEAR_FAILED_PHRASE}."
+
+  @Test
+  fun `structured MCP wedge arms only its device and stays armed until runner recovery`() {
+    withRecoveryPool { recovery, pool ->
+      val affectedClient = pool.get(affectedDevice)
+      val unaffectedClient = pool.get(unaffectedDevice)
+
+      assertTrue(
+        affectedClient.noteIfNonRecoverableWedge(
+          RunYamlResponse(
+            sessionId = SessionId("direct-mcp-structured-wedge"),
+            success = false,
+            errorMessage = "on-device failure",
+            nonRecoverableWedge = true,
+          ),
+        ),
+      )
+      assertTrue(recovery.requiresRestart(affectedDevice))
+      assertFalse(recovery.requiresRestart(unaffectedDevice))
+      assertSame(affectedClient, pool.get(affectedDevice))
+      assertSame(unaffectedClient, pool.get(unaffectedDevice))
+
+      pool.evict(affectedDevice)
+
+      assertTrue(recovery.requiresRestart(affectedDevice))
+      assertNotSame(affectedClient, pool.get(affectedDevice))
+      assertSame(unaffectedClient, pool.get(unaffectedDevice))
+
+      recovery.markRecovered(affectedDevice)
+
+      assertFalse(recovery.requiresRestart(affectedDevice))
+      assertFalse(recovery.requiresRestart(unaffectedDevice))
+    }
+  }
+
+  @Test
+  fun `untagged legacy MCP response arms the affected runner`() {
+    assertInlineResponseArmsRunner(legacyWedgeMessage)
+  }
+
+  @Test
+  fun `untagged Android 35 MCP response arms the affected runner`() {
+    assertInlineResponseArmsRunner(reflectionBlockedWedgeMessage)
+  }
+
+  @Test
+  fun `legacy MCP HTTP failure arms the affected runner`() {
+    assertHttpFailureArmsRunner(legacyWedgeMessage)
+  }
+
+  @Test
+  fun `Android 35 MCP HTTP failure arms the affected runner`() {
+    assertHttpFailureArmsRunner(reflectionBlockedWedgeMessage)
+  }
+
+  @Test
+  fun `ordinary MCP failure does not arm or evict either runner`() {
+    withRecoveryPool { recovery, pool ->
+      val affectedClient = pool.get(affectedDevice)
+      val unaffectedClient = pool.get(unaffectedDevice)
+
+      assertFalse(
+        affectedClient.noteIfNonRecoverableWedge(
+          RunYamlResponse(
+            sessionId = SessionId("direct-mcp-ordinary-failure"),
+            success = false,
+            errorMessage = "Element not found",
+          ),
+        ),
+      )
+
+      assertFalse(recovery.requiresRestart(affectedDevice))
+      assertFalse(recovery.requiresRestart(unaffectedDevice))
+      assertSame(affectedClient, pool.get(affectedDevice))
+      assertSame(unaffectedClient, pool.get(unaffectedDevice))
+    }
+  }
+
+  private fun assertInlineResponseArmsRunner(errorMessage: String) {
+    withRecoveryPool { recovery, pool ->
+      val unaffectedClient = pool.get(unaffectedDevice)
+
+      assertTrue(
+        pool.get(affectedDevice).noteIfNonRecoverableWedge(
+          RunYamlResponse(
+            sessionId = SessionId("direct-mcp-legacy-wedge"),
+            success = false,
+            errorMessage = errorMessage,
+          ),
+        ),
+      )
+
+      assertTrue(recovery.requiresRestart(affectedDevice))
+      assertFalse(recovery.requiresRestart(unaffectedDevice))
+      assertSame(unaffectedClient, pool.get(unaffectedDevice))
+    }
+  }
+
+  private fun assertHttpFailureArmsRunner(errorMessage: String) {
+    val server = MockRpcServer(affectedDevice)
+    server.responseBody =
+      """{"errorType":"UNKNOWN_ERROR","message":"Failed to capture screen state","details":${
+        TrailblazeJsonInstance.encodeToString(String.serializer(), errorMessage)
+      }}"""
+    server.start()
+
+    try {
+      withRecoveryPool { recovery, pool ->
+        val unaffectedClient = pool.get(unaffectedDevice)
+        val result = runBlocking {
+          pool.get(affectedDevice).rpcCall(GetScreenStateRequest(includeScreenshot = false))
+        }
+
+        assertTrue(result is RpcResult.Failure)
+        assertTrue(recovery.requiresRestart(affectedDevice))
+        assertFalse(recovery.requiresRestart(unaffectedDevice))
+        assertSame(unaffectedClient, pool.get(unaffectedDevice))
+        assertEquals(1, server.requestLog["/rpc/GetScreenStateRequest"]?.size)
+      }
+    } finally {
+      server.stop()
+    }
+  }
+
+  private inline fun withRecoveryPool(
+    block: (
+      TrailblazeMcpBridgeImpl.OnDeviceRunnerRecovery,
+      OnDeviceRpcClientPool<OnDeviceRpcClient>,
+    ) -> Unit,
+  ) {
+    val recovery = TrailblazeMcpBridgeImpl.OnDeviceRunnerRecovery()
+    val pool = OnDeviceRpcClientPool { deviceId ->
+      OnDeviceRpcClient(
+        trailblazeDeviceId = deviceId,
+        onNonRecoverableWedge = { recovery.arm(deviceId) },
+      )
+    }
+
+    try {
+      block(recovery, pool)
+    } finally {
+      pool.close()
+    }
+  }
+}

--- a/trailblaze-server/src/main/java/xyz/block/trailblaze/mcp/android/ondevice/rpc/OnDeviceRpcClient.kt
+++ b/trailblaze-server/src/main/java/xyz/block/trailblaze/mcp/android/ondevice/rpc/OnDeviceRpcClient.kt
@@ -72,8 +72,9 @@ class OnDeviceRpcClient(
   /**
    * Typed twin of the string-matching [noteIfNonRecoverableWedge]: arms the breaker when an
    * `awaitCompletion = true` [RunYamlResponse] is tagged [RunYamlResponse.nonRecoverableWedge]
-   * at the source, and returns whether it armed so the call site can shape its own terminal
-   * result (FatalError, `recoverable = false`, …).
+   * at the source, or an older runner returns a terminal UiAutomation error without the tag.
+   * Returns whether it armed so the call site can shape its own terminal result
+   * (FatalError, `recoverable = false`, …).
    *
    * A wedge tagged this way arrives as an `RpcResult.Success` carrying `success = false` — the
    * per-call `Failure`-arm string matches in [rpcCall] never see it (no failure body
@@ -83,10 +84,13 @@ class OnDeviceRpcClient(
    * the first time (trailblaze-android-pr/2712).
    */
   fun noteIfNonRecoverableWedge(response: RunYamlResponse): Boolean {
-    if (response.nonRecoverableWedge) {
+    val nonRecoverableWedge = response.nonRecoverableWedge ||
+      (response.success == false &&
+        UiAutomationHandleErrors.isNonRecoverableStaleHandleSignature(response.errorMessage))
+    if (nonRecoverableWedge) {
       onNonRecoverableWedge()
     }
-    return response.nonRecoverableWedge
+    return nonRecoverableWedge
   }
 
   /**

--- a/trailblaze-server/src/main/java/xyz/block/trailblaze/mcp/android/ondevice/rpc/OnDeviceRpcClient.kt
+++ b/trailblaze-server/src/main/java/xyz/block/trailblaze/mcp/android/ondevice/rpc/OnDeviceRpcClient.kt
@@ -42,9 +42,9 @@ class OnDeviceRpcClient(
   /**
    * Arms [onNonRecoverableWedge] when either the failure [message] or its [details] carries the
    * terminal non-recoverable stale-handle signature. Both are checked because the signature can
-   * land in `message` (handler-caught path) or `details` (HTTP-error path). The matcher requires
-   * two distinct phrases, so an ordinary failure can't trip it. `@PublishedApi internal` for the
-   * same inline-visibility reason as [onNonRecoverableWedge].
+   * land in `message` (handler-caught path) or `details` (HTTP-error path). The matcher recognizes
+   * only terminal UiAutomation recovery failures, so an ordinary failure can't trip it.
+   * `@PublishedApi internal` for the same inline-visibility reason as [onNonRecoverableWedge].
    */
   @PublishedApi
   internal fun noteIfNonRecoverableWedge(message: String?, details: String?) {

--- a/trailblaze-server/src/test/kotlin/xyz/block/trailblaze/mcp/android/ondevice/rpc/OnDeviceRpcClientWedgeTest.kt
+++ b/trailblaze-server/src/test/kotlin/xyz/block/trailblaze/mcp/android/ondevice/rpc/OnDeviceRpcClientWedgeTest.kt
@@ -59,6 +59,12 @@ class OnDeviceRpcClientWedgeTest {
       "test APK process and re-launch the Trailblaze on-device server to recover. Original error: " +
       "UiAutomation not connected"
 
+  private val reflectionBlockedWedgeMessage =
+    "UiAutomation is not connected and the cached handle could not be cleared via reflection " +
+      "(both Instrumentation.disconnectUiAutomation() and the mUiAutomation field are " +
+      "inaccessible — Android internal API may have changed). Recover by restarting the " +
+      "Trailblaze on-device server. Original error: UiAutomation not connected"
+
   private val port = testDeviceId.getTrailblazeOnDeviceSpecificPort()
 
   @Volatile
@@ -104,6 +110,21 @@ class OnDeviceRpcClientWedgeTest {
   }
 
   @Test
+  fun `rpcCall arms the breaker when Android blocks reflective UiAutomation recovery`() {
+    responseBody =
+      """{"errorType":"UNKNOWN_ERROR","message":"Failed to capture screen state","details":${
+        TrailblazeJsonInstance.encodeToString(String.serializer(), reflectionBlockedWedgeMessage)
+      }}"""
+
+    var armed = false
+    val client = OnDeviceRpcClient(testDeviceId, onNonRecoverableWedge = { armed = true })
+    val result = runBlocking { client.rpcCall(GetScreenStateRequest(includeScreenshot = false)) }
+
+    assertTrue(result is RpcResult.Failure, "expected an RPC failure")
+    assertTrue(armed, "blocked reflective recovery must arm the runner restart")
+  }
+
+  @Test
   fun `rpcCall does not arm the breaker on an ordinary failure`() {
     responseBody = """{"errorType":"UNKNOWN_ERROR","message":"Element not found","details":"Element not found"}"""
 
@@ -122,6 +143,16 @@ class OnDeviceRpcClientWedgeTest {
     // The handler-caught path lands the signature in `message` rather than `details`.
     client.noteIfNonRecoverableWedge(message = nonRecoverableWedgeMessage, details = null)
     assertTrue(armed, "breaker must fire when the wedge signature is in message")
+  }
+
+  @Test
+  fun `the breaker fires when reflective recovery failure is in the failure message`() {
+    var armed = false
+    val client = OnDeviceRpcClient(testDeviceId, onNonRecoverableWedge = { armed = true })
+
+    client.noteIfNonRecoverableWedge(message = reflectionBlockedWedgeMessage, details = null)
+
+    assertTrue(armed, "blocked reflective recovery must arm the runner restart")
   }
 
   @Test

--- a/trailblaze-server/src/test/kotlin/xyz/block/trailblaze/mcp/android/ondevice/rpc/OnDeviceRpcClientWedgeTest.kt
+++ b/trailblaze-server/src/test/kotlin/xyz/block/trailblaze/mcp/android/ondevice/rpc/OnDeviceRpcClientWedgeTest.kt
@@ -187,6 +187,57 @@ class OnDeviceRpcClientWedgeTest {
   }
 
   @Test
+  fun `the typed RunYamlResponse overload recognizes an untagged legacy wedge`() {
+    var armed = false
+    val client = OnDeviceRpcClient(testDeviceId, onNonRecoverableWedge = { armed = true })
+
+    val noted = client.noteIfNonRecoverableWedge(
+      RunYamlResponse(
+        sessionId = SessionId("legacy-wedge-overload"),
+        success = false,
+        errorMessage = nonRecoverableWedgeMessage,
+      ),
+    )
+
+    assertTrue(noted, "a legacy terminal error must be recognized without the structured flag")
+    assertTrue(armed, "a legacy terminal error must arm the runner restart")
+  }
+
+  @Test
+  fun `the typed RunYamlResponse overload recognizes untagged blocked reflective recovery`() {
+    var armed = false
+    val client = OnDeviceRpcClient(testDeviceId, onNonRecoverableWedge = { armed = true })
+
+    val noted = client.noteIfNonRecoverableWedge(
+      RunYamlResponse(
+        sessionId = SessionId("reflection-blocked-wedge-overload"),
+        success = false,
+        errorMessage = reflectionBlockedWedgeMessage,
+      ),
+    )
+
+    assertTrue(noted, "blocked reflective recovery must be recognized without the structured flag")
+    assertTrue(armed, "blocked reflective recovery must arm the runner restart")
+  }
+
+  @Test
+  fun `the typed RunYamlResponse overload ignores terminal text on successful responses`() {
+    var armed = false
+    val client = OnDeviceRpcClient(testDeviceId, onNonRecoverableWedge = { armed = true })
+
+    val noted = client.noteIfNonRecoverableWedge(
+      RunYamlResponse(
+        sessionId = SessionId("successful-wedge-diagnostic"),
+        success = true,
+        errorMessage = nonRecoverableWedgeMessage,
+      ),
+    )
+
+    assertFalse(noted, "successful diagnostic output must not trigger runner recovery")
+    assertFalse(armed, "successful responses must not arm the runner restart")
+  }
+
+  @Test
   fun `the typed RunYamlResponse overload does not arm on an ordinary inline failure`() {
     var armed = false
     val client = OnDeviceRpcClient(testDeviceId, onNonRecoverableWedge = { armed = true })


### PR DESCRIPTION
Android 35 can block reflective cleanup of a disconnected `UiAutomation` handle, leaving the device-side runner wedged and causing subsequent trails to fail. Recognize this terminal failure across device and host recovery boundaries so Trailblaze restarts only the affected runner before the next trail, without replaying an in-progress trail or restarting on ordinary errors.