### PR TITLE
add gemma4 as a model for google

### DIFF
--- a/docs/generated/LLM_MODELS.md
+++ b/docs/generated/LLM_MODELS.md
@@ -21,6 +21,7 @@ Trailblaze ships with the following built-in models. When you reference a model 
 | `gemini-3.1-flash-lite-preview` | 1M | 65K | $0.25 | $1.50 | $0.03 | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 | `gemini-3.1-pro-preview` | 1M | 65K | $2.00 | $12.00 | $0.20 | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 | `gemini-3.1-pro-preview-customtools` | 1M | 65K | $2.00 | $12.00 | $0.20 | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
+| `gemma-4-26b-a4b-it` | 262K | 65K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 
 ## Ollama
 

--- a/trailblaze-models/src/commonMain/resources/trails/config/providers/google.yaml
+++ b/trailblaze-models/src/commonMain/resources/trails/config/providers/google.yaml
@@ -45,3 +45,11 @@ models:
       input_per_million: 0.25
       output_per_million: 1.50
       cached_input_per_million: 0.025
+
+  - id: gemma-4-31b-it
+    context_length: 262144
+    max_output_tokens: 65536
+    cost:
+      input_per_million: 0.0
+      output_per_million: 0.0
+      cached_input_per_million: 0.0


### PR DESCRIPTION
Integrate Gemma4 as a model for google provider.

This is limiting in terms of context size but it does allow for some free usage which is nice for testing.