### PR TITLE
Embed the selector engine in the standalone report viewer

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -146,11 +146,18 @@ jobs:
       - name: Set up Java
         # Only for `:trailblaze-selector-engine-js:bundleSelectorEngine` below — the Kotlin/JS
         # compile behind the viewer's UI Inspector. Nothing else in this deploy needs a JVM.
+        #
+        # Deliberately no `cache: gradle` (and no gradle/actions/setup-gradle): this workflow
+        # PUBLISHES — it holds `pages: write` + `id-token: write` and deploys whatever it built to
+        # the live site. Restoring a dependency cache into a publishing workflow is the
+        # cache-poisoning vector zizmor flags, and here it lands squarely on the payload this step
+        # exists to produce: the engine bundle embedded in the published viewer. Same posture as
+        # build-desktop.yml and release.yml, neither of which caches. The cost is a cold compile of
+        # one small Kotlin/JS module per deploy.
         uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 17
-          cache: gradle
 
       - name: Build the standalone report viewer
         # docs/report-viewer/index.html is generated, never committed (see .gitignore).

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -143,13 +143,26 @@ jobs:
         # `scripts/build-viewer-shell.sh` transpiles the viewer with bun macros.
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
+      - name: Set up Java
+        # Only for `:trailblaze-selector-engine-js:bundleSelectorEngine` below — the Kotlin/JS
+        # compile behind the viewer's UI Inspector. Nothing else in this deploy needs a JVM.
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: gradle
+
       - name: Build the standalone report viewer
         # docs/report-viewer/index.html is generated, never committed (see .gitignore).
         # Without this step docs_hooks.py drops its stand-in page and the published
         # viewer is a placeholder that cannot open a session archive.
+        # --require-engine: the script builds the selector-engine bundle itself (it has a
+        # JDK and bun here), and a missing engine is invisible in the rendered page — the
+        # viewer works, only the Inspector's selector suggestions silently vanish. Fail the
+        # deploy instead of publishing a viewer with a dead "Inspect UI" panel.
         # Deliberately NOT continue-on-error: the script guards its own output, and a
         # viewer that silently degrades to the placeholder is the failure mode to avoid.
-        run: ./scripts/build-viewer-shell.sh docs/report-viewer
+        run: ./scripts/build-viewer-shell.sh --require-engine docs/report-viewer
 
       - name: Build MkDocs site
         run: mkdocs build --strict

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -102,8 +102,10 @@ path that always works: the archive is read in your browser, nothing is uploaded
 request leaves the page. It works offline, and on an archive you'd never put on a network.
 
 The viewer is one self-contained file — the same stylesheet and the same renderer an
-exported report carries, with no run baked into it. So it can't drift from the reports it
-renders, and you can host or keep your own copy:
+exported report carries, with no run baked into it. It also carries the selector engine, so
+**Inspect UI** computes the same ranked selector suggestions here as it does in an exported
+report: the daemon's own generator and resolver compiled to JavaScript, not a re-implementation.
+So it can't drift from the reports it renders, and you can host or keep your own copy:
 
 ```
 ./scripts/build-viewer-shell.sh out    # writes out/index.html — serve it anywhere, or just open it

--- a/scripts/build-viewer-shell.sh
+++ b/scripts/build-viewer-shell.sh
@@ -17,12 +17,26 @@
 #     serving the archive sends `Access-Control-Allow-Origin`.
 #
 # Requires `bun` on PATH.
+#
+# The UI Inspector's selector suggestions need the Kotlin/JS selector-engine bundle, a Gradle build
+# artifact this script builds on demand when `./gradlew` is present (a JDK is therefore optional —
+# without one you get a working viewer whose Inspector shows no suggestions, and a warning saying
+# so). Pass `--require-engine` to fail instead, which is what the docs deploy does so the published
+# viewer can never quietly lose the feature.
 
 set -euo pipefail
 
-OUT_DIR="${1:-}"
+OUT_DIR=""
+REQUIRE_ENGINE=0
+for arg in "$@"; do
+  case "$arg" in
+    --require-engine) REQUIRE_ENGINE=1 ;;
+    -*) echo "usage: $0 [--require-engine] <out-dir>" >&2; exit 2 ;;
+    *) OUT_DIR="$arg" ;;
+  esac
+done
 if [ -z "$OUT_DIR" ]; then
-  echo "usage: $0 <out-dir>" >&2
+  echo "usage: $0 [--require-engine] <out-dir>" >&2
   exit 2
 fi
 
@@ -32,6 +46,17 @@ APP_DIR="$REPO_ROOT/trailblaze-report/src/main/resources/xyz/block/trailblaze/tr
 
 [ -f "$APP_DIR/viewer-shell-cli.ts" ] || { echo "error: missing source $APP_DIR/viewer-shell-cli.ts" >&2; exit 1; }
 command -v bun >/dev/null 2>&1 || { echo "error: bun not on PATH — see https://bun.sh" >&2; exit 1; }
+
+# The UI Inspector's selector suggestions are computed by the daemon's own selector engine compiled
+# to JS. That bundle is a Gradle build artifact (never committed), and the macro that embeds it into
+# the shell silently embeds nothing when it's missing — which ships a viewer whose "Inspect UI" panel
+# can never show a suggestion. Build it on demand so the default path produces a complete viewer.
+ENGINE_BUNDLE="${TRAILBLAZE_SELECTOR_ENGINE_BUNDLE:-$REPO_ROOT/trailblaze-selector-engine-js/build/dist/trailblaze-selector-engine.min.js}"
+if [ ! -f "$ENGINE_BUNDLE" ] && [ -z "${TRAILBLAZE_SELECTOR_ENGINE_BUNDLE:-}" ] && [ -x "$REPO_ROOT/gradlew" ]; then
+  echo "Building the selector engine bundle (needed for UI Inspector suggestions)…" >&2
+  (cd "$REPO_ROOT" && ./gradlew --quiet :trailblaze-selector-engine-js:bundleSelectorEngine) \
+    || echo "warning: selector engine build failed — continuing without Inspector suggestions." >&2
+fi
 
 mkdir -p "$OUT_DIR"
 OUT_FILE="$(cd "$OUT_DIR" && pwd)/index.html"
@@ -51,5 +76,19 @@ OUT_FILE="$(cd "$OUT_DIR" && pwd)/index.html"
 [ "$(head -c 15 "$OUT_FILE")" = "<!doctype html>" ] || { echo "error: generated file does not begin with the doctype — something wrote to stdout first" >&2; exit 1; }
 grep -q 'data-tb-shell' "$OUT_FILE" || { echo "error: generated file is not a viewer shell (no data-tb-shell marker)" >&2; exit 1; }
 tail -c 20 "$OUT_FILE" | grep -q '</html>' || { echo "error: generated shell is truncated (no closing </html>)" >&2; exit 1; }
+
+# The selector engine is the one payload whose absence is invisible in a rendered page: the shell
+# looks and works fine, and only the Inspector's suggestions are quietly missing. Report it either
+# way, and let a publisher demand it.
+if grep -q 'id="tb-selector-engine"' "$OUT_FILE"; then
+  echo "✓ UI Inspector selector engine embedded" >&2
+elif [ "$REQUIRE_ENGINE" = 1 ]; then
+  echo "error: --require-engine was passed but no selector engine is embedded." >&2
+  echo "       Build it first: ./gradlew :trailblaze-selector-engine-js:bundleSelectorEngine" >&2
+  exit 1
+else
+  echo "warning: no selector engine embedded — the UI Inspector will show no selector suggestions." >&2
+  echo "         Build it with: ./gradlew :trailblaze-selector-engine-js:bundleSelectorEngine" >&2
+fi
 
 echo "Built viewer shell: $OUT_FILE ($(wc -c < "$OUT_FILE" | tr -d ' ') bytes)" >&2

--- a/trailblaze-report/src/main/resources/xyz/block/trailblaze/trailrunner/web/app/run-report-shell-html.ts
+++ b/trailblaze-report/src/main/resources/xyz/block/trailblaze/trailrunner/web/app/run-report-shell-html.ts
@@ -11,10 +11,26 @@
 import { RUN_REPORT_CSS } from './run-report-css';
 import { embeddedShellScript } from './run-report-shell-bundle.macro' with { type: 'macro' };
 import { embeddedViewerScript } from './run-report-viewer-bundle.macro' with { type: 'macro' };
-import { inertScriptBody } from './run-report-payload';
+import { inertScriptBody, toInertJson } from './run-report-payload';
+import { embeddedSelectorEngine } from './selector-engine-bundle.macro' with { type: 'macro' };
 import { embeddedZipReportCoreScript } from './zip-report-core-bundle.macro' with { type: 'macro' };
 
 const RUN_REPORT_VIEWER_SCRIPT: string = embeddedViewerScript();
+
+// The UI Inspector's selector engine, in the same `#tb-selector-engine` transport an exported report
+// uses. Null when the Kotlin/JS bundle wasn't built — the shell then embeds no chunk and the
+// Inspector degrades exactly as it did before, rather than failing the build.
+const SELECTOR_ENGINE = embeddedSelectorEngine();
+
+// Unlike a report — which embeds the engine only when a session carries an analyzable hierarchy —
+// the shell has no session at build time and must carry it unconditionally: any archive dropped
+// later may need it, and there is no second chance to fetch one in an offline, single-file viewer.
+const SELECTOR_ENGINE_CHUNK: string = SELECTOR_ENGINE && (SELECTOR_ENGINE.js || SELECTOR_ENGINE.gz)
+  ? `\n<script type="application/json" id="tb-selector-engine">${toInertJson({
+    ...(SELECTOR_ENGINE.js ? { js: SELECTOR_ENGINE.js } : {}),
+    ...(SELECTOR_ENGINE.gz ? { gz: SELECTOR_ENGINE.gz } : {}),
+  })}</script>`
+  : '';
 
 // The viewer shell's loader script, inlined the same way (see run-report-shell-bundle.macro.ts).
 const VIEWER_SHELL_SCRIPT: string = embeddedShellScript();
@@ -135,7 +151,7 @@ function buildViewerShellHtml(): string {
 </div>
 <script>${inertScriptBody(embeddedZipReportCoreScript())}</script>
 <script>${inertScriptBody(RUN_REPORT_VIEWER_SCRIPT)}</script>
-<script>${inertScriptBody(VIEWER_SHELL_SCRIPT)}</script>
+<script>${inertScriptBody(VIEWER_SHELL_SCRIPT)}</script>${SELECTOR_ENGINE_CHUNK}
 </body>
 </html>`;
 }

--- a/trailblaze-report/src/main/resources/xyz/block/trailblaze/trailrunner/web/app/selector-engine-bundle.macro.ts
+++ b/trailblaze-report/src/main/resources/xyz/block/trailblaze/trailrunner/web/app/selector-engine-bundle.macro.ts
@@ -1,0 +1,44 @@
+// Bun MACRO (imported `with { type: 'macro' }` from run-report-shell-html.ts): the Kotlin/JS
+// selector-engine bundle, read and packed at TRANSPILE time so the standalone viewer shell carries
+// the UI Inspector's engine the same way an exported report does.
+//
+// Why the shell needs its own copy. An exported report gets the engine from the Kotlin side:
+// RunReportGenerator stages the JAR resource and run-report-cli.ts packs it into the
+// `#tb-selector-engine` chunk. The shell has no such generation step — it is built by bun alone,
+// with no run baked in — so without this macro the shell ships every line of Inspector code and no
+// engine to run, and `loadSelectorEngineFromChunk` degrades to null: the "Inspect UI" button opens
+// a panel that can never show a suggestion.
+//
+// Same transport as the report (`packSelectorEngine` — imported, not re-implemented, so the two
+// homes can't drift): `{ js }` inline below the threshold, `{ gz }` gzip+base64 above it. The real
+// bundle is ~320 KB, so it always lands on the gz side at ~110 KB.
+//
+// The bundle is a BUILD ARTIFACT, never committed: `./gradlew
+// :trailblaze-selector-engine-js:bundleSelectorEngine` writes it, and that task itself skips
+// cleanly when bun is absent. Absent bundle → null → the shell embeds no chunk and behaves exactly
+// as it did before this macro existed. build-viewer-shell.sh builds it on demand and can be asked
+// to fail rather than ship a viewer without it (`--require-engine`).
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { packSelectorEngine } from '../../../report/run-report-cli';
+
+/** Default location of the Gradle-built bundle, relative to this file (repo root is ten up). */
+const DEFAULT_BUNDLE = '../../../../../../../../../../trailblaze-selector-engine-js/build/dist/trailblaze-selector-engine.min.js';
+
+/**
+ * The packed engine payload, or null when the bundle hasn't been built. `TRAILBLAZE_SELECTOR_ENGINE_BUNDLE`
+ * overrides the path for packagers that build the bundle somewhere else.
+ */
+export function embeddedSelectorEngine(): { js?: string | null; gz?: string | null } | null {
+  const override = process.env.TRAILBLAZE_SELECTOR_ENGINE_BUNDLE;
+  const path = override && override.trim()
+    ? override.trim()
+    : fileURLToPath(new URL(DEFAULT_BUNDLE, import.meta.url));
+  let code: string;
+  try {
+    code = readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+  return packSelectorEngine(code.trim() ? code : null);
+}


### PR DESCRIPTION
The UI Inspector's selector suggestions were unavailable in the standalone report viewer — the one the docs site publishes and anyone can self-host. The shell embeds every line of Inspector code (`Inspect UI`, `selectorSuggestion*`, the `#tb-selector-engine` reader) but nothing ever embedded the **engine** for it to run, so `loadSelectorEngineFromChunk` returned null and the panel opened with no suggestions. Silently: a null engine is a designed degrade path.

Exported reports were never affected. There the Kotlin side supplies it — `RunReportGenerator` stages the JAR resource, `run-report-cli.ts` packs it into the chunk. The shell is built by bun alone, with no run baked in, and had no equivalent step.

Verified on today's `docs-report-clock` artifact — the exported report carries the payload and the published viewer does not:

| | Inspector code | engine payload |
|---|---|---|
| `report-interactive.html` | ✅ | ✅ |
| hosted viewer shell | ✅ | ❌ |

## The fix

A bun macro reads the Kotlin/JS bundle at transpile time and `buildViewerShellHtml` embeds it as the same `#tb-selector-engine` chunk a report uses. The macro imports `packSelectorEngine` rather than re-implementing the transport, so the two homes can't drift.

The shell embeds it **unconditionally**, unlike a report, which embeds it only when a session carries an analyzable hierarchy: the shell has no session at build time, any archive dropped later may need it, and an offline single-file viewer gets no second chance to fetch one.

**Size:** 416,116 → 531,155 bytes (+115 KB — gzip+base64 of the ~320 KB bundle, which always lands on the gz side of the threshold). The macro is replaced by its value at transpile time, so no driver code enters the bundle; the delta is the payload and its wrapper, nothing else.

**Delivery.** `build-viewer-shell.sh` builds the bundle on demand when `./gradlew` is present, so the default path produces a complete viewer. A JDK stays optional: without one you get today's viewer plus a warning naming the gradle task. `--require-engine` turns that warning into a failure, and the Pages deploy passes it — a missing engine is invisible in a rendered page, so this is the one payload worth failing a deploy over. That step needs a JVM, so the deploy gains `setup-java` (JDK 17, gradle cache) used for nothing else.

## Test plan

- [x] Built the shell, loaded a real CI session archive, clicked **Inspect UI**, selected a node — engine loaded (`TrailblazeSelectorEngine` exposing `resolveTapTarget` / `resolveSelector` / `computeSelectorAnalysis`) and suggestions rendered: `textRegex: ALARM` marked UNIQUE/BEST, plus the structural content-free suggestion
- [x] `--require-engine` with the bundle absent exits 1; without the flag exits 0 and emits a shell **byte-identical** to today's (416,116 bytes), so the degrade path is unchanged
- [x] `tsc --noEmit` clean; `bun test` 440 pass / 0 fail
- [x] No driver code leaked into the shell (`packSelectorEngine`, `readSelectorEngineSource`, `anyAnalyzableHierarchy` all absent from the output)
- [x] Bundle is a gitignored build artifact — nothing generated is committed
- [ ] CI green
- [ ] After merge: **Inspect UI** shows suggestions on the gallery runs
