### PR TITLE
Add D-pad key support for Android TV navigation

### DIFF
--- a/trailblaze-agent/src/main/resources/trailblaze_system_prompt.md
+++ b/trailblaze-agent/src/main/resources/trailblaze_system_prompt.md
@@ -8,3 +8,4 @@
 - A text field must be focused before you can enter text into it.
 - A disabled button will have no effect when clicked.
 - Any blank or loading screens should use the wait tool in order to provide the next valid view state.
+- If the device description indicates a TV, this is a D-pad/remote-driven UI: prefer `pressKey` with `DPAD_UP`/`DPAD_DOWN`/`DPAD_LEFT`/`DPAD_RIGHT` to move focus and `DPAD_CENTER` to activate the focused element, instead of `tap`. The `[focused]` marker in the view hierarchy shows which element currently has D-pad focus — use its position relative to your target to choose a direction.

--- a/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidTrailblazeDeviceInfoUtil.kt
+++ b/trailblaze-android/src/main/java/xyz/block/trailblaze/android/AndroidTrailblazeDeviceInfoUtil.kt
@@ -1,5 +1,7 @@
 package xyz.block.trailblaze.android
 
+import android.app.UiModeManager
+import android.content.res.Configuration
 import android.os.Build
 import android.util.DisplayMetrics
 import xyz.block.trailblaze.InstrumentationUtil.withInstrumentation
@@ -52,7 +54,20 @@ object AndroidTrailblazeDeviceInfoUtil {
     }
   }
 
+  /**
+   * Same runtime check play-android itself uses (`Context.isTv()` in `ContextExtensions.kt`)
+   * to distinguish a TV from a landscape tablet — Android TV isn't a separate device category
+   * in [TrailblazeAndroidDeviceCategory], it's detected orthogonally via [UiModeManager].
+   */
+  fun isTelevision(): Boolean = withInstrumentation {
+    val uiModeManager = context.getSystemService(UiModeManager::class.java)
+    uiModeManager?.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION
+  }
+
   fun getConsumerAndroidClassifiers(): List<TrailblazeDeviceClassifier> = buildList {
+    // Prepended so it becomes the headline term in the LLM-facing device description
+    // (see TrailblazeKoogLlmClientHelper.buildDeviceDescription, which reads classifiers.first()).
+    if (isTelevision()) add(TrailblazeDeviceClassifier("tv"))
     add(getDeviceCategoryClassifier())
   }
 

--- a/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/PressKeyTrailblazeTool.kt
+++ b/trailblaze-common/src/jvmAndAndroid/kotlin/xyz/block/trailblaze/toolcalls/commands/PressKeyTrailblazeTool.kt
@@ -23,6 +23,12 @@ Press a special key that isn't used for regular text input. Examples:
 - BACKSPACE: delete the character before the caret in the currently focused field.
 - TAB: move focus to the next field.
 - ESCAPE: dismiss the keyboard or current modal.
+- DPAD_UP / DPAD_DOWN / DPAD_LEFT / DPAD_RIGHT: move D-pad/remote focus on a
+  TV or other remote-driven UI. Use these instead of tap to navigate between
+  focusable elements. The currently focused element is marked `[focused]` in
+  the view hierarchy.
+- DPAD_CENTER: activate/select the currently focused element (the D-pad
+  equivalent of tap on a TV).
 """,
 )
 data class PressKeyTrailblazeTool(
@@ -42,6 +48,14 @@ data class PressKeyTrailblazeTool(
     BACKSPACE,
     TAB,
     ESCAPE,
+    // D-pad / TV remote navigation. Maestro's KeyCode already has native REMOTE_* entries
+    // wired all the way through AdbCommandUtil.pressKey (Android keycodes 19-23) — this
+    // just exposes them through the typed tool surface, same as the keys above.
+    DPAD_UP,
+    DPAD_DOWN,
+    DPAD_LEFT,
+    DPAD_RIGHT,
+    DPAD_CENTER,
     ;
 
     object Serializer : CaseInsensitiveEnumSerializer<PressKeyCode>(PressKeyCode::class)
@@ -57,6 +71,11 @@ data class PressKeyTrailblazeTool(
           PressKeyCode.BACKSPACE -> KeyCode.BACKSPACE
           PressKeyCode.TAB -> KeyCode.TAB
           PressKeyCode.ESCAPE -> KeyCode.ESCAPE
+          PressKeyCode.DPAD_UP -> KeyCode.REMOTE_UP
+          PressKeyCode.DPAD_DOWN -> KeyCode.REMOTE_DOWN
+          PressKeyCode.DPAD_LEFT -> KeyCode.REMOTE_LEFT
+          PressKeyCode.DPAD_RIGHT -> KeyCode.REMOTE_RIGHT
+          PressKeyCode.DPAD_CENTER -> KeyCode.REMOTE_CENTER
         }
       },
     ),

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/host/recording/MaestroInteractionToolFactory.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/host/recording/MaestroInteractionToolFactory.kt
@@ -111,6 +111,10 @@ class MaestroInteractionToolFactory(
       "Back" -> PressKeyTrailblazeTool.PressKeyCode.BACK
       "Enter" -> PressKeyTrailblazeTool.PressKeyCode.ENTER
       "Home" -> PressKeyTrailblazeTool.PressKeyCode.HOME
+      "ArrowUp" -> PressKeyTrailblazeTool.PressKeyCode.DPAD_UP
+      "ArrowDown" -> PressKeyTrailblazeTool.PressKeyCode.DPAD_DOWN
+      "ArrowLeft" -> PressKeyTrailblazeTool.PressKeyCode.DPAD_LEFT
+      "ArrowRight" -> PressKeyTrailblazeTool.PressKeyCode.DPAD_RIGHT
       else -> return null // Unsupported key for Maestro recording
     }
     return PressKeyTrailblazeTool(keyCode = keyCode) to PressKeyTrailblazeTool::class.toolName().toolName

--- a/trailblaze-host/src/main/java/xyz/block/trailblaze/host/recording/OnDeviceRpcDeviceScreenStream.kt
+++ b/trailblaze-host/src/main/java/xyz/block/trailblaze/host/recording/OnDeviceRpcDeviceScreenStream.kt
@@ -171,6 +171,10 @@ class OnDeviceRpcDeviceScreenStream(
       "Backspace", "Delete" -> PressKeyTrailblazeTool.PressKeyCode.BACKSPACE
       "Tab" -> PressKeyTrailblazeTool.PressKeyCode.TAB
       "Escape" -> PressKeyTrailblazeTool.PressKeyCode.ESCAPE
+      "ArrowUp" -> PressKeyTrailblazeTool.PressKeyCode.DPAD_UP
+      "ArrowDown" -> PressKeyTrailblazeTool.PressKeyCode.DPAD_DOWN
+      "ArrowLeft" -> PressKeyTrailblazeTool.PressKeyCode.DPAD_LEFT
+      "ArrowRight" -> PressKeyTrailblazeTool.PressKeyCode.DPAD_RIGHT
       else -> return
     }
     dispatchTool(PressKeyTrailblazeTool(keyCode = keyCode))

--- a/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/recording/InteractiveDeviceComposable.kt
+++ b/trailblaze-ui/src/commonMain/kotlin/xyz/block/trailblaze/ui/recording/InteractiveDeviceComposable.kt
@@ -393,6 +393,26 @@ fun InteractiveDeviceComposable(
             launchIo { stream.pressKey("Tab") }
             true
           }
+          Key.DirectionUp -> {
+            pendingLiveText.clear()
+            launchIo { stream.pressKey("ArrowUp") }
+            true
+          }
+          Key.DirectionDown -> {
+            pendingLiveText.clear()
+            launchIo { stream.pressKey("ArrowDown") }
+            true
+          }
+          Key.DirectionLeft -> {
+            pendingLiveText.clear()
+            launchIo { stream.pressKey("ArrowLeft") }
+            true
+          }
+          Key.DirectionRight -> {
+            pendingLiveText.clear()
+            launchIo { stream.pressKey("ArrowRight") }
+            true
+          }
           Key.Escape -> {
             pendingLiveText.clear()
             launchIo {


### PR DESCRIPTION
## Summary

- Extends `PressKeyTrailblazeTool.PressKeyCode` with `DPAD_UP`/`DPAD_DOWN`/`DPAD_LEFT`/`DPAD_RIGHT`/`DPAD_CENTER`, mapped to Maestro's existing `KeyCode.REMOTE_*` values. `AdbCommandUtil` already dispatches those as real `KEYCODE_DPAD_*` key events, so this closes a gap where the on-device execution path for D-pad worked end-to-end but had no typed tool surface to reach it.
- Adds the same arrow-key handling to the live device viewer / Maestro recording path (`OnDeviceRpcDeviceScreenStream`, `MaestroInteractionToolFactory`, `InteractiveDeviceComposable`), so Android TV trails can be authored interactively, not just replayed.
- Adds on-device TV detection (`AndroidTrailblazeDeviceInfoUtil.isTelevision()`, the same `UiModeManager` check used by TV apps themselves) that prepends a `"tv"` device classifier, plus a system prompt hint so the agent prefers D-pad navigation over `tap` when it's driving a TV.

## Motivation

Testing against a real Android TV app (Compose TV Material3), I found that Trailblaze's accessibility-based tap doesn't reliably activate elements gated on real D-pad focus/select semantics — a `pressKey DPAD_CENTER` on the focused element does. Without a first-class D-pad primitive, trail authors are stuck working around this with brittle hardcoded coordinate taps instead of semantic, resolution-independent D-pad presses.

## Test plan

Verified live against a running Android TV emulator with a Compose TV app:
- [x] `trailblaze tool pressKey keyCode=DPAD_RIGHT` / `DPAD_DOWN` move D-pad focus; the moved-to element shows up as `[focused]` in `trailblaze snapshot`.
- [x] `trailblaze tool pressKey keyCode=DPAD_CENTER` reliably activates the focused element, including a profile-picker tile that was previously unreliable via a plain accessibility tap.
- [x] Existing `pressKey keyCode=BACK` still works (no regression from the enum change).
- [x] Full uber-jar build succeeds from source.

Note on AI assistance: I used Claude Code to research the codebase, draft this change, and drive the emulator verification above; I reviewed the diff and testing results myself before opening this PR.