### PR TITLE
Add every hosted Gemma 4 model, and document adding your own without a release

### DIFF
--- a/docs/adding_a_model.md
+++ b/docs/adding_a_model.md
@@ -1,0 +1,194 @@
+---
+title: Adding a Model
+---
+
+# Adding a Model
+
+**You do not need a new Trailblaze release to use a new model.** Model definitions are
+config, not code. Add the model to your workspace's `trails/config/trailblaze.yaml` and
+Trailblaze picks it up on the next run.
+
+The built-in registry ([Built-in Models](generated/LLM_MODELS.md)) exists so common models
+work with zero configuration and correct specs. It is a convenience, not a gate — a model
+missing from it is not a model Trailblaze refuses to run. Model families ship faster than
+release cycles, so this page is the escape hatch that keeps you off the upgrade treadmill.
+
+## The 30-second version
+
+```yaml
+# trails/config/trailblaze.yaml
+llm:
+  providers:
+    google:
+      models:
+        - id: gemma-4-31b-it
+          context_length: 262144
+          max_output_tokens: 32768
+  defaults:
+    model: gemma-4-31b-it
+```
+
+```bash
+trailblaze config models          # confirm it's listed
+trailblaze config llm google/gemma-4-31b-it
+```
+
+Set the provider's API key (`GOOGLE_API_KEY` here — see the
+[env var table](llm_configuration.md#environment-variables)) and you're running.
+
+## How your entry combines with the built-ins
+
+Workspace config **adds to** the built-in registry — it does not replace it. Entries are
+matched by `id`:
+
+| Your `id` | Result |
+|---|---|
+| Not in the built-in registry | A new model, defined entirely by your entry |
+| Already in the built-in registry | Field-by-field merge — the fields you set win, the rest are inherited |
+
+So a workspace entry is equally the way to **add** a model and the way to **pin or correct**
+one that ships in the box (stale pricing, a context window your gateway caps lower).
+
+Anything you omit falls back to a safe default rather than failing: `context_length`
+defaults to **131072** and `max_output_tokens` to **8192**. Both are conservative — set them
+explicitly for any model whose real limits you know, or you'll silently leave context on the
+table.
+
+## Filling in the values
+
+| Field | Set it when | Where to find it |
+|---|---|---|
+| `id` | Always | The exact model string the provider's API expects — copy it from the provider's model list, not from marketing copy |
+| `context_length` | Always, in practice | The provider's model card / docs |
+| `max_output_tokens` | Always, in practice | Same. If the provider publishes no figure, use the largest any host documents |
+| `vision` | Text-only models | Set `false`. Defaults to `true` |
+| `cost.*` | You want spend reported accurately | Provider pricing page. Local / free-tier models: `0.0` |
+| `temperature` | The model needs a non-default | Provider guidance |
+| `screenshot.max_dimensions` | The model has a tighter image limit | Provider image-input docs |
+
+Full field reference: [LLM Configuration → Model fields](llm_configuration.md#model-fields).
+
+**What Trailblaze actually needs from a model.** The agent loop drives a device by looking at
+an annotated screenshot and emitting tool calls, so a model wants **image input** and
+**function/tool calling** to be useful. A text-only model (`vision: false`) still works for
+text-only flows, but it will struggle on anything that needs to read the screen. Smaller
+local models frequently accept the tools and then ignore them — try before you commit a
+team-wide default.
+
+## Recipes
+
+### A hosted model on a built-in provider
+
+`openai`, `anthropic`, `google`, `ollama`, and `openrouter` already know their endpoint and
+auth env var. You only supply the model:
+
+```yaml
+llm:
+  providers:
+    openrouter:
+      models:
+        - id: google/gemma-4-31b-it:free
+          context_length: 262144
+          max_output_tokens: 32768
+          cost:
+            input_per_million: 0.0
+            output_per_million: 0.0
+```
+
+### A local Ollama model
+
+```yaml
+llm:
+  providers:
+    ollama:
+      models:
+        - id: "gemma4:31b"
+          context_length: 262144
+          max_output_tokens: 8192
+  defaults:
+    model: "gemma4:31b"
+```
+
+Quote Ollama ids — the `:` makes them look like YAML mappings otherwise. Trailblaze also
+discovers whatever `ollama list` reports at runtime, so a model already pulled locally shows
+up without any config; listing it explicitly is how you tell teammates which model the
+project expects. Nothing is auto-downloaded — they run `ollama pull gemma4:31b`.
+
+### A model behind your own gateway
+
+A provider Trailblaze has never heard of is the same amount of work, plus the endpoint:
+
+```yaml
+llm:
+  providers:
+    acme_gateway:
+      type: openai_compatible
+      base_url: "https://ai.acme.example.com/v1"
+      auth:
+        env_var: ACME_AI_TOKEN
+      models:
+        - id: acme-vision-large
+          context_length: 200000
+          max_output_tokens: 32768
+  defaults:
+    model: acme-vision-large
+```
+
+See [Enterprise gateway](llm_configuration.md#enterprise-gateway) for headers, custom
+completion paths, and the on-device story.
+
+### Override a built-in model's specs
+
+Specify only what you're changing:
+
+```yaml
+llm:
+  providers:
+    openai:
+      models:
+        - id: gpt-4.1
+          max_output_tokens: 16384   # our gateway caps output lower than the default
+```
+
+## Where to put the file
+
+| Scope | Path |
+|---|---|
+| Whole team (commit it) | `<workspace>/trails/config/trailblaze.yaml` |
+| Just you | `~/.trailblaze/trailblaze.yaml` |
+
+The workspace file wins over the user file; environment variables win over both. Full
+precedence table: [Configuration → Precedence](configuration.md#precedence).
+
+Committing the workspace file is the recommended shape for teams — everyone who clones the
+repo gets a working model with no per-machine setup, and the project is pinned to models you
+have actually validated rather than to whatever the current release happens to ship.
+
+## Verifying
+
+```bash
+trailblaze config models    # every model Trailblaze can see, per provider
+trailblaze config llm       # the provider/model currently selected
+trailblaze config show      # all persisted settings
+```
+
+If your model isn't listed, the usual causes are: the file isn't at
+`trails/config/trailblaze.yaml` (Trailblaze walks up from the current directory looking for
+exactly that path — see [Project Layout](project_layout.md)), the entry is nested under the
+wrong provider key, or an unquoted `id` containing `:` parsed as a map.
+
+## Contributing a model to the built-in registry
+
+Once a model is worth having work out of the box for everyone, send it upstream — but note
+you never have to wait for that to use it.
+
+1. Add the entry to the matching provider file in
+   [`trailblaze-models/src/commonMain/resources/trails/config/providers/`](https://github.com/block/trailblaze/tree/main/trailblaze-models/src/commonMain/resources/trails/config/providers).
+2. Regenerate the docs — [`docs/generated/LLM_MODELS.md`](generated/LLM_MODELS.md) is
+   generated from those provider files, so hand-editing it drifts and fails CI:
+
+   ```bash
+   ./gradlew :docs:generator:run
+   ```
+
+3. Commit both the provider YAML and the regenerated `LLM_MODELS.md`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,124 @@
 title: Configuration
 ---
 
+# Configuration
+
+Most of Trailblaze needs no configuration — a single `.trail.yaml` file is a complete
+project. When you do want project-level settings (which app to target, which LLM to use,
+which toolsets your agent sees), they live in one file: **`trailblaze.yaml`**.
+
+## `trailblaze.yaml` — the workspace config file
+
+```
+my-project/
+└── trails/
+    ├── config/
+    │   └── trailblaze.yaml   ← this file
+    └── login/
+        └── trail.yaml
+```
+
+Trailblaze walks up from the current directory (or from the directory containing the trail
+you invoked) until it finds `trails/config/trailblaze.yaml`. The owning `trails/` directory
+becomes the **workspace root**, and every relative path inside the file resolves against
+`trails/config/`. See [Project Layout](project_layout.md) for the discovery rules and
+[External Config](generated/external-config.md) for the full `trails/config/` directory shape.
+
+`trailblaze.yaml` is config, never a trail — Trailblaze will not try to run it.
+
+**Every section is optional**, and an empty file is valid. Committing it is the point: it's
+how a team pins one target, one model, and one toolset surface for everybody who clones the
+repo, with no per-machine setup.
+
+```yaml
+# trails/config/trailblaze.yaml — everything below is optional
+defaults:
+  target: my-app
+  max-llm-calls: 25
+
+targets:
+  - my-app
+
+llm:
+  providers:
+    openai:
+      models:
+        - id: gpt-4.1
+  defaults:
+    model: gpt-4.1
+```
+
+### Top-level keys
+
+| Key | Type | What it does |
+|---|---|---|
+| `defaults` | map | Workspace-wide defaults — see below |
+| `targets` | list of ids | Target-trailmap ids this workspace opts into. **Omit to auto-discover** every target trailmap under `<workspace>/trailmaps/`. Listing ids is how a workspace with many trailmaps loads only a subset. Each id must be a *target* trailmap (one with a `target:` block); library trailmaps reach scope through a target's `dependencies:`. |
+| `toolsets` | list | Extra toolsets, either written inline or pulled in with `ref: path/to/toolset.yaml` |
+| `tools` | list | Extra tools, same inline-or-`ref:` shape |
+| `providers` | list | Reserved for standalone LLM provider files. Provider and model definitions are read from the `llm:` block today — put them there. |
+| `llm` | map | LLM providers, models, and defaults — see [LLM Configuration](llm_configuration.md) |
+
+### `defaults`
+
+| Key | What it does |
+|---|---|
+| `target` | Target-trailmap id used when nothing more specific is set. Must match a loaded target (case-sensitive); an unknown id is logged and skipped rather than failing the run. |
+| `max-llm-calls` | Team-wide cap on LLM calls per objective, so every developer and CI runner inherits the same budget without passing `--max-llm-calls`. Positive integer. |
+
+### `ref:` entries
+
+`toolsets`, `tools`, and `providers` each accept either the entry written inline or a
+pointer to a separate file:
+
+```yaml
+toolsets:
+  - ref: toolsets/my-toolset.yaml     # relative to trails/config/
+  - name: inline-toolset              # or write the whole thing here
+    tools: [tapOn, assertVisible]
+```
+
+Ref paths are always resolved relative to the directory holding `trailblaze.yaml` — a
+leading `/` is stripped and treated the same way, so `/foo.yaml` is not an escape to the
+filesystem root. A `ref:` entry may not carry any sibling keys.
+
+## Precedence
+
+Later rows win.
+
+| Priority | Source | Scope |
+|---|---|---|
+| 1 (lowest) | Built-in defaults shipped in the binary | Everyone |
+| 2 | `~/.trailblaze/trailblaze.yaml` | Just you, every workspace |
+| 3 | `<workspace>/trails/config/trailblaze.yaml` | Everyone in this project |
+| 4 | Persisted per-machine settings (`trailblaze config …`) | Just you, this machine |
+| 5 (highest) | Environment variables and per-run CLI flags | This invocation |
+
+Two clarifications worth knowing:
+
+- **Workspace beats user file, but per-run beats everything.** A committed workspace file is
+  the team's baseline; `--target`, `-d`, `TRAILBLAZE_DEFAULT_MODEL` and friends still win for
+  a single run, which is what makes CI overrides work.
+- **`defaults.target` is deliberately ranked below a real user selection but above the
+  neutral built-in target** — and a persisted selection of the neutral `default` target does
+  *not* count as a real selection, so it can't mask the committed workspace default. Full
+  ordering in [Project Layout → Workspace defaults](project_layout.md#workspace-defaults).
+
+## Common tasks
+
+| I want to… | Go to |
+|---|---|
+| Use a model that isn't built in | [Adding a Model](adding_a_model.md) |
+| Point at a private LLM gateway | [LLM Configuration](llm_configuration.md#enterprise-gateway) |
+| See what's currently in effect | `trailblaze config show` ([CLI](CLI.md#trailblaze-config)) |
+| Set a default target for the team | `defaults.target`, above |
+| Understand the `trails/config/` directory | [External Config](generated/external-config.md) |
+| Add custom tools to a project | [Your First Trailmap](your-first-trailmap.md) |
+
+Per-machine settings (`trailblaze config llm`, `trailblaze config target`, …) live in
+`~/.trailblaze/` and are documented with the [`trailblaze config`](CLI.md#trailblaze-config)
+command.
+
 ## On-Device Android Instrumentation Arguments
 * `trailblaze.aiEnabled` (defaults to `true`) - This will have the Trailblaze SDK send all requests to the LLM.  When `false`, only recordings can be used.
 * `trailblaze.reverseProxy` (defaults to `false`) - This will enable the reverse proxy for all Trailblaze traffic.
@@ -12,6 +130,9 @@ title: Configuration
     * It is also helpful/important because in the future it will allow you to not send your API Keys to the device itself, but add the `Authorization` information via the reverse proxy.
 * `trailblaze.httpsPort` (defaults to `52526`, i.e. `trailblaze.port` + 1) - The HTTPS port for the Trailblaze server. Override this when running multiple Trailblaze instances.
 * `trailblaze.logsEndpoint` - Defaults to the same values as the `reverseProxy` uses.  You can use this value if you want to use a remote logs server.  NOTE: Logging timeouts are set to 5 seconds as they are expected to be fast.
+
+LLM selection for on-device runs has its own resolution order — see
+[LLM Configuration → On-Device Android Agent](llm_configuration.md#on-device-android-agent).
 
 ## Scripting Callback Channel
 

--- a/docs/generated/LLM_MODELS.md
+++ b/docs/generated/LLM_MODELS.md
@@ -21,12 +21,17 @@ Trailblaze ships with the following built-in models. When you reference a model 
 | `gemini-3.1-flash-lite-preview` | 1M | 65K | $0.25 | $1.50 | $0.03 | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 | `gemini-3.1-pro-preview` | 1M | 65K | $2.00 | $12.00 | $0.20 | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 | `gemini-3.1-pro-preview-customtools` | 1M | 65K | $2.00 | $12.00 | $0.20 | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
-| `gemma-4-31b-it` | 262K | 65K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
+| `gemma-4-12b-it` | 262K | 32K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
+| `gemma-4-26b-a4b-it` | 262K | 32K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
+| `gemma-4-31b-it` | 262K | 32K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 
 ## Ollama
 
 | Model ID | Context | Max Output | Input $/1M | Output $/1M | Cached Input $/1M | Capabilities |
 |----------|---------|------------|-----------|------------|-------------------|--------------|
+| `gemma4:12b` | 262K | 8K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
+| `gemma4:26b` | 262K | 8K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
+| `gemma4:31b` | 262K | 8K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 | `gpt-oss:120b` | 131K | 65K | free | free | free | basic-json-schema, completion, document, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 | `gpt-oss:20b` | 131K | 65K | free | free | free | basic-json-schema, completion, document, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |
 | `qwen3-vl:2b` | 131K | 8K | free | free | free | basic-json-schema, completion, document, image, multipleChoices, openai-endpoint-chat-completions, openai-endpoint-responses, speculation, standard-json-schema, temperature, toolChoice, tools |

--- a/docs/generated/external-config.md
+++ b/docs/generated/external-config.md
@@ -8,6 +8,8 @@ title: External Config
 
 Trailblaze's desktop/CLI binary currently builds the effective app-target config from three layers, in order: framework-bundled `trails/config/**` resources, an optional workspace `trails/config/` directory, and the current workspace's `trails/config/trailblaze.yaml` entries. Later layers override earlier ones by id / filename.
 
+> This page covers the `trails/config/` **directory** — authoring targets, toolsets, and tools. The `trailblaze.yaml` **file** itself (its keys, workspace defaults, and precedence) is documented in [Configuration](../configuration.md).
+
 The intended split is now the live split: `trails/` is the workspace anchor, `trails/config/trailblaze.yaml` is the workspace manifest, and `trails/config/` is the artifact directory that holds concrete trailmap, target, toolset, and tool files, plus the reserved location for provider YAMLs.
 
 ## Lookup Order for Filesystem Config

--- a/docs/generator/src/main/java/xyz/block/trailblaze/docs/ExternalConfigDocsGenerator.kt
+++ b/docs/generator/src/main/java/xyz/block/trailblaze/docs/ExternalConfigDocsGenerator.kt
@@ -56,6 +56,14 @@ class ExternalConfigDocsGenerator(
         )
         appendLine()
         appendLine(
+          "> This page covers the `${TrailblazeConfigPaths.WORKSPACE_CONFIG_DIR}/` **directory** — " +
+            "authoring targets, toolsets, and tools. The " +
+            "`${TrailblazeProjectConfigLoader.CONFIG_FILENAME}` **file** itself (its keys, " +
+            "workspace defaults, and precedence) is documented in " +
+            "[Configuration](../configuration.md).",
+        )
+        appendLine()
+        appendLine(
           "The intended split is now the live split: ${workspaceAnchorDir()} is the workspace anchor, " +
             "`${TrailblazeConfigPaths.WORKSPACE_CONFIG_FILE}` is the workspace manifest, and " +
             "`${TrailblazeConfigPaths.WORKSPACE_CONFIG_DIR}/` is the artifact directory that holds " +

--- a/docs/index.md
+++ b/docs/index.md
@@ -273,7 +273,8 @@ and project context to the loop, which the built-in agent can't.
   the [Trailmaps](trailmaps.md) manifest schema, and the [Trailblaze Tools](tools.md)
   catalog of scripted / pure-YAML / Kotlin flavors.
 - **Customizing the LLM?** See [LLM Configuration](llm_configuration.md) and
-  [Built-in Models](generated/LLM_MODELS.md).
+  [Built-in Models](generated/LLM_MODELS.md). Using a model that isn't built in — no
+  Trailblaze upgrade required — is [Adding a Model](adding_a_model.md).
 - **Going deep?** See [Architecture](architecture.md) and the [devlog](devlog/index.md).
 
 ## License

--- a/docs/llm_configuration.md
+++ b/docs/llm_configuration.md
@@ -4,6 +4,10 @@ title: LLM Configuration
 
 Trailblaze supports configurable LLM providers and models via YAML files. This allows teams to use enterprise endpoints, custom gateways, self-hosted models, and project-specific defaults without modifying source code.
 
+> **Just want to use a model Trailblaze doesn't ship with?** You don't need a new release —
+> add it to your workspace config. [Adding a Model](adding_a_model.md) is the short,
+> task-focused version of this page.
+
 ## Configuration Loading Order
 
 Configuration is loaded from multiple locations. Later sources override earlier ones:
@@ -370,3 +374,5 @@ Trailblaze ships with a registry of models from major providers. See [Built-in L
 When referencing a built-in model by `id` in your YAML config, all specs (pricing, context length, capabilities) are inherited automatically. You only need to specify fields you want to override.
 
 Built-in model specs are updated with each Trailblaze release. If you need stable, predictable pricing or specs, override them in your workspace config.
+
+**A model missing from the registry is not blocked** — the registry only saves you from typing the specs. Declare any model your provider serves in `trails/config/trailblaze.yaml` and it works on the next run, no upgrade needed. See [Adding a Model](adding_a_model.md), which also covers contributing the model back to the built-in registry.

--- a/trailblaze-models/src/commonMain/resources/trails/config/providers/google.yaml
+++ b/trailblaze-models/src/commonMain/resources/trails/config/providers/google.yaml
@@ -46,9 +46,29 @@ models:
       output_per_million: 1.50
       cached_input_per_million: 0.025
 
+  # Gemma 4 — open weights, served on the Gemini API at $0 on a rate-limited free tier.
+  # Multimodal (text + image) with native function calling; 256K context on all three.
+  # max_output_tokens is 32768 rather than the 65536 the Gemini models above use: Google
+  # publishes no output cap for Gemma 4, and 32768 is the largest figure any host documents.
+  - id: gemma-4-12b-it
+    context_length: 262144
+    max_output_tokens: 32768
+    cost:
+      input_per_million: 0.0
+      output_per_million: 0.0
+      cached_input_per_million: 0.0
+
+  - id: gemma-4-26b-a4b-it
+    context_length: 262144
+    max_output_tokens: 32768
+    cost:
+      input_per_million: 0.0
+      output_per_million: 0.0
+      cached_input_per_million: 0.0
+
   - id: gemma-4-31b-it
     context_length: 262144
-    max_output_tokens: 65536
+    max_output_tokens: 32768
     cost:
       input_per_million: 0.0
       output_per_million: 0.0

--- a/trailblaze-models/src/commonMain/resources/trails/config/providers/ollama.yaml
+++ b/trailblaze-models/src/commonMain/resources/trails/config/providers/ollama.yaml
@@ -53,3 +53,16 @@ models:
   - id: "qwen3.5:latest"
     context_length: 131072
     max_output_tokens: 8192
+
+  # Gemma 4 models (vision-capable, 256K context)
+  # The edge builds (e2b/e4b — and `gemma4:latest`, which resolves to e4b) are omitted
+  # deliberately: 128K context and much weaker at screenshot-driven tool calling.
+  - id: "gemma4:12b"
+    context_length: 262144
+    max_output_tokens: 8192
+  - id: "gemma4:26b"
+    context_length: 262144
+    max_output_tokens: 8192
+  - id: "gemma4:31b"
+    context_length: 262144
+    max_output_tokens: 8192


### PR DESCRIPTION
> Stacked on #228 — review that first. This PR's own changes are the two commits below; the base will collapse once #228 merges.

## Summary

**Every Gemma 4 model Google and Ollama serve is now built in.** #225 added one; there are three, and you can pick any of them by id with no specs to look up:

| Where | Ids |
|---|---|
| Gemini API (free tier) | `gemma-4-12b-it`, `gemma-4-26b-a4b-it`, `gemma-4-31b-it` |
| Ollama (local) | `gemma4:12b`, `gemma4:26b`, `gemma4:31b` |

Google's own reference for the Gemini API ids: [Gemma on the Gemini API](https://ai.google.dev/gemma/docs/core/gemma_on_gemini_api).

**And a new docs page says out loud that you never had to wait for a release to use a new model.** A workspace `trailblaze.yaml` can declare any model its provider serves, and it takes effect on the next run — that was previously one sentence buried in the LLM reference. [Adding a Model](https://github.com/block/trailblaze/blob/gemma4-model-coverage/docs/adding_a_model.md) is now the page to hand someone who asks.

## Two things worth flagging on #225

- **`gemma-4-31b-it` and `gemma-4-26b-a4b-it` are both real, distinct models** — 31B dense and 26B-A4B MoE. #225's `google.yaml` declared the first and its hand-written `LLM_MODELS.md` row named the second, which reads like a typo but isn't. `LLM_MODELS.md` is generated from the provider yamls, so regenerating it (in #228) resolved the mismatch by silently dropping one real model. Both are back, plus the 12B.
- **`max_output_tokens` is 32768, not the 65536** the Gemini models use. Google publishes no output cap for Gemma 4; 32768 is the largest figure any host documents.

The `e2b` / `e4b` edge builds are deliberately omitted from Ollama: 128K context and much weaker at the screenshot-driven tool calling the agent loop does. Worth knowing that `gemma4:latest` resolves to `e4b`, so name a size explicitly.

## The docs change

Two files, one gap each.

**New: `docs/adding_a_model.md`.** How a workspace entry combines with the built-in list (matched by `id` — an unknown id adds a model, a known id overrides it field-by-field), the 131K/8K fallbacks you inherit by omitting the limits, what a model actually needs to be useful here (image input + tool calling), and recipes for hosted / local Ollama / your-own-gateway. Ends with how to contribute a model back to the built-in registry — including running `:docs:generator:run`, since `LLM_MODELS.md` is generated and hand-editing it is exactly what tripped up #225.

**Rewritten opening of `docs/configuration.md`.** The page titled "Configuration" documented Android instrumentation args and scripting callback timeouts and never mentioned `trailblaze.yaml` at all. It now opens with the file itself: where it lives and how it's discovered, that every section is optional, a table of the top-level keys (`defaults`, `targets`, `toolsets`, `tools`, `providers`, `llm`), the inline-or-`ref:` shape those lists accept, and one precedence table covering built-ins → user file → workspace file → persisted settings → env/flags. Existing sections are unchanged, below.

Cross-links added from `index.md` and `llm_configuration.md`.

## Test plan

- [x] `./gradlew :docs:generator:run` — `LLM_MODELS.md` regenerates with all six rows, no other drift
- [x] Doc anchors resolve against the pages they point at
- [ ] CI green
