### PR TITLE
Harden the Playwright driver download and extend CI caching to main workflows

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -38,13 +38,12 @@ jobs:
           java-version: '17'
           check-latest: true
 
-      - name: Setup Gradle
-        # Dependency + build cache reuse across runs. Seeded by pushes to main;
-        # PR and tag builds restore read-only. Mirrors pr-checks.yml.
-        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-
+      # NOTE: deliberately no gradle/actions/setup-gradle here. This workflow
+      # publishes GitHub Releases on tag pushes, and restoring a cache into a
+      # release-publishing workflow is a cache-poisoning vector (zizmor
+      # cache-poisoning rule): a poisoned cache entry could inject content
+      # into the published JAR. Release builds stay hermetic; the other
+      # (non-publishing) workflows get Gradle caching instead.
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -38,6 +38,13 @@ jobs:
           java-version: '17'
           check-latest: true
 
+      - name: Setup Gradle
+        # Dependency + build cache reuse across runs. Seeded by pushes to main;
+        # PR and tag builds restore read-only. Mirrors pr-checks.yml.
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 

--- a/.github/workflows/clock-trails.yml
+++ b/.github/workflows/clock-trails.yml
@@ -39,6 +39,13 @@ jobs:
           distribution: zulu
           java-version: 17
 
+      - name: Setup Gradle
+        # Dependency + build cache reuse across runs (this workflow only runs
+        # on main, so it reads and writes the cache). Mirrors pr-checks.yml.
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 
@@ -47,7 +54,7 @@ jobs:
 
       - name: Build trailblaze uber JAR (with WASM template embedded)
         env:
-          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true
+          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true --parallel
         run: ./scripts/install-trailblaze-source.sh
 
       - name: Stage artifact contents

--- a/.github/workflows/ios-contacts-trails.yml
+++ b/.github/workflows/ios-contacts-trails.yml
@@ -40,6 +40,13 @@ jobs:
           distribution: zulu
           java-version: 17
 
+      - name: Setup Gradle
+        # Dependency + build cache reuse across runs (this workflow only runs
+        # on main, so it reads and writes the cache). Mirrors pr-checks.yml.
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
       - name: Setup Android SDK
         # trailblaze-desktop transitively depends on Android-targeted modules,
         # so the Android Gradle Plugin needs an SDK to evaluate the build.
@@ -51,7 +58,7 @@ jobs:
 
       - name: Build trailblaze uber JAR (with WASM template embedded)
         env:
-          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true
+          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true --parallel
         run: ./scripts/install-trailblaze-source.sh
 
       - name: Stage artifact contents

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -211,6 +211,19 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
+      - name: Cache Playwright driver
+        # The uber JAR ships without Playwright's ~200 MB driver-bundle; the CLI
+        # downloads it from Maven Central at first use and caches it under
+        # ~/.cache/trailblaze/playwright-driver. Restore it across runs so the
+        # trail isn't exposed to that download (a stalled Maven Central
+        # connection here has burned a full 10-minute no-progress timeout).
+        # The main-seeded entry comes from wikipedia-trails.yml, since caches
+        # created inside a PR are only visible to that PR.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/trailblaze/playwright-driver
+          key: playwright-driver-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+
       - name: Download prebuilt uber JAR
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/wikipedia-trails.yml
+++ b/.github/workflows/wikipedia-trails.yml
@@ -35,6 +35,13 @@ jobs:
           distribution: zulu
           java-version: 17
 
+      - name: Setup Gradle
+        # Dependency + build cache reuse across runs (this workflow only runs
+        # on main, so it reads and writes the cache). Mirrors pr-checks.yml.
+        uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
       - name: Setup Android SDK
         uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407
 
@@ -43,7 +50,7 @@ jobs:
 
       - name: Build trailblaze uber JAR (with WASM template embedded)
         env:
-          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true
+          TRAILBLAZE_GRADLE_EXTRA_ARGS: -Ptrailblaze.wasm=true --parallel
         run: ./scripts/install-trailblaze-source.sh
 
       - name: Stage artifact contents
@@ -89,6 +96,18 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Cache Playwright driver
+        # The uber JAR ships without Playwright's ~200 MB driver-bundle; the CLI
+        # downloads it from Maven Central at first use and caches it under
+        # ~/.cache/trailblaze/playwright-driver. This main-run cache entry is
+        # what the PR-time wikipedia-trails job in pr-checks.yml restores
+        # (caches created inside a PR are only visible to that PR, so main has
+        # to seed the shared one).
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/trailblaze/playwright-driver
+          key: playwright-driver-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
 
       - name: Download prebuilt uber JAR
         uses: actions/download-artifact@v4

--- a/trailblaze-playwright/src/main/java/xyz/block/trailblaze/playwright/PlaywrightDriverManager.kt
+++ b/trailblaze-playwright/src/main/java/xyz/block/trailblaze/playwright/PlaywrightDriverManager.kt
@@ -113,11 +113,28 @@ object PlaywrightDriverManager {
     }
   }
 
+  /** Attempts per source URL before falling through to the next source. */
+  private const val DOWNLOAD_MAX_ATTEMPTS_PER_SOURCE = 3
+
+  /**
+   * Stall detection window for the driver-bundle download. The connection's read timeout only
+   * fires when the socket delivers *zero* bytes for its duration; a server that trickles a few
+   * bytes per second resets it forever and can pin a download for the caller's entire timeout
+   * budget (observed in CI: a Maven Central download that normally takes ~5s hung a trail run
+   * for its full 10-minute no-progress watchdog). Requiring [STALL_MIN_BYTES_PER_WINDOW] per
+   * window kills those near-dead connections while still tolerating genuinely slow links
+   * (the floor works out to ~17 KB/s).
+   */
+  private const val STALL_WINDOW_MS = 60_000L
+  private const val STALL_MIN_BYTES_PER_WINDOW = 1L * 1024 * 1024
+
   /**
    * Downloads the `driver-bundle` JAR from a Maven-layout repository and extracts only the current
-   * platform's driver files into [driverDir]. Tries each base URL from [driverBundleRepoBaseUrls]
-   * in order, falling through to the next on any download failure. Maven Central is always the
-   * last entry, so a broken override (auth issue, wrong path, transient outage) self-heals.
+   * platform's driver files into [driverDir]. Each base URL from [driverBundleRepoBaseUrls] gets
+   * [DOWNLOAD_MAX_ATTEMPTS_PER_SOURCE] attempts (with backoff) before falling through to the next
+   * source — a dropped or stalled connection is usually transient, and retrying beats failing a
+   * run that already booted its device. Maven Central is always the last entry, so a broken
+   * override (auth issue, wrong path, transient outage) self-heals.
    */
   private fun downloadAndExtractDriver(version: String, driverDir: Path) {
     val platform = detectPlatform()
@@ -134,21 +151,39 @@ object PlaywrightDriverManager {
     val failures = mutableListOf<String>()
     try {
       for ((index, url) in urls.withIndex()) {
-        println("[Playwright] [${index + 1}/${urls.size}] Attempting download from $url")
-        try {
-          downloadFile(url, tempJar)
-          extractPlatformDriver(tempJar, driverDir, platform)
-          println("[Playwright] Driver $version installed at $driverDir (from $url)")
-          return
-        } catch (e: Exception) {
-          // Clean up the partial tempJar so the next attempt starts from scratch.
-          Files.deleteIfExists(tempJar)
-          val detail = "${e.javaClass.simpleName}: ${e.message}"
-          failures += "$url -> $detail"
-          println("[Playwright] [${index + 1}/${urls.size}] Failed: $detail")
-          if (index < urls.size - 1) {
-            println("[Playwright] Falling through to next source")
+        for (attempt in 1..DOWNLOAD_MAX_ATTEMPTS_PER_SOURCE) {
+          println(
+            "[Playwright] [${index + 1}/${urls.size}] Attempt " +
+              "$attempt/$DOWNLOAD_MAX_ATTEMPTS_PER_SOURCE: downloading from $url"
+          )
+          try {
+            downloadFile(url, tempJar)
+            extractPlatformDriver(tempJar, driverDir, platform)
+            println("[Playwright] Driver $version installed at $driverDir (from $url)")
+            return
+          } catch (e: Exception) {
+            // Clean up the partial tempJar so the next attempt starts from scratch.
+            Files.deleteIfExists(tempJar)
+            val detail = "${e.javaClass.simpleName}: ${e.message}"
+            failures += "$url (attempt $attempt) -> $detail"
+            println(
+              "[Playwright] [${index + 1}/${urls.size}] Attempt " +
+                "$attempt/$DOWNLOAD_MAX_ATTEMPTS_PER_SOURCE failed: $detail"
+            )
+            if (attempt < DOWNLOAD_MAX_ATTEMPTS_PER_SOURCE) {
+              val backoffSeconds = 3L * attempt * attempt
+              println("[Playwright] Retrying in ${backoffSeconds}s…")
+              try {
+                Thread.sleep(backoffSeconds * 1000)
+              } catch (ie: InterruptedException) {
+                Thread.currentThread().interrupt()
+                throw e
+              }
+            }
           }
+        }
+        if (index < urls.size - 1) {
+          println("[Playwright] Source exhausted; falling through to next source")
         }
       }
       // Every source failed — clean up the destination so the next run retries cleanly, and
@@ -156,7 +191,8 @@ object PlaywrightDriverManager {
       // exactly which source rejected the request and why.
       driverDir.toFile().deleteRecursively()
       throw RuntimeException(
-        "Failed to download Playwright driver after trying ${urls.size} source(s). " +
+        "Failed to download Playwright driver after trying ${urls.size} source(s) × " +
+          "$DOWNLOAD_MAX_ATTEMPTS_PER_SOURCE attempt(s). " +
           "You can manually place the driver at $driverDir, add " +
           "com.microsoft.playwright:driver-bundle:$version to the classpath, " +
           "or point TRAILBLAZE_PLAYWRIGHT_DRIVER_REPO at a different Maven mirror. " +
@@ -185,7 +221,15 @@ object PlaywrightDriverManager {
       }
       val totalBytes = connection.contentLengthLong
       connection.inputStream.use { input ->
-        Files.copy(input, target, StandardCopyOption.REPLACE_EXISTING)
+        copyWithStallDetection(input, target, totalBytes)
+      }
+      // A Content-Length mismatch means the connection closed mid-body without an error;
+      // treat it as a failure so the retry loop gets a chance instead of extraction
+      // exploding on a truncated ZIP.
+      if (totalBytes > 0 && Files.size(target) < totalBytes) {
+        throw java.io.IOException(
+          "Truncated download: got ${Files.size(target)} of $totalBytes bytes"
+        )
       }
       if (totalBytes > 0) {
         val downloadedMB = Files.size(target) / (1024 * 1024)
@@ -193,6 +237,41 @@ object PlaywrightDriverManager {
       }
     } finally {
       connection.disconnect()
+    }
+  }
+
+  /**
+   * Streams [input] to [target], enforcing a minimum throughput of
+   * [STALL_MIN_BYTES_PER_WINDOW] per [STALL_WINDOW_MS]. Complements the socket read timeout,
+   * which only catches fully silent connections — this catches the trickling ones.
+   */
+  private fun copyWithStallDetection(input: java.io.InputStream, target: Path, totalBytes: Long) {
+    Files.newOutputStream(
+      target,
+      java.nio.file.StandardOpenOption.CREATE,
+      java.nio.file.StandardOpenOption.TRUNCATE_EXISTING,
+    ).use { output ->
+      val buffer = ByteArray(256 * 1024)
+      var windowStartNanos = System.nanoTime()
+      var windowBytes = 0L
+      while (true) {
+        val read = input.read(buffer)
+        if (read < 0) break
+        output.write(buffer, 0, read)
+        windowBytes += read
+        val windowElapsedMs = (System.nanoTime() - windowStartNanos) / 1_000_000
+        if (windowElapsedMs >= STALL_WINDOW_MS) {
+          if (windowBytes < STALL_MIN_BYTES_PER_WINDOW) {
+            throw java.io.IOException(
+              "Download stalled: only ${windowBytes / 1024} KB received in the last " +
+                "${windowElapsedMs / 1000}s (need ≥ ${STALL_MIN_BYTES_PER_WINDOW / 1024} KB)" +
+                if (totalBytes > 0) " — expected $totalBytes bytes total" else ""
+            )
+          }
+          windowStartNanos = System.nanoTime()
+          windowBytes = 0L
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Follow-up to #232, prompted by the `wikipedia-trails` flake on that PR's run: the one-shot ~200 MB Playwright driver-bundle download from Maven Central (normally ~5s) stalled and burned the trail runner's full 10-minute no-progress watchdog. The socket trickled just enough bytes that the 60s read timeout never fired, and there was no retry.

**`PlaywrightDriverManager`** (helps released-CLI users too, not just CI):
- Stall detection on the download stream — abort if under 1 MB arrives in any 60s window (~17 KB/s floor), catching the slow-trickle connections a read timeout can't.
- Retry each source up to 3 times with backoff before falling through to the next mirror.
- Verify Content-Length so a silently truncated body fails the attempt instead of exploding during ZIP extraction.

**CI:**
- Cache `~/.cache/trailblaze/playwright-driver` (keyed on `gradle/libs.versions.toml`) in both `wikipedia-trails` jobs. The push-to-main workflow seeds the shared entry — caches created inside a PR are only visible to that PR — and PR runs restore it, skipping the download entirely.
- Extend `gradle/actions/setup-gradle` + `--parallel` (added to `pr-checks.yml` in #232) to the remaining Gradle-running workflows: `wikipedia-trails`, `clock-trails`, `ios-contacts-trails`, `build-desktop`. Each was rebuilding the uber JAR cold (~11 min) on every push to main.