### PR TITLE
Cache Gradle state across CI runs to cut PR-check wall clock

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -46,6 +46,15 @@ jobs:
           distribution: zulu
           java-version: 17
 
+      - name: Setup Gradle
+        # Persists the Gradle User Home (dependency cache + local build cache)
+        # across runs. Pushes to main seed the cache; PR runs restore it
+        # read-only, so warm PR builds pull unchanged task outputs — including
+        # the ~5-minute Kotlin/WASM compile+optimize chain — from cache.
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
       - name: Setup Android SDK
         # trailblaze-desktop transitively depends on Android-targeted modules,
         # so the Android Gradle Plugin needs an SDK to evaluate the build.
@@ -64,9 +73,11 @@ jobs:
         # `packageUberJarForCurrentOS` and copies the launcher script
         # alongside the JAR into `trailblaze-desktop/build/release/`.
         # TRAILBLAZE_GRADLE_EXTRA_ARGS layers in `-Ptrailblaze.wasm=true` so
-        # the report template gets bundled into the JAR's classpath.
+        # the report template gets bundled into the JAR's classpath, and
+        # `--parallel` so independent modules compile concurrently (the
+        # `checks` job already runs the same task graph with `--parallel`).
         env:
-          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true
+          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true --parallel
         run: ./scripts/install-trailblaze-source.sh
 
       - name: Stage artifact contents
@@ -109,6 +120,14 @@ jobs:
           java-version: '17'
           check-latest: true
 
+      - name: Setup Gradle
+        # Dependency + build cache reuse across runs (seeded on main pushes,
+        # restored read-only on PRs) — unchanged modules restore compiled
+        # classes and test results metadata from cache instead of rebuilding.
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
       - name: Setup Bun
         # bun is the sole supported JS runtime. `assemble check` triggers
         # `:trailblaze-scripting-subprocess:installTrailblazeScriptingSdk`
@@ -149,6 +168,13 @@ jobs:
           distribution: 'zulu'
           java-version: '17'
           check-latest: true
+
+      - name: Setup Gradle
+        # Dependency + build cache reuse across runs (seeded on main pushes,
+        # restored read-only on PRs).
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Setup Bun
         # The subprocess tests `bun install` and then spawn `bun`/`tsx` for each
@@ -415,6 +441,15 @@ jobs:
         with:
           distribution: zulu
           java-version: 17
+
+      - name: Setup Gradle
+        # Dependency + build cache reuse across runs (seeded on main pushes,
+        # restored read-only on PRs). This job runs Gradle twice — the
+        # instrumentation build below and the WASM-enabled report fallback in
+        # pr_generate_trailblaze_report.sh — both benefit.
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,14 @@ android.nonTransitiveRClass=true
 group=xyz.block.trailblaze
 version=0.1.0-SNAPSHOT
 
+# Reuse task outputs across builds (and across CI runs — the setup-gradle
+# action persists the Gradle User Home, including the local build cache,
+# between workflow runs). Tasks whose inputs are unchanged are restored from
+# cache instead of re-executing; this is what lets warm CI runs skip the
+# expensive Kotlin/WASM compile+optimize chain when the UI/report modules
+# haven't changed.
+org.gradle.caching=true
+
 # Set to true to enable Kotlin/WASM targets (requires yarn tooling setup).
 # Most builds don't need WASM — only release uber jars and report template generation.
 # Usage: ./gradlew <task> -Ptrailblaze.wasm=true


### PR DESCRIPTION
PR checks run every Gradle job from a cold start — no dependency cache, no build cache — putting a green run at ~25 min wall clock. The critical path is `build-uber-jar` (~11.5 min, of which ~5 min is the Kotlin/WASM compile + binaryen optimize chain) gating the iOS/Android trail jobs.

Changes:

- Enable `org.gradle.caching=true` so task outputs are reusable across builds (helps local dev too).
- Add `gradle/actions/setup-gradle` (SHA-pinned v6.3.0) to the four Gradle-running jobs: `build-uber-jar`, `checks`, `checks-scripting-subprocess`, `android-tests-on-device`. Pushes to `main` seed the per-job cache; PR runs restore it read-only (`cache-read-only` on non-main refs), so a PR only pays for the delta between its diff and `main` — including skipping the whole WASM chain when UI/report modules are untouched.
- Run the uber JAR build with `--parallel`, matching the `checks` job's existing flags.

This also eliminates the second full WASM compile in `android-tests-on-device`: its report-generation fallback (`pr_generate_trailblaze_report.sh`) runs the same `-Ptrailblaze.wasm=true` tasks, now served from the warm cache.

Expected steady state once the cache is seeded (first push to `main` after merge): uber jar ~4–6 min, `checks` ~8–10 min, total PR wall clock ~16–18 min, floored by the iOS trail run itself. This PR's own run is still cold, so timings here won't show the improvement yet.