### PR TITLE
Always await on-device completion for MCP tool dispatch

### DIFF
--- a/.github/pr_run_android_mcp_dispatch.sh
+++ b/.github/pr_run_android_mcp_dispatch.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Direct-MCP dispatch path: an external MCP client (Claude Code, Codex, Goose)
+# calls a *first-class* TrailblazeTool over `POST /mcp` — `tapOnPoint`,
+# `assertVisible`, … — instead of going through the `step` tool's inner agent.
+#
+# Why this needs its own job. The other two Android jobs miss this code path
+# entirely:
+#   * `pr_run_android_tests_on_device.sh` is pure instrumentation
+#     (`connectedDebugAndroidTest`); no host bridge is involved.
+#   * `pr_run_android_tests_host_rpc.sh` drives `trailblaze trail …`, which goes
+#     through DesktopYamlRunner → HostOnDeviceRpcTrailblazeAgent, not the MCP
+#     bridge.
+# Only the first-class MCP surface reaches
+# `TrailblazeMcpBridgeImpl.executeToolViaRpc` with the interface's
+# `blocking = false` default, which is exactly where a fire-and-forget dispatch
+# used to report phantom success and leave a terminal UiAutomation wedge unarmed.
+#
+# The two assertions below are the regression:
+#   1. a tool that FAILS on device must surface as `isError: true`
+#   2. a tool that SUCCEEDS must return the tool's own output, never the
+#      outcome-free `Executed <ToolName>` placeholder a fire-and-forget response
+#      produces
+#
+# `trailblaze` resolves on $PATH because the workflow runs
+# `install-trailblaze-from-artifact.sh` against the upstream `build-uber-jar`
+# job's prebuilt JAR before invoking this script.
+# Note: intentionally not using `set -e` so log collection always runs even if an
+# assertion fails.
+
+TRAILBLAZE_LOGS_DIR="$(pwd)/trailblaze-logs"
+TRAILBLAZE_LOCAL_LOGS_DIR="$HOME/.trailblaze/logs"
+# The daemon honours TRAILBLAZE_PORT; CI leaves it unset and gets the default.
+# Overridable so a contributor can run this script against an isolated daemon
+# while another worktree holds 52525.
+PORT="${TRAILBLAZE_PORT:-52525}"
+MCP_URL="http://localhost:$PORT/mcp"
+PING_URL="http://localhost:$PORT/ping"
+MCP_OUT_DIR="$(pwd)/mcp-dispatch"
+
+mkdir -p "$TRAILBLAZE_LOGS_DIR" "$MCP_OUT_DIR"
+
+echo "========================================="
+echo "Starting Android MCP dispatch check"
+echo "Working directory: $(pwd)"
+echo "========================================="
+
+# ---------------------------------------------------------------------------
+# MCP streamable-HTTP helpers
+#
+# The daemon runs the transport with `enableJsonResponse = true`, so a POST gets
+# a plain JSON-RPC body back — no SSE framing to unwrap.
+# ---------------------------------------------------------------------------
+MCP_SESSION_ID=""
+
+mcp_post() {
+  local body="$1"
+  local -a session_header=()
+  [ -n "$MCP_SESSION_ID" ] && session_header=(-H "Mcp-Session-Id: $MCP_SESSION_ID")
+  curl -s --max-time 300 -D "$MCP_OUT_DIR/headers.txt" -X POST "$MCP_URL" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    "${session_header[@]}" \
+    -d "$body"
+}
+
+# Calls a first-class MCP tool and writes the raw JSON-RPC response to
+# $MCP_OUT_DIR/<label>.json for artifact upload.
+mcp_call_tool() {
+  local label="$1" name="$2" args="$3"
+  mcp_post "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args}}" \
+    > "$MCP_OUT_DIR/$label.json"
+  echo "--- $label ($name) ---"
+  cat "$MCP_OUT_DIR/$label.json"
+  echo
+}
+
+# ---------------------------------------------------------------------------
+# Daemon startup
+# ---------------------------------------------------------------------------
+echo "Starting Trailblaze daemon (app --foreground --headless)..."
+trailblaze app --foreground --headless > /tmp/trailblaze.log 2>&1 &
+TRAILBLAZE_PID=$!
+echo "Trailblaze daemon started with PID: $TRAILBLAZE_PID"
+echo "Waiting for Trailblaze daemon to be ready on port $PORT (this may take up to 2 minutes)..."
+sleep 10
+for attempt in $(seq 1 20); do
+  if curl -s --connect-timeout 1 "$PING_URL" > /dev/null 2>&1; then
+    break
+  fi
+  echo "Attempt $attempt/20..."
+  sleep 5
+done
+if ! curl -s --connect-timeout 1 "$PING_URL" > /dev/null 2>&1; then
+  echo "ERROR: Trailblaze daemon failed to start"
+  echo "=== Trailblaze logs ==="
+  cat /tmp/trailblaze.log
+  SETUP_FAILED=true
+else
+  echo "✓ Trailblaze daemon is running on port $PORT!"
+fi
+echo "========================================="
+
+echo "Starting logcat capture (filtering out noise)..."
+adb logcat | grep -v "skipping invisible child" > logcat.log &
+LOGCAT_PID=$!
+echo "========================================="
+
+# ---------------------------------------------------------------------------
+# Bind the emulator. This installs + launches the on-device runner APK and, on
+# connect, makes the daemon re-register the driver-scoped first-class tools —
+# without a bound device `tools/list` carries no TrailblazeTools at all.
+# ---------------------------------------------------------------------------
+if [ "$SETUP_FAILED" != "true" ]; then
+  ANDROID_DEVICE_ID="$(adb devices | awk '/\tdevice$/ {print $1; exit}')"
+  if [ -z "$ANDROID_DEVICE_ID" ]; then
+    echo "ERROR: no booted Android device visible to adb"
+    adb devices -l
+    SETUP_FAILED=true
+  else
+    echo "Binding android/$ANDROID_DEVICE_ID (installs + starts the on-device runner)..."
+    trailblaze snapshot -d "android/$ANDROID_DEVICE_ID" || {
+      echo "ERROR: could not bind android/$ANDROID_DEVICE_ID"
+      SETUP_FAILED=true
+    }
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# MCP handshake + tool discovery
+# ---------------------------------------------------------------------------
+if [ "$SETUP_FAILED" != "true" ]; then
+  echo "Opening an MCP session against $MCP_URL..."
+  mcp_post '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"pr-checks-mcp-dispatch","version":"1"}}}' \
+    > "$MCP_OUT_DIR/initialize.json"
+  MCP_SESSION_ID="$(grep -i '^mcp-session-id:' "$MCP_OUT_DIR/headers.txt" | awk '{print $2}' | tr -d '\r')"
+  if [ -z "$MCP_SESSION_ID" ]; then
+    echo "ERROR: MCP initialize did not return an Mcp-Session-Id"
+    cat "$MCP_OUT_DIR/initialize.json"
+    SETUP_FAILED=true
+  else
+    echo "✓ MCP session: $MCP_SESSION_ID"
+    mcp_post '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null
+    mcp_post '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' > "$MCP_OUT_DIR/tools-list.json"
+    for required in tapOnPoint assertVisible; do
+      if ! jq -e --arg n "$required" '.result.tools | map(.name) | index($n)' "$MCP_OUT_DIR/tools-list.json" > /dev/null; then
+        echo "ERROR: first-class tool '$required' is not advertised — the device never bound," \
+          "so the direct-MCP dispatch path is not under test"
+        jq -r '.result.tools[]?.name' "$MCP_OUT_DIR/tools-list.json"
+        SETUP_FAILED=true
+      fi
+    done
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 1 — a tool that fails on device must surface as an error.
+#
+# `assertVisible` against a ref that is not on any screen fails inside the
+# on-device runner. A dispatch that does not await completion gets back a
+# response with no `success` and no `errorMessage`, so the failure is invisible
+# to the caller and the call reports OK.
+# ---------------------------------------------------------------------------
+if [ "$SETUP_FAILED" != "true" ]; then
+  mcp_call_tool ondevice-failure assertVisible \
+    '{"ref":"zzz999","reasoning":"pr-checks: ref that is deliberately not on screen"}'
+  if [ "$(jq -r '.result.isError' "$MCP_OUT_DIR/ondevice-failure.json")" != "true" ]; then
+    echo "ERROR: a failing on-device tool did not surface as isError=true."
+    echo "       The dispatch returned before the tool ran (phantom success)."
+    TEST_FAILED=true
+  else
+    echo "✓ On-device failure surfaced to the MCP caller"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 2 — a tool that succeeds must return its own output.
+#
+# `Executed <ToolName>` is the outcome-free placeholder the bridge emits when the
+# on-device response carries no `success` field. Seeing it means the dispatch was
+# fire-and-forget even though this one happens to have worked.
+# ---------------------------------------------------------------------------
+if [ "$SETUP_FAILED" != "true" ]; then
+  mcp_call_tool ondevice-success tapOnPoint \
+    '{"x":100,"y":100,"reasoning":"pr-checks: dispatch that must report a real outcome"}'
+  SUCCESS_TEXT="$(jq -r '.result.content[0].text // ""' "$MCP_OUT_DIR/ondevice-success.json")"
+  if [ "$(jq -r '.result.isError' "$MCP_OUT_DIR/ondevice-success.json")" != "false" ]; then
+    echo "ERROR: tapOnPoint reported an error: $SUCCESS_TEXT"
+    TEST_FAILED=true
+  elif printf '%s' "$SUCCESS_TEXT" | grep -qE '^\[OK\] Executed [A-Za-z]+TrailblazeTool$'; then
+    echo "ERROR: dispatch returned the outcome-free placeholder: $SUCCESS_TEXT"
+    echo "       The bridge never read a terminal on-device response."
+    TEST_FAILED=true
+  else
+    echo "✓ Successful dispatch returned the tool's own result: $SUCCESS_TEXT"
+  fi
+fi
+
+echo "========================================="
+echo "MCP dispatch check completed (setup failed: ${SETUP_FAILED:-false}, assertions failed: ${TEST_FAILED:-false})"
+echo "========================================="
+
+# ---------------------------------------------------------------------------
+# Log collection + cleanup (mirrors pr_run_android_tests_host_rpc.sh)
+# ---------------------------------------------------------------------------
+adb devices -l || echo "Could not list ADB devices"
+
+echo "Pulling logs from device..."
+adb pull /sdcard/Download/trailblaze-logs/. "$TRAILBLAZE_LOGS_DIR" && echo "Log pull succeeded" || echo "Failed to pull logs"
+
+if [ -d "$TRAILBLAZE_LOCAL_LOGS_DIR" ]; then
+  cp -r "$TRAILBLAZE_LOCAL_LOGS_DIR"/* "$TRAILBLAZE_LOGS_DIR/" 2>/dev/null || echo "No logs found in $TRAILBLAZE_LOCAL_LOGS_DIR"
+fi
+
+if [ -f /tmp/trailblaze.log ]; then
+  cp /tmp/trailblaze.log "$TRAILBLAZE_LOGS_DIR/trailblaze-daemon.log"
+fi
+cp -r "$MCP_OUT_DIR" "$TRAILBLAZE_LOGS_DIR/" 2>/dev/null || true
+
+echo "Cleaning up background processes..."
+[ -n "$LOGCAT_PID" ] && kill $LOGCAT_PID 2>/dev/null
+[ -n "$TRAILBLAZE_PID" ] && kill $TRAILBLAZE_PID 2>/dev/null
+echo "✓ Cleanup complete"
+echo "========================================="
+
+if [ "$SETUP_FAILED" = "true" ] || [ "$TEST_FAILED" = "true" ]; then
+  echo "MCP dispatch check failed — exiting with code 1"
+  exit 1
+fi

--- a/.github/pr_run_android_mcp_dispatch.sh
+++ b/.github/pr_run_android_mcp_dispatch.sh
@@ -76,27 +76,38 @@ mcp_call_tool() {
 
 # ---------------------------------------------------------------------------
 # Daemon startup
+#
+# `bun install` first: the workspace trailmaps under trails/config/trailmaps/
+# ship meta-only scripted-tool descriptors that need the analyzer to enrich.
+# Without `sdks/typescript/node_modules`, trailmap compilation fails hard and
+# `app --foreground --headless` exits before it ever binds the port.
 # ---------------------------------------------------------------------------
-echo "Starting Trailblaze daemon (app --foreground --headless)..."
-trailblaze app --foreground --headless > /tmp/trailblaze.log 2>&1 &
-TRAILBLAZE_PID=$!
-echo "Trailblaze daemon started with PID: $TRAILBLAZE_PID"
-echo "Waiting for Trailblaze daemon to be ready on port $PORT (this may take up to 2 minutes)..."
-sleep 10
-for attempt in $(seq 1 20); do
-  if curl -s --connect-timeout 1 "$PING_URL" > /dev/null 2>&1; then
-    break
+echo "Installing TypeScript SDK devDependencies (analyzer + esbuild)..."
+(cd sdks/typescript && bun install --frozen-lockfile) \
+  || { echo "ERROR: bun install failed in sdks/typescript"; SETUP_FAILED=true; }
+
+if [ "$SETUP_FAILED" != "true" ]; then
+  echo "Starting Trailblaze daemon (app --foreground --headless)..."
+  trailblaze app --foreground --headless > /tmp/trailblaze.log 2>&1 &
+  TRAILBLAZE_PID=$!
+  echo "Trailblaze daemon started with PID: $TRAILBLAZE_PID"
+  echo "Waiting for Trailblaze daemon to be ready on port $PORT (this may take up to 2 minutes)..."
+  sleep 10
+  for attempt in $(seq 1 20); do
+    if curl -s --connect-timeout 1 "$PING_URL" > /dev/null 2>&1; then
+      break
+    fi
+    echo "Attempt $attempt/20..."
+    sleep 5
+  done
+  if ! curl -s --connect-timeout 1 "$PING_URL" > /dev/null 2>&1; then
+    echo "ERROR: Trailblaze daemon failed to start"
+    echo "=== Trailblaze logs ==="
+    cat /tmp/trailblaze.log
+    SETUP_FAILED=true
+  else
+    echo "✓ Trailblaze daemon is running on port $PORT!"
   fi
-  echo "Attempt $attempt/20..."
-  sleep 5
-done
-if ! curl -s --connect-timeout 1 "$PING_URL" > /dev/null 2>&1; then
-  echo "ERROR: Trailblaze daemon failed to start"
-  echo "=== Trailblaze logs ==="
-  cat /tmp/trailblaze.log
-  SETUP_FAILED=true
-else
-  echo "✓ Trailblaze daemon is running on port $PORT!"
 fi
 echo "========================================="
 
@@ -217,8 +228,8 @@ fi
 cp -r "$MCP_OUT_DIR" "$TRAILBLAZE_LOGS_DIR/" 2>/dev/null || true
 
 echo "Cleaning up background processes..."
-[ -n "$LOGCAT_PID" ] && kill $LOGCAT_PID 2>/dev/null
-[ -n "$TRAILBLAZE_PID" ] && kill $TRAILBLAZE_PID 2>/dev/null
+[ -n "$LOGCAT_PID" ] && kill "$LOGCAT_PID" 2>/dev/null
+[ -n "$TRAILBLAZE_PID" ] && kill "$TRAILBLAZE_PID" 2>/dev/null
 echo "✓ Cleanup complete"
 echo "========================================="
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -554,3 +554,88 @@ jobs:
         run: |
           echo "Tests failed - failing the workflow"
           exit 1
+
+  # Drives a first-class TrailblazeTool over the daemon's `POST /mcp` endpoint —
+  # the surface an external MCP client (Claude Code, Codex, Goose) uses. This is
+  # the only job that reaches `TrailblazeMcpBridgeImpl.executeToolViaRpc` with
+  # the interface's `blocking = false` default: android-tests-on-device is pure
+  # instrumentation, and android-tests-host-rpc goes through DesktopYamlRunner.
+  # Asserts an on-device failure surfaces as `isError` and a success returns the
+  # tool's own output rather than an outcome-free placeholder.
+  android-tests-mcp-dispatch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: build-uber-jar
+    env:
+      # Tools are dispatched by name — the inner agent (and therefore the LLM) is
+      # never invoked. See android-tests-on-device above.
+      OPENAI_API_KEY: no-key-set
+
+    steps:
+      - name: Enable KVM group perms
+        if: runner.os == 'Linux'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls /dev/kvm
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
+
+      - name: Download prebuilt uber JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: trailblaze-uber-jar
+          path: trailblaze-uber-jar/
+
+      - name: Install trailblaze from prebuilt artifact
+        env:
+          TRAILBLAZE_ARTIFACT_DIR: ${{ github.workspace }}/trailblaze-uber-jar
+        run: ./scripts/install-trailblaze-from-artifact.sh
+
+      - name: Create and start emulator and run MCP dispatch check (Linux)
+        if: runner.os == 'Linux'
+        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b
+        id: run-tests-linux
+        continue-on-error: true
+        with:
+          api-level: 34
+          arch: x86_64
+          disable-animations: true
+          disk-size: 6000M
+          heap-size: 600M
+          profile: Nexus 6
+          script: ./.github/pr_run_android_mcp_dispatch.sh
+
+      - name: Create artifacts
+        if: always()
+        continue-on-error: true
+        run: ./.github/pr_create_artifacts.sh
+
+      - name: Upload artifacts
+        if: always()  # Ensures this runs even if the previous step failed
+        uses: actions/upload-artifact@v4
+        with:
+          name: trailblaze-artifacts-mcp-dispatch
+          path: |
+            trailblaze-logs.zip
+            logcat.log
+            mcp-dispatch/
+
+      - name: Fail if the MCP dispatch check failed
+        if: steps.run-tests-linux.outcome == 'failure'
+        run: |
+          echo "MCP dispatch check failed - failing the workflow"
+          exit 1

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -594,6 +594,9 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
       - name: Download prebuilt uber JAR
         uses: actions/download-artifact@v4
         with:

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeImpl.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeImpl.kt
@@ -61,6 +61,7 @@ import xyz.block.trailblaze.report.utils.LogsRepo
 import xyz.block.trailblaze.toolcalls.TrailblazeTool
 import xyz.block.trailblaze.toolcalls.TrailblazeToolResult
 import xyz.block.trailblaze.ui.TrailblazeDeviceManager
+import xyz.block.trailblaze.ui.TrailblazeDeviceManager.DeviceSessionResolution
 import xyz.block.trailblaze.util.AccessibilityServiceSetupUtils
 import xyz.block.trailblaze.compose.driver.rpc.ExecuteToolsRequest as ComposeExecuteToolsRequest
 import xyz.block.trailblaze.compose.driver.rpc.GetScreenStateResponse as ComposeGetScreenStateResponse
@@ -552,6 +553,57 @@ class TrailblazeMcpBridgeImpl(
   }
 
   companion object {
+    /**
+     * Builds the [RunYamlRequest] a single on-device MCP tool dispatch puts on the wire.
+     * Pure — no bridge instance required, so the wire contract is testable in isolation.
+     *
+     * [awaitCompletion] is unconditionally true and deliberately NOT derived from the caller's
+     * `blocking` flag, which governs only the HOST/Maestro path. A fire-and-forget
+     * `RunYamlResponse` returns before any tool runs, so it carries no `success`, no
+     * `errorMessage`, and no `nonRecoverableWedge`. The direct-MCP dispatchers
+     * (`TrailblazeToolToMcpBridge`, `DirectMcpToolExecutor`, `TrailExecutor`,
+     * `BridgeTrailblazeAgent`) all take the `blocking = false` default, so deriving the wait
+     * from it made those dispatches report phantom success AND left a terminal UiAutomation
+     * wedge unarmed — the poisoned runner then served every following MCP action.
+     */
+    internal fun buildOnDeviceToolRunYamlRequest(
+      tool: TrailblazeTool,
+      yaml: String,
+      trailblazeDeviceId: TrailblazeDeviceId,
+      driverType: TrailblazeDriverType?,
+      traceId: TraceId?,
+      targetAppId: String?,
+      trailblazeLlmModel: TrailblazeLlmModel,
+      sessionResolution: DeviceSessionResolution,
+      captureNetworkTraffic: Boolean,
+    ): RunYamlRequest = RunYamlRequest(
+      yaml = yaml,
+      testName = "tool_${tool::class.simpleName}",
+      trailFilePath = null,
+      targetAppName = targetAppId,
+      useRecordedSteps = false,
+      trailblazeLlmModel = trailblazeLlmModel,
+      trailblazeDeviceId = trailblazeDeviceId,
+      referrer = TrailblazeReferrer.MCP,
+      traceId = traceId,
+      driverType = driverType,
+      awaitCompletion = true,
+      config = TrailblazeConfig(
+        overrideSessionId = sessionResolution.sessionId,
+        // Emit start only when this call created the session. This preserves host-managed
+        // MCP sessions (no duplicate start logs) while still initializing direct tool-first sessions.
+        sendSessionStartLog = sessionResolution.isNewSession,
+        sendSessionEndLog = false,
+        // Propagate the toggle so on-device launch tools can do their own capture-aware
+        // setup — they may need to seed debug SharedPrefs that survive the launch tool's own
+        // clearAppData / clearState=true cycle, and the host can't reach into that window
+        // from outside. Today nothing on-device reads this; the host bridge is the only
+        // consumer. Wired here so the next iteration can flip launch-tool behavior off this
+        // signal without another hop.
+        captureNetworkTraffic = captureNetworkTraffic,
+      ),
+    )
+
     internal fun androidDisconnectStatus(
       deviceId: TrailblazeDeviceId,
       connectedDevices: Collection<TrailblazeDeviceId>,
@@ -1771,39 +1823,16 @@ class TrailblazeMcpBridgeImpl(
             }
         }
       }
-      val request = RunYamlRequest(
+      val request = buildOnDeviceToolRunYamlRequest(
+        tool = tool,
         yaml = yaml,
-        testName = "tool_${tool::class.simpleName}",
-        trailFilePath = null,
-        targetAppName = resolvedTargetAppId,
-        useRecordedSteps = false,
-        trailblazeLlmModel = trailblazeDeviceManager.currentTrailblazeLlmModelProvider(),
         trailblazeDeviceId = trailblazeDeviceId,
-        referrer = TrailblazeReferrer.MCP,
-        traceId = traceId,
         driverType = driverType,
-        // Always await on-device completion — the caller's `blocking` flag only governs the
-        // HOST/Maestro path below. A fire-and-forget RunYamlResponse carries no `success` and
-        // no `nonRecoverableWedge` (the device returns before any tool runs), so the default
-        // `blocking = false` used by the direct-MCP dispatchers (TrailblazeToolToMcpBridge,
-        // DirectMcpToolExecutor, TrailExecutor, BridgeTrailblazeAgent) would report phantom
-        // success AND leave a terminal UiAutomation wedge unarmed — the poisoned runner would
-        // then serve every following MCP action. Matches the RunYamlRequest default.
-        awaitCompletion = true,
-        config = TrailblazeConfig(
-          overrideSessionId = sessionResolution.sessionId,
-          // Emit start only when this call created the session. This preserves host-managed
-          // MCP sessions (no duplicate start logs) while still initializing direct tool-first sessions.
-          sendSessionStartLog = sessionResolution.isNewSession,
-          sendSessionEndLog = false,
-          // Propagate the toggle so on-device launch tools can do their own capture-aware
-          // setup — they may need to seed debug SharedPrefs that survive the launch tool's own
-          // clearAppData / clearState=true cycle, and the host can't reach into that window
-          // from outside. Today nothing on-device reads this; the host bridge is the only
-          // consumer. Wired here so the next iteration can flip launch-tool behavior off this
-          // signal without another hop.
-          captureNetworkTraffic = captureNetworkTraffic,
-        ),
+        traceId = traceId,
+        targetAppId = resolvedTargetAppId,
+        trailblazeLlmModel = trailblazeDeviceManager.currentTrailblazeLlmModelProvider(),
+        sessionResolution = sessionResolution,
+        captureNetworkTraffic = captureNetworkTraffic,
       )
 
       Console.log("[executeToolViaRpc] Sending ${tool::class.simpleName} to on-device agent")

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeImpl.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeImpl.kt
@@ -1854,10 +1854,12 @@ class TrailblazeMcpBridgeImpl(
           // - `success == true`: terminal success. Report executed.
           // - `success == false`: terminal failure. Surface the on-device error message
           //   so the daemon log and the caller see the real cause instead of a phantom OK.
-          // - `success == null`: the runner returned before the job finished despite
-          //   `awaitCompletion = true` — only an older runner that predates the flag does this.
-          //   No terminal signal is available, so a wedge on that runner can't be armed here;
-          //   the RPC-failure string match in `rpcCall` is the remaining safety net.
+          // - `success == null`: contract violation. We always send `awaitCompletion = true`, so
+          //   the runner owes us a terminal outcome; `null` means it returned early (a runner
+          //   predating the flag). Reporting "Executed" there would be the same phantom success
+          //   this dispatch path exists to remove — and no wedge could be armed from it. Fail,
+          //   matching [HostAccessibilityRpcClient.execute] and
+          //   [HostOnDeviceRpcTrailblazeAgent.toToolResult], which already reject this shape.
           when (response.success) {
             true -> {
               Console.log("[executeToolViaRpc] On-device execution complete: ${response.sessionId}")
@@ -1878,12 +1880,11 @@ class TrailblazeMcpBridgeImpl(
               error("On-device execution of ${tool::class.simpleName} failed: $message")
             }
             null -> {
-              Console.log(
-                "[executeToolViaRpc] On-device runner returned no terminal state despite " +
-                  "awaitCompletion=true (session: ${response.sessionId}); update the runner APK " +
-                  "so tool failures and UiAutomation wedges are reported.",
-              )
-              "Executed ${tool::class.simpleName} on device ${trailblazeDeviceId.instanceId} (session: ${response.sessionId})"
+              val message = "On-device server returned null success inline for " +
+                "${tool::class.simpleName} — contract violation for awaitCompletion=true " +
+                "(expected true/false, got null). Update the on-device runner APK."
+              Console.log("[executeToolViaRpc] $message")
+              error(message)
             }
           }
         }

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeImpl.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeImpl.kt
@@ -1416,7 +1416,7 @@ class TrailblazeMcpBridgeImpl(
       // the device via decodeTrailOrToolEnvelope → decodeTools — never the legacy list-shape trail
       // parser. (The host/Maestro path below keeps the trail-item `yaml` it decodes host-side.)
       val toolEnvelopeYaml = createTrailblazeYaml().encodeTools(listOf(fromTrailblazeTool(tool)))
-      val result = executeToolViaRpc(tool, trailblazeDeviceId, toolEnvelopeYaml, blocking, traceId)
+      val result = executeToolViaRpc(tool, trailblazeDeviceId, toolEnvelopeYaml, traceId)
       cachedScreenStates.remove(trailblazeDeviceId.instanceId)
       return result
     }
@@ -1708,7 +1708,6 @@ class TrailblazeMcpBridgeImpl(
     tool: TrailblazeTool,
     trailblazeDeviceId: TrailblazeDeviceId,
     yaml: String,
-    blocking: Boolean = false,
     traceId: TraceId? = null,
   ): String {
     val driverType = getConfiguredDriverType(trailblazeDeviceId.trailblazeDevicePlatform)
@@ -1783,11 +1782,14 @@ class TrailblazeMcpBridgeImpl(
         referrer = TrailblazeReferrer.MCP,
         traceId = traceId,
         driverType = driverType,
-        // Map the caller's `blocking` flag onto the protocol-level wait. With `blocking=true`
-        // (every current caller), the on-device handler holds the HTTP response until the job
-        // terminates — that's also the RunYamlRequest default. With `blocking=false`, fire-and-forget:
-        // the device returns the new sessionId immediately and the caller can move on.
-        awaitCompletion = blocking,
+        // Always await on-device completion — the caller's `blocking` flag only governs the
+        // HOST/Maestro path below. A fire-and-forget RunYamlResponse carries no `success` and
+        // no `nonRecoverableWedge` (the device returns before any tool runs), so the default
+        // `blocking = false` used by the direct-MCP dispatchers (TrailblazeToolToMcpBridge,
+        // DirectMcpToolExecutor, TrailExecutor, BridgeTrailblazeAgent) would report phantom
+        // success AND leave a terminal UiAutomation wedge unarmed — the poisoned runner would
+        // then serve every following MCP action. Matches the RunYamlRequest default.
+        awaitCompletion = true,
         config = TrailblazeConfig(
           overrideSessionId = sessionResolution.sessionId,
           // Emit start only when this call created the session. This preserves host-managed
@@ -1805,12 +1807,10 @@ class TrailblazeMcpBridgeImpl(
       )
 
       Console.log("[executeToolViaRpc] Sending ${tool::class.simpleName} to on-device agent")
-      // With `awaitCompletion = blocking`, rpcCall returns once the on-device job has reached
-      // its terminal state (when blocking) or as soon as the session is created (when not).
-      // Either way, no host-side log polling is needed — a previous version awaited the
-      // resulting TrailblazeToolLog here under blocking, but by the time that ran every
-      // on-device log was already on disk and `skipExisting=true` filtered them all out,
-      // burning a fixed 120s timeout on every tool call.
+      // rpcCall returns once the on-device job has reached its terminal state. No host-side log
+      // polling is needed — a previous version awaited the resulting TrailblazeToolLog here, but
+      // by the time that ran every on-device log was already on disk and `skipExisting=true`
+      // filtered them all out, burning a fixed 120s timeout on every tool call.
       when (val result: RpcResult<RunYamlResponse> = rpcClient.rpcCall(request)) {
         is RpcResult.Success -> {
           val response = result.data
@@ -1822,12 +1822,13 @@ class TrailblazeMcpBridgeImpl(
           // ([HostOnDeviceRpcTrailblazeAgent.toToolResult],
           // [HostAccessibilityRpcClient.execute]) correctly inspect `success` — match that.
           //
-          // - `success == true`: terminal success when `awaitCompletion=true` (i.e.
-          //   `blocking=true` here). Report executed.
+          // - `success == true`: terminal success. Report executed.
           // - `success == false`: terminal failure. Surface the on-device error message
           //   so the daemon log and the caller see the real cause instead of a phantom OK.
-          // - `success == null`: fire-and-forget (`awaitCompletion=false`). Run is ongoing;
-          //   the session id is the handle the caller subscribes to for terminal state.
+          // - `success == null`: the runner returned before the job finished despite
+          //   `awaitCompletion = true` — only an older runner that predates the flag does this.
+          //   No terminal signal is available, so a wedge on that runner can't be armed here;
+          //   the RPC-failure string match in `rpcCall` is the remaining safety net.
           when (response.success) {
             true -> {
               Console.log("[executeToolViaRpc] On-device execution complete: ${response.sessionId}")
@@ -1848,7 +1849,11 @@ class TrailblazeMcpBridgeImpl(
               error("On-device execution of ${tool::class.simpleName} failed: $message")
             }
             null -> {
-              Console.log("[executeToolViaRpc] On-device execution started: ${response.sessionId}")
+              Console.log(
+                "[executeToolViaRpc] On-device runner returned no terminal state despite " +
+                  "awaitCompletion=true (session: ${response.sessionId}); update the runner APK " +
+                  "so tool failures and UiAutomation wedges are reported.",
+              )
               "Executed ${tool::class.simpleName} on device ${trailblazeDeviceId.instanceId} (session: ${response.sessionId})"
             }
           }

--- a/trailblaze-host/src/test/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeOnDeviceDispatchTest.kt
+++ b/trailblaze-host/src/test/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeOnDeviceDispatchTest.kt
@@ -1,0 +1,135 @@
+package xyz.block.trailblaze.mcp
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import xyz.block.trailblaze.devices.TrailblazeDeviceId
+import xyz.block.trailblaze.devices.TrailblazeDevicePlatform
+import xyz.block.trailblaze.devices.TrailblazeDriverType
+import xyz.block.trailblaze.llm.OnDeviceRpcTimeouts
+import xyz.block.trailblaze.llm.RunYamlResponse
+import xyz.block.trailblaze.llm.TrailblazeLlmModels
+import xyz.block.trailblaze.logs.model.SessionId
+import xyz.block.trailblaze.mcp.android.ondevice.rpc.OnDeviceRpcClient
+import xyz.block.trailblaze.toolcalls.commands.TapOnPointTrailblazeTool
+import xyz.block.trailblaze.ui.TrailblazeDeviceManager.DeviceSessionResolution
+import xyz.block.trailblaze.util.UiAutomationHandleErrors
+
+/**
+ * Pins the wire contract of a single on-device MCP tool dispatch
+ * ([TrailblazeMcpBridgeImpl.buildOnDeviceToolRunYamlRequest]).
+ *
+ * The load-bearing field is `awaitCompletion`. It used to be derived from
+ * `executeTrailblazeTool`'s `blocking` flag, whose interface default is `false` — and every
+ * direct-MCP dispatcher (`TrailblazeToolToMcpBridge`, `DirectMcpToolExecutor`, `TrailExecutor`,
+ * `BridgeTrailblazeAgent`) takes that default. A fire-and-forget dispatch gets back a response
+ * with no `success`, no `errorMessage`, and no `nonRecoverableWedge`, so those calls reported
+ * phantom success and could never arm the terminal-wedge recovery added in #219.
+ */
+class TrailblazeMcpBridgeOnDeviceDispatchTest {
+
+  private val deviceId = TrailblazeDeviceId(
+    instanceId = "emulator-5554",
+    trailblazeDevicePlatform = TrailblazeDevicePlatform.ANDROID,
+  )
+
+  private fun buildRequest(isNewSession: Boolean = true) =
+    TrailblazeMcpBridgeImpl.buildOnDeviceToolRunYamlRequest(
+      tool = TapOnPointTrailblazeTool(x = 10, y = 20),
+      yaml = "- tapOnPoint:\n    x: 10\n    y: 20\n",
+      trailblazeDeviceId = deviceId,
+      driverType = TrailblazeDriverType.ANDROID_ONDEVICE_INSTRUMENTATION,
+      traceId = null,
+      targetAppId = "com.example.app",
+      trailblazeLlmModel = TrailblazeLlmModels.GPT_4O_MINI,
+      sessionResolution = DeviceSessionResolution(
+        sessionId = SessionId("session-under-test"),
+        isNewSession = isNewSession,
+      ),
+      captureNetworkTraffic = false,
+    )
+
+  /**
+   * The regression this locks down: the request must ask the runner to hold the response until
+   * the job reaches a terminal state, regardless of the caller's `blocking` flag.
+   */
+  @Test
+  fun `on-device tool dispatch always awaits completion`() {
+    assertTrue(
+      buildRequest().awaitCompletion,
+      "Direct-MCP dispatchers use blocking=false; without awaitCompletion the response carries " +
+        "no terminal state and a UiAutomation wedge can never be armed",
+    )
+  }
+
+  /**
+   * The consequence that makes awaiting safe: `awaitCompletion = true` widens the host's socket
+   * timeout past the on-device handler's own await cap, so the host reads the runner's terminal
+   * response (including a wedge tag) instead of tearing the socket down first.
+   */
+  @Test
+  fun `awaiting dispatch outlives the on-device handler await cap`() {
+    val request = buildRequest()
+
+    assertEquals(OnDeviceRpcTimeouts.HTTP_REQUEST_CAP_MS, request.requestTimeoutMs)
+    assertTrue(
+      request.requestTimeoutMs!! > OnDeviceRpcTimeouts.HANDLER_AWAIT_CAP_MS,
+      "The host must outlast the device's own await cap so the terminal response is read",
+    )
+  }
+
+  /** The rest of the single-tool dispatch envelope the host runners and session wiring rely on. */
+  @Test
+  fun `on-device tool dispatch keeps its MCP session envelope`() {
+    val newSession = buildRequest(isNewSession = true)
+    assertEquals(SessionId("session-under-test"), newSession.config.overrideSessionId)
+    // The host owns session lifecycle: emit start only for a session this dispatch created,
+    // and never let a single tool call end the session.
+    assertTrue(newSession.config.sendSessionStartLog)
+    assertFalse(newSession.config.sendSessionEndLog)
+    assertFalse(buildRequest(isNewSession = false).config.sendSessionStartLog)
+  }
+
+  /**
+   * End of the chain: given the awaited response above, a terminal wedge — tagged (#219's typed
+   * field) or untagged (an older runner returning only the signature text) — arms the pooled
+   * client's recovery callback. This is the branch a `blocking = false` dispatch could not reach
+   * before, because the fire-and-forget response had `success == null`.
+   */
+  @Test
+  fun `terminal wedge on an awaited response arms recovery`() {
+    val taggedWedge = RunYamlResponse(
+      sessionId = SessionId("session-under-test"),
+      success = false,
+      errorMessage = "on-device failure",
+      nonRecoverableWedge = true,
+    )
+    val untaggedWedge = RunYamlResponse(
+      sessionId = SessionId("session-under-test"),
+      success = false,
+      errorMessage = "UiAutomation is not connected and the " +
+        "${UiAutomationHandleErrors.NON_RECOVERABLE_CACHE_CLEAR_FAILED_PHRASE}.",
+    )
+    val fireAndForget = RunYamlResponse(
+      sessionId = SessionId("session-under-test"),
+      memorySnapshot = emptyMap(),
+    )
+
+    assertTrue(armedBy(taggedWedge), "Typed wedge tag must arm recovery")
+    assertTrue(armedBy(untaggedWedge), "Older untagged runner signature must arm recovery")
+    assertFalse(
+      armedBy(fireAndForget),
+      "A fire-and-forget response has no terminal state — this is why the dispatch must await",
+    )
+  }
+
+  private fun armedBy(response: RunYamlResponse): Boolean {
+    var armed = false
+    OnDeviceRpcClient(
+      trailblazeDeviceId = deviceId,
+      onNonRecoverableWedge = { armed = true },
+    ).use { it.noteIfNonRecoverableWedge(response) }
+    return armed
+  }
+}

--- a/trailblaze-host/src/test/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeRecoveryTest.kt
+++ b/trailblaze-host/src/test/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeRecoveryTest.kt
@@ -95,6 +95,31 @@ class TrailblazeMcpBridgeRecoveryTest {
     assertHttpFailureArmsRunner(reflectionBlockedWedgeMessage)
   }
 
+  /**
+   * A fire-and-forget [RunYamlResponse] (`awaitCompletion = false`) returns before any tool runs,
+   * so it carries neither `success` nor `nonRecoverableWedge` — there is nothing to arm from. This
+   * is why the bridge's on-device tool dispatch always sends `awaitCompletion = true` regardless of
+   * the caller's `blocking` flag: the direct-MCP dispatchers (TrailblazeToolToMcpBridge,
+   * DirectMcpToolExecutor, TrailExecutor, BridgeTrailblazeAgent) all use the `blocking = false`
+   * default, and a fire-and-forget dispatch would leave a terminal wedge unarmed for every one of
+   * them.
+   */
+  @Test
+  fun `fire-and-forget MCP response carries no terminal signal to arm`() {
+    withRecoveryPool { recovery, pool ->
+      assertFalse(
+        pool.get(affectedDevice).noteIfNonRecoverableWedge(
+          RunYamlResponse(
+            sessionId = SessionId("direct-mcp-fire-and-forget"),
+            memorySnapshot = emptyMap(),
+          ),
+        ),
+      )
+
+      assertFalse(recovery.requiresRestart(affectedDevice))
+    }
+  }
+
   @Test
   fun `ordinary MCP failure does not arm or evict either runner`() {
     withRecoveryPool { recovery, pool ->

--- a/trailblaze-host/src/test/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeRecoveryTest.kt
+++ b/trailblaze-host/src/test/java/xyz/block/trailblaze/mcp/TrailblazeMcpBridgeRecoveryTest.kt
@@ -95,31 +95,6 @@ class TrailblazeMcpBridgeRecoveryTest {
     assertHttpFailureArmsRunner(reflectionBlockedWedgeMessage)
   }
 
-  /**
-   * A fire-and-forget [RunYamlResponse] (`awaitCompletion = false`) returns before any tool runs,
-   * so it carries neither `success` nor `nonRecoverableWedge` — there is nothing to arm from. This
-   * is why the bridge's on-device tool dispatch always sends `awaitCompletion = true` regardless of
-   * the caller's `blocking` flag: the direct-MCP dispatchers (TrailblazeToolToMcpBridge,
-   * DirectMcpToolExecutor, TrailExecutor, BridgeTrailblazeAgent) all use the `blocking = false`
-   * default, and a fire-and-forget dispatch would leave a terminal wedge unarmed for every one of
-   * them.
-   */
-  @Test
-  fun `fire-and-forget MCP response carries no terminal signal to arm`() {
-    withRecoveryPool { recovery, pool ->
-      assertFalse(
-        pool.get(affectedDevice).noteIfNonRecoverableWedge(
-          RunYamlResponse(
-            sessionId = SessionId("direct-mcp-fire-and-forget"),
-            memorySnapshot = emptyMap(),
-          ),
-        ),
-      )
-
-      assertFalse(recovery.requiresRestart(affectedDevice))
-    }
-  }
-
   @Test
   fun `ordinary MCP failure does not arm or evict either runner`() {
     withRecoveryPool { recovery, pool ->

--- a/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/mcp/TrailblazeMcpBridge.kt
+++ b/trailblaze-models/src/commonMain/kotlin/xyz/block/trailblaze/mcp/TrailblazeMcpBridge.kt
@@ -74,10 +74,14 @@ interface TrailblazeMcpBridge {
    * This enables MCP clients to act as the agent, calling low-level device control tools.
    *
    * @param tool The TrailblazeTool to execute (e.g., TapOnPointTrailblazeTool, SwipeTrailblazeTool)
-   * @param blocking When true, suspends until the tool execution completes on the device.
-   *   When false (default), the HOST/Maestro path is fire-and-forget and may return before
-   *   the action finishes. Use blocking=true when you need to capture screen state after
-   *   the action (e.g., agent-driven CLI flows).
+   * @param blocking Governs the HOST/Maestro path only. When true, suspends until the tool
+   *   execution completes on the device. When false (default), that path is fire-and-forget and
+   *   may return before the action finishes. Use blocking=true when you need to capture screen
+   *   state after the action (e.g., agent-driven CLI flows).
+   *
+   *   The Android on-device path ignores this flag and always awaits completion: its
+   *   fire-and-forget response carries no outcome and no terminal-wedge tag, so a non-blocking
+   *   dispatch there would report phantom success and leave a poisoned runner in place.
    * @return Result string describing the execution outcome
    */
   suspend fun executeTrailblazeTool(


### PR DESCRIPTION
Follow-up to #219, addressing https://github.com/block/trailblaze/pull/219#discussion_r3675949396.

#219 wired the terminal wedge signal into `TrailblazeMcpBridgeImpl.executeToolViaRpc` — the pooled client got an `onNonRecoverableWedge` callback, and the `success == false` branch reads both the typed `RunYamlResponse.nonRecoverableWedge` field and the older string signature. But that code never runs for most direct-MCP callers.

`executeToolViaRpc` mapped `awaitCompletion = blocking`, and its comment claimed "every current caller" passes `blocking = true`. The `TrailblazeMcpBridge.executeTrailblazeTool` default is `false`, and `TrailblazeToolToMcpBridge` (the MCP tool-call handler), `DirectMcpToolExecutor`, `TrailExecutor`, and `BridgeTrailblazeAgent` all take that default.

With `awaitCompletion = false` the on-device handler returns before any tool runs, so the response carries no `success`, no `errorMessage`, and no `nonRecoverableWedge`. Those dispatches reported phantom success *and* left a terminal UiAutomation wedge unarmed — the poisoned runner then served every following MCP action, which is the loop the reviewer flagged.

**Scope.** The affected surface is the first-class MCP tool registration (`TrailblazeMcpServer` → `TrailblazeToolToMcpBridge.handleToolCall`) — what an external MCP client such as Claude Code, Codex, or Goose calls directly. `trailblaze tool` on the CLI is *not* affected: it dispatches the `step` MCP tool, whose `rawToolExecutor` passes `blocking = true`.

## Changes

- The on-device RPC branch always sends `awaitCompletion = true` (the `RunYamlRequest` default). `blocking` keeps governing the HOST/Maestro path only. Timeouts line up by construction: `awaitCompletion = true` sets `requestTimeoutMs = HTTP_REQUEST_CAP_MS` (20 min), above the on-device `HANDLER_AWAIT_CAP_MS` (15 min).
- A `null` `success` is now a hard failure rather than an "execution started" success. Under `awaitCompletion = true` it means the runner returned early (contract violation), so reporting "Executed" would be the same phantom success this change removes. `HostAccessibilityRpcClient` and `HostOnDeviceRpcTrailblazeAgent` already reject that shape — this matches them.
- Corrected the `executeTrailblazeTool` KDoc, which implied `blocking` governs all paths.
- Extracted the single-tool `RunYamlRequest` construction into a pure `buildOnDeviceToolRunYamlRequest` so the wire contract is testable without a live bridge (same `internal`-for-test pattern as `expandDelegatingToolHostSide` in the same companion).
- New `android-tests-mcp-dispatch` CI job — see below.

## Testing

`:trailblaze-host:test`, `:trailblaze-server:test`, `:trailblaze-common:jvmTest`, `:trailblaze-models:jvmTest` pass.

New `TrailblazeMcpBridgeOnDeviceDispatchTest` covers the request awaiting completion, its socket timeout outlasting the device's await cap, the session envelope, and wedge-arming across the tagged / untagged / fire-and-forget response shapes. Verified non-vacuous by reintroducing `awaitCompletion = blocking` — 2 of the 4 fail, including `requestTimeoutMs` collapsing to `null`.

### Reproduced on hardware

Android 35 emulator (`google_apis` arm64), on-device instrumentation driver, daemon on an isolated port, driven over `POST /mcp` as an external MCP client would. `assertVisible` against a ref that is not on screen:

```
before  {"isError":false,"text":"[OK] Executed AssertVisibleTrailblazeTool"}
after   {"isError":true, "text":"[FAILED] Failed to execute assertVisible\nOn-device execution of
         AssertVisibleTrailblazeTool failed: … Element ref 'zzz999' not found on current screen …"}
```

A succeeding `tapOnPoint` goes from `[OK] Executed TapOnPointTrailblazeTool` to the tool's own `[OK] Tapped at (100, 100)`.

### New CI job

`android-tests-mcp-dispatch` (`.github/pr_run_android_mcp_dispatch.sh`) closes the coverage gap that let this survive. Neither existing Android job reaches `executeToolViaRpc`: `android-tests-on-device` is pure instrumentation, and `android-tests-host-rpc` drives `trailblaze trail …` through `DesktopYamlRunner` → `HostOnDeviceRpcTrailblazeAgent`.

The job binds an emulator, opens an MCP session against the daemon, and asserts both halves of the regression — a failing tool must surface as `isError: true`, and a succeeding one must return its own output rather than the outcome-free `Executed <ToolName>` placeholder. Both assertions run independently so one failing doesn't mask the other. Verified against the pre-fix build: exits 1 with both assertions reporting.

## Not covered

- **The wedge itself.** The new job proves the dispatch now reads a terminal on-device response; it does not synthesize an Android 35 `UiAutomation` wedge, so the recovery branch #219 added is still only covered by unit tests.
- `getScreenStateViaRpc` still doesn't consult `onDeviceRunnerRecovery.requiresRestart`, so a snapshot on an armed device hits the wedged runner and returns null. Wiring recovery there would call `ensureOnDeviceAgentRunning`, which blocks up to 150s on a latch, while `RpcScreenStateAdapter.captureScreenState` runs under a 10s `withTimeoutOrNull` — it would hang the snapshot tool. Arming still happens via `rpcCall`'s failure match, and the next tool dispatch restarts the runner, so it self-heals.
