### PR TITLE
Publish Dokka javadoc jars so Central Portal validation passes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,11 +181,18 @@ subprojects
             }
           }
 
+          // A real javadoc jar, not None(): Central Portal validation REJECTS a deployment whose
+          // JVM jars carry no javadoc entry ("Javadocs must be provided but not found in
+          // entries") — the v2026.08.11 release failed on exactly this, across every KotlinJvm
+          // module and every KMP -jvm variant. Dokka is already applied to every subproject (top
+          // of this file), so the -javadoc classifier ships Dokka's rendered HTML — the standard
+          // Kotlin-ecosystem shape for Central. Android AARs are exempt from the requirement
+          // (they passed the same validation), so publishJavadocJar stays false below.
           if (plugins.hasPlugin("org.jetbrains.kotlin.jvm")) {
             publishing.configure(
               KotlinJvm(
                 sourcesJar = true,
-                javadocJar = JavadocJar.None(),
+                javadocJar = JavadocJar.Dokka("dokkaHtml"),
               )
             )
           }
@@ -194,7 +201,7 @@ subprojects
             publishing.configure(
               KotlinMultiplatform(
                 sourcesJar = true,
-                javadocJar = JavadocJar.None(),
+                javadocJar = JavadocJar.Dokka("dokkaHtml"),
               )
             )
           } else if (plugins.hasPlugin("com.android.library")) {

--- a/trailblaze-android-gradle/build.gradle.kts
+++ b/trailblaze-android-gradle/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
   `java-gradle-plugin`
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.vanniktech.maven.publish)
+  // Dokka renders the -javadoc jar Central requires. The root build applies dokka to every
+  // subproject, but this is a composite-included build the root's `subprojects {}` can't reach,
+  // so it applies its own (same version — shared catalog).
+  alias(libs.plugins.dokka)
 }
 
 // Same bare-CalVer publish gate the including build applies. This is a separate Gradle build, so
@@ -57,8 +61,8 @@ dependencies {
 // Use the `vanniktech.maven.publish.base` flavour (matches the rest of `opensource/`) and
 // configure for a Gradle plugin: this publishes the plugin's own `jar` artifact plus the
 // `<plugin-id>.gradle.plugin` marker artifact that `pluginManagement` resolves from. Sources
-// jar is on; javadoc jar is off because the only public API is the plugin's id + extension
-// (documented in this module's README).
+// jar is on; the javadoc jar carries Dokka's rendered HTML for the plugin sources (the primary
+// docs remain this module's README).
 mavenPublishing {
   // `automaticRelease = true` matches the root `opensource/build.gradle.kts` subprojects block.
   // Without it the Central Portal deployment uploads as USER_MANAGED and waits for a manual
@@ -73,7 +77,9 @@ mavenPublishing {
 
   configure(
     GradlePlugin(
-      javadocJar = JavadocJar.None(),
+      // A real Dokka javadoc jar, not None: Central Portal validation rejects JVM jars without
+      // a javadoc entry — the v2026.08.11 deployment failed on this.
+      javadocJar = JavadocJar.Dokka("dokkaHtml"),
       sourcesJar = true,
     ),
   )


### PR DESCRIPTION
The v2026.08.11 release ran the new publish path end to end — version computed as `0.1.0-2026.08.11`, both deployments uploaded, validation awaited — and Central **rejected both deployments** with one error, repeated for every KotlinJvm module, every KMP `-jvm` variant, and the Gradle plugin:

```
Javadocs must be provided but not found in entries
```

The publications were configured with `JavadocJar.None()`. The Central Portal requires a javadoc entry for JVM jars; `0.0.2` predates the Portal migration (OSSRH didn't enforce this), which is why the old config ever worked.

This ships **real docs**, not a placeholder: `JavadocJar.Dokka("dokkaHtml")` puts Dokka's rendered HTML into the `-javadoc` classifier — the standard Kotlin-ecosystem shape for Central. Dokka was already applied to every subproject by the root build; the composite-included `trailblaze-android-gradle` build now applies it itself (same version via the shared catalog), since the root's `subprojects {}` can't reach it.

Android AARs passed the same validation, so `publishJavadocJar` stays `false` for them.

Two side effects worth noting:

- The fail-loudly change in #235 is what surfaced this — the identical rejection has been happening silently on the server side all along. The `USER_MANAGED` deployments parked in the Portal since the migration would have failed the same validation; they were never publishable, so the "drop the backlog" concern is moot.
- Verified via `publishToMavenLocal` across **every publishing module** with `-Ptrailblaze.wasm=true`: 25 javadoc jars produced, all real Dokka HTML (e.g. `trailblaze-agent`: 231 HTML files), covering KotlinJvm, KMP `-jvm`/`-wasm-js` variants, and the Gradle plugin.

Release builds get slower (Dokka renders ~15 modules), which is release/snapshot-path-only cost.

After merge, re-tag to release — `v2026.08.11.1` (the tag shape check accepts `vYYYY.MM.DD[.N]`) or the next date. The rejected `0.1.0-2026.08.11` coordinate was never published, so it's reusable, but a fresh tag name keeps the GitHub release history clean.