### PR TITLE
Build the standalone report viewer in the Pages deploy

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -133,6 +133,18 @@ jobs:
           fetch_assets "ios-contacts-trails.yml" "docs/report-assets/ios-contacts"
           fetch_assets "clock-trails.yml" "docs/report-assets/clock"
 
+      - name: Set up Bun
+        # `scripts/build-viewer-shell.sh` transpiles the viewer with bun macros.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Build the standalone report viewer
+        # docs/report-viewer/index.html is generated, never committed (see .gitignore).
+        # Without this step docs_hooks.py drops its stand-in page and the published
+        # viewer is a placeholder that cannot open a session archive.
+        # Deliberately NOT continue-on-error: the script guards its own output, and a
+        # viewer that silently degrades to the placeholder is the failure mode to avoid.
+        run: ./scripts/build-viewer-shell.sh docs/report-viewer
+
       - name: Build MkDocs site
         run: mkdocs build --strict
 


### PR DESCRIPTION
The hosted report viewer at https://block.github.io/trailblaze/report-viewer/ has been serving `docs_hooks.py`'s placeholder stand-in, not the real viewer — the page says so itself: *"this docs build (which has no `bun`) is serving a stand-in."*

`docs_hooks.py` documents the contract it depends on:

> the GitHub Pages workflow builds it with `scripts/build-viewer-shell.sh` (which needs `bun`) into the docs dir just before `mkdocs build`

That step was never added. `docs/report-viewer/` is gitignored, so there's no committed fallback either: every build takes the `_fill_viewer_placeholder()` path, `mkdocs build --strict` passes because the link resolves, and the deploy goes green. The failure is invisible at the workflow level — every Pages run since the viewer landed has succeeded.

This adds the two missing steps, using the pinned `setup-bun` SHA the other five workflows already use.

Not `continue-on-error`, unlike the gallery-asset fetch above it: the script guards its own output (non-empty, leading doctype, `data-tb-shell` marker, closing `</html>`), and a viewer that silently degrades back to the placeholder is the failure mode this fixes.

## Test plan

- [x] `./scripts/build-viewer-shell.sh docs/report-viewer` locally — 416,116 bytes, all four guards pass
- [x] `_fill_viewer_placeholder()` leaves the real file untouched when it exists (416,116 bytes before and after)
- [ ] CI green
- [ ] After merge: deployed page opens a session `.zip` instead of showing the stand-in
